### PR TITLE
fix: add companion package resolution step to version lookup workflow

### DIFF
--- a/skills/opentelemetry-sdk-versions/SKILL.md
+++ b/skills/opentelemetry-sdk-versions/SKILL.md
@@ -20,12 +20,17 @@ If the broader task is manual instrumentation design or review, pair this with `
 - if the latest release is not compatible, choose the latest compatible version and state the compatibility reason explicitly
 - reuse that decision for the rest of the task unless the language, package, or constraints change
 
-3. Use the linked follow-up sources when needed.
+3. Resolve companion packages from the release source.
+- the index covers one primary SDK package per language
+- if the task requires additional packages from the same ecosystem (exporters, instrumentations, resource detectors), look up their versions from the release source — do not infer or reuse the primary package version
+- sub-packages within the same project often share a version line but not always; confirm each package individually
+
+4. Use the linked follow-up sources when needed.
 - use the Release Source column to confirm the package or repo
 - use the Setup Docs column for SDK setup guidance
 - use the Examples column for implementation references when examples are available
 
-4. Handle gaps explicitly.
+5. Handle gaps explicitly.
 - if the requested language or package is not in the bundled index, say that the index does not cover that exact package
 - then fall back to the official release source and official docs for that package
 - do not assume an unreleased, prerelease, or incompatible version is acceptable without saying so


### PR DESCRIPTION
## Summary

- Adds a new step 3 ("Resolve companion packages from the release source") to the SDK version lookup workflow
- The version index covers one primary SDK package per language, but tasks often require additional ecosystem packages (exporters, instrumentations, resource detectors)
- Without this step, agents infer sub-package versions from the primary package — causing version mismatches (e.g. mixing `0.52.x` exporters with `0.214.0` `sdk-node`)

## Context

Observed failure: an agent used the index to find `@opentelemetry/sdk-node@0.214.0` correctly, then guessed `0.52.1` for all companion packages (`exporter-trace-otlp-http`, `instrumentation-express`, etc.), resulting in `npm install` failures due to incompatible peer dependencies.