### PR TITLE
feat: add opentelemetry-go skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This repository contains reusable agent skills for OpenTelemetry.
 Install any skill using the skills CLI:
 
 ```bash
-npx skills add niwoerner/opentelemetry-agent-skills
+npx skills add ollygarden/opentelemetry-agent-skills
 ```
 
 Install a specific skill from this repository:
 
 ```bash
-npx skills add niwoerner/opentelemetry-agent-skills --skill opentelemetry-manual-instrumentation
+npx skills add ollygarden/opentelemetry-agent-skills --skill opentelemetry-manual-instrumentation
 ```
 
 Replace the skill name with any entry from the table below.
@@ -25,6 +25,7 @@ Replace the skill name with any entry from the table below.
 | `opentelemetry-manual-instrumentation` | `skills/opentelemetry-manual-instrumentation/` | Planning, adding, or reviewing manual instrumentation; choosing runtime boundaries and signals; configuring SDK defaults; controlling cardinality; handling propagation; and performing final instrumentation review. |
 | `opentelemetry-semantic-conventions` | `skills/opentelemetry-semantic-conventions/` | Selecting released semantic convention groups, attributes, and span naming rules; checking semantic convention compliance; and looking up exact upstream semantic convention entries. |
 | `opentelemetry-sdk-versions` | `skills/opentelemetry-sdk-versions/` | Choosing the latest compatible released OpenTelemetry SDK or package version for a language and finding setup docs or examples. |
+| `opentelemetry-go` | `skills/opentelemetry-go/` | Writing, reviewing, or configuring OpenTelemetry instrumentation in Go; looking up current versions, import paths, API surface, contrib libraries, SDK setup, or performance tuning. |
 | `span-events-to-logs-migration` | `skills/span-events-to-logs-migration/` | Migrating instrumentation from the deprecated Span Event API (AddEvent, RecordException) to the Logs API following the OTEP 4430 deprecation plan. |
 | `telemetrygen` | `skills/telemetrygen/` | Constructing telemetrygen commands for generating synthetic traces, metrics, and logs; load testing collectors and backends; testing OTTL transforms, tail sampling, and filter rules; multi-tenant and correlated-signal scenarios. |
 

--- a/skills/opentelemetry-go/SKILL.md
+++ b/skills/opentelemetry-go/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: opentelemetry-go
+description: >
+  OpenTelemetry Go API, SDK, and instrumentation library mechanics.
+  Use when writing, reviewing, or configuring OpenTelemetry instrumentation
+  in Go applications. Covers current versions, import paths, breaking changes,
+  provider setup, contrib libraries, and performance tuning.
+---
+
+# OpenTelemetry Go
+
+Mechanics reference for the OpenTelemetry Go API, SDK, and instrumentation libraries.
+
+## Current Versions
+
+| Component | Version | Notes |
+|---|---|---|
+| SDK (`go.opentelemetry.io/otel`) | v1.42.0 | Requires Go 1.25+ |
+| Contrib (`go.opentelemetry.io/contrib`) | v1.42.0 | Matches SDK version |
+| Semconv package | `go.opentelemetry.io/otel/semconv/v1.40.0` | Latest available |
+
+## Gotchas and Breaking Changes
+
+- `span.RecordError()` and `span.AddEvent()` are deprecated. Use the Logs API to emit events and record exceptions within the context of the active span.
+- `go.opentelemetry.io/contrib/config` is deprecated (contrib v1.35.0). Use `go.opentelemetry.io/contrib/otelconf/v0.3.0` instead. The API is identical.
+- Current SDK version: v1.42.0 (requires Go 1.25+). Current semconv package: `go.opentelemetry.io/otel/semconv/v1.40.0`.
+- otelhttp removed `DefaultClient`, `Get`, `Head`, `Post`, `PostForm`, `WithPublicEndpoint`, `WithRouteTag` in contrib v1.40.0. Always create a custom client with `otelhttp.NewTransport`.
+- RPC semantic convention renames in contrib v1.40.0+: `rpc.system` -> `rpc.system.name`; `rpc.method` + `rpc.service` merged into `rpc.method`; `rpc.client.duration`/`rpc.server.duration` -> `rpc.client.call.duration`/`rpc.server.call.duration` (unit changed to seconds); `rpc.grpc.status_code` -> `rpc.response.status_code`.
+- otelgrpc in contrib v1.42.0: no longer emits `rpc.message` span events, `rpc.*.request/response.size` metrics, or `network.*` attributes. Even with `WithMessageEvents`.
+- HTTP instrumentation (contrib v1.40.0+) sets `error.type` attribute instead of `exception` span events.
+- otelgrpc: prefer stats handlers (`NewServerHandler`/`NewClientHandler`) over deprecated interceptors for new code.
+- `trace.SpanFromContext()` never returns nil — no nil checks or `IsRecording()` guards needed.
+- Propagator must be set manually via `otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))` until contrib issue #6712 is resolved.
+- `WithMetricAttributesFn` deprecated in otelhttp (contrib v1.41.0). Use `Labeler` instead.
+- `log.Record.SetErr(err)` (v1.42.0) — the SDK automatically sets `exception.type` and `exception.message` attributes.
+
+## References
+
+Load these on demand based on the task:
+
+- Setting up the SDK, configuring providers, or initializing telemetry? Read `references/sdk-setup.md`.
+- Using the tracing, metrics, or logs API? Read `references/api.md`.
+- Adding or configuring instrumentation libraries (otelhttp, otelgrpc, otelgin, otelsql, logging bridges)? Read `references/instrumentation-libraries.md`.
+- Tuning batch sizes, sampling, cardinality limits, or export intervals? Read `references/performance.md`.
+- Using file-based YAML configuration for the SDK? Use the `opentelemetry-sdk-configuration` skill for the schema, then see `references/sdk-setup.md` for Go-specific loading via `otelconf`.

--- a/skills/opentelemetry-go/references/api.md
+++ b/skills/opentelemetry-go/references/api.md
@@ -1,0 +1,332 @@
+# OpenTelemetry Go API
+
+**Module**: `go.opentelemetry.io/otel`
+
+## Import Paths
+```go
+import (
+    "go.opentelemetry.io/otel"                    // Global API
+    "go.opentelemetry.io/otel/trace"              // Tracing API
+    "go.opentelemetry.io/otel/metric"             // Metrics API
+    "go.opentelemetry.io/otel/log"                // Logs API (stable as of v1.34.0)
+    "go.opentelemetry.io/otel/log/global"         // Global LoggerProvider
+    "go.opentelemetry.io/otel/attribute"          // Attributes
+    "go.opentelemetry.io/otel/codes"              // Status codes
+    "go.opentelemetry.io/otel/propagation"        // Context propagation
+    "go.opentelemetry.io/otel/baggage"            // Baggage API
+)
+```
+
+## Global API Access
+
+### Provider Registration
+```go
+// Set global providers (typically in main())
+otel.SetTracerProvider(tracerProvider)
+otel.SetMeterProvider(meterProvider)
+otel.SetTextMapPropagator(propagator)
+
+// Get providers from global
+tp := otel.GetTracerProvider()
+mp := otel.GetMeterProvider()
+```
+
+### Convenience Accessors
+```go
+// Get a tracer from the global TracerProvider
+tracer := otel.Tracer("github.com/user/pkg")
+
+// Get a meter from the global MeterProvider
+meter := otel.Meter("github.com/user/pkg")
+```
+
+### Error Handling
+```go
+// Set global error handler
+otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+    // Log or handle errors
+}))
+```
+
+## Tracing API
+
+### Core Types
+```go
+trace.TracerProvider    // Creates Tracers
+trace.Tracer           // Creates Spans
+trace.Span             // Represents a unit of work
+trace.SpanContext      // Immutable span identifier
+trace.TraceID          // [16]byte unique trace identifier
+trace.SpanID           // [8]byte unique span identifier
+```
+
+### Creating Tracers and Spans
+```go
+// Get tracer (use import path as name)
+tracer := otel.Tracer("github.com/user/pkg")
+
+// Start span with automatic context propagation
+ctx, span := tracer.Start(ctx, "verb object",
+    trace.WithAttributes(
+        attribute.String("key", "value"),
+    ),
+    trace.WithSpanKind(trace.SpanKindServer),
+)
+defer span.End()
+
+// Add attributes during execution
+span.SetAttributes(attribute.Int64("items.count", 42))
+
+// Set status on error
+if err != nil {
+    span.SetStatus(codes.Error, err.Error())
+}
+```
+
+### Span Options
+```go
+trace.WithAttributes(attrs...)      // Initial attributes
+trace.WithSpanKind(kind)            // Server, Client, Producer, Consumer, Internal
+trace.WithNewRoot()                 // Start new trace
+trace.WithLinks(links...)           // Link to other spans
+```
+
+### Context Utilities
+```go
+// Extract span from context
+span := trace.SpanFromContext(ctx)
+
+// Get current span context
+sc := span.SpanContext()
+traceID := sc.TraceID()
+spanID := sc.SpanID()
+```
+
+## Metrics API
+
+### Core Types
+```go
+metric.MeterProvider    // Creates Meters
+metric.Meter           // Creates Instruments
+// Synchronous instruments
+metric.Int64Counter
+metric.Float64Counter
+metric.Int64UpDownCounter
+metric.Float64UpDownCounter
+metric.Int64Histogram
+metric.Float64Histogram
+metric.Int64Gauge
+metric.Float64Gauge
+// Asynchronous instruments (callbacks)
+metric.Int64ObservableCounter
+metric.Float64ObservableCounter
+metric.Int64ObservableUpDownCounter
+metric.Float64ObservableUpDownCounter
+metric.Int64ObservableGauge
+metric.Float64ObservableGauge
+```
+
+### Creating Meters and Instruments
+```go
+// Get meter (use import path as name)
+meter := otel.Meter("github.com/user/pkg")
+
+// Counter - monotonic sum
+counter, _ := meter.Int64Counter("requests.total",
+    metric.WithDescription("Total requests"),
+    metric.WithUnit("1"),
+)
+counter.Add(ctx, 1,
+    metric.WithAttributes(attribute.String("method", "GET")))
+
+// UpDownCounter - non-monotonic sum
+updown, _ := meter.Int64UpDownCounter("queue.size")
+updown.Add(ctx, -1)
+
+// Histogram - distribution of values
+histogram, _ := meter.Float64Histogram("request.duration",
+    metric.WithUnit("ms"),
+)
+histogram.Record(ctx, 123.45)
+
+// Gauge - current value
+gauge, _ := meter.Float64Gauge("cpu.usage",
+    metric.WithUnit("%"),
+)
+gauge.Record(ctx, 75.5)
+
+// Observable (async) gauge with callback
+_, _ = meter.Int64ObservableGauge("memory.usage",
+    metric.WithCallback(func(ctx context.Context, o metric.Int64Observer) error {
+        o.Observe(getCurrentMemory())
+        return nil
+    }),
+)
+
+// Check if an instrument is enabled before expensive operations (v1.40.0+)
+// Available on all synchronous instruments: Counter, UpDownCounter, Histogram, Gauge
+if counter.Enabled(ctx, metric.WithAttributes(attribute.String("method", "GET"))) {
+    // Only compute expensive value if the instrument will record
+    value := computeExpensiveMetric()
+    counter.Add(ctx, value, metric.WithAttributes(attribute.String("method", "GET")))
+}
+```
+
+## Attributes
+
+### Creating Attributes
+```go
+// Typed attribute constructors
+attribute.String("key", "value")
+attribute.Int64("count", 42)
+attribute.Float64("ratio", 0.95)
+attribute.Bool("enabled", true)
+attribute.StringSlice("tags", []string{"a", "b"})
+attribute.Int64Slice("ids", []int64{1, 2, 3})
+attribute.Float64Slice("values", []float64{1.1, 2.2})
+attribute.BoolSlice("flags", []bool{true, false})
+```
+
+### Attribute Sets
+```go
+// Create reusable attribute set
+attrs := attribute.NewSet(
+    attribute.String("service.name", "api"),
+    attribute.String("service.version", "1.0.0"),
+)
+
+// Filter attributes
+filtered := attrs.Filter(func(kv attribute.KeyValue) bool {
+    return kv.Key != "service.version"
+})
+```
+
+## Propagation
+
+### Context Propagation
+```go
+// Create composite propagator
+propagator := propagation.NewCompositeTextMapPropagator(
+    propagation.TraceContext{},  // W3C Trace Context
+)
+
+// Set global propagator
+otel.SetTextMapPropagator(propagator)
+
+// Extract from HTTP headers
+ctx = propagator.Extract(ctx, propagation.HeaderCarrier(r.Header))
+
+// Inject into HTTP headers
+propagator.Inject(ctx, propagation.HeaderCarrier(w.Header()))
+```
+
+## Logs API
+
+The Logs API became stable in v1.34.0. It provides a bridge for existing logging libraries.
+
+### Core Types
+```go
+log.LoggerProvider     // Creates Loggers
+log.Logger             // Emits log records
+log.Record             // Log record with attributes
+log.Value              // Typed attribute value
+log.Severity           // Log severity level
+```
+
+### Creating Loggers and Emitting Records
+```go
+// Get logger (use import path as name)
+logger := global.GetLoggerProvider().Logger("github.com/user/pkg")
+
+// Check if logging is enabled
+var params log.EnabledParameters
+params.SetSeverity(log.SeverityInfo)
+if logger.Enabled(ctx, params) {
+    var rec log.Record
+    rec.SetTimestamp(time.Now())
+    rec.SetSeverity(log.SeverityInfo)
+    rec.SetBody(log.StringValue("User logged in"))
+    rec.AddAttributes(
+        log.String("user.id", userID),
+        log.String("session.id", sessionID),
+    )
+    logger.Emit(ctx, rec)
+}
+
+// Attach an error to a log record (v1.42.0+)
+// The SDK automatically sets exception attributes (exception.type, exception.message)
+var rec log.Record
+rec.SetSeverity(log.SeverityError)
+rec.SetBody(log.StringValue("operation failed"))
+rec.SetErr(err) // Attaches error; SDK sets exception attributes automatically
+logger.Emit(ctx, rec)
+
+// Read back the error from a record
+if recordErr := rec.Err(); recordErr != nil {
+    // Handle the error
+}
+```
+
+### Severity Levels
+```go
+log.SeverityTrace1 through log.SeverityTrace4
+log.SeverityDebug1 through log.SeverityDebug4
+log.SeverityInfo1 through log.SeverityInfo4
+log.SeverityWarn1 through log.SeverityWarn4
+log.SeverityError1 through log.SeverityError4
+log.SeverityFatal1 through log.SeverityFatal4
+```
+
+### Log Values
+```go
+log.StringValue("text")
+log.IntValue(42)
+log.Int64Value(int64(42))
+log.Float64Value(3.14)
+log.BoolValue(true)
+log.BytesValue([]byte("data"))
+log.SliceValue(log.StringValue("a"), log.StringValue("b"))
+log.MapValue(log.String("key", "value"))
+```
+
+## Logging Bridges
+
+Logging bridges connect existing logging libraries to OpenTelemetry.
+
+> **Note (contrib v1.35.0):** otelzap and otelslog emit `code.function` with the full package path-qualified function name (e.g., `github.com/user/pkg.MyFunc`). The `code.namespace` attribute is no longer emitted.
+
+```go
+import (
+    // For zap logging
+    "go.opentelemetry.io/contrib/bridges/otelzap"
+
+    // For slog logging (Go 1.21+)
+    "go.opentelemetry.io/contrib/bridges/otelslog"
+
+    // For logrus logging
+    "go.opentelemetry.io/contrib/bridges/otellogrus"
+
+    // For zerolog logging
+    "go.opentelemetry.io/contrib/bridges/otelzerolog"
+
+    // For logr logging
+    "go.opentelemetry.io/contrib/bridges/otellogr"
+)
+```
+
+### Example: zap bridge
+```go
+// Create zap logger with OpenTelemetry bridge
+core := zapcore.NewTee(
+    zapcore.NewCore(encoder, os.Stdout, zapcore.InfoLevel),
+    otelzap.NewCore("my-service", otelzap.WithLoggerProvider(loggerProvider)),
+)
+logger := zap.New(core)
+```
+
+### Example: slog bridge
+```go
+// Create slog handler with OpenTelemetry bridge
+handler := otelslog.NewHandler("my-service", otelslog.WithLoggerProvider(loggerProvider))
+logger := slog.New(handler)
+```

--- a/skills/opentelemetry-go/references/instrumentation-libraries.md
+++ b/skills/opentelemetry-go/references/instrumentation-libraries.md
@@ -1,0 +1,388 @@
+# OpenTelemetry Go Instrumentation Libraries
+
+## Detecting Existing Instrumentation
+
+Before adding manual instrumentation, check for these imports and middleware patterns in the codebase:
+
+```go
+import (
+    // HTTP frameworks
+    "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+    "go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
+    "go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
+    "go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
+
+    // gRPC
+    "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+
+    // Logging bridges
+    "go.opentelemetry.io/contrib/bridges/otelzap"
+    "go.opentelemetry.io/contrib/bridges/otelslog"
+    "go.opentelemetry.io/contrib/bridges/otellogrus"
+    "go.opentelemetry.io/contrib/bridges/otelzerolog"
+)
+```
+
+If these middleware/wrapper patterns are present, spans are already being created:
+
+```go
+handler := otelhttp.NewHandler(mux, "service-name")       // net/http
+router.Use(otelgin.Middleware("service-name"))             // gin (also emits HTTP metrics)
+router.Use(otelmux.Middleware("service-name"))             // gorilla/mux (also emits HTTP metrics)
+```
+
+## Library Catalog
+
+### HTTP
+
+| Library | Package |
+|---------|---------|
+| net/http | `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` |
+| Gin | `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin` |
+| Gorilla mux | `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux` |
+| Echo | `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho` |
+| go-restful | `go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful` |
+
+```go
+// HTTP server with automatic instrumentation
+func setupHTTPServer() *http.Server {
+    mux := http.NewServeMux()
+    mux.HandleFunc("/users", handleUsers)
+
+    // Automatic span creation and context propagation
+    handler := otelhttp.NewHandler(mux, "user-service")
+
+    return &http.Server{
+        Addr:    ":8080",
+        Handler: handler,
+    }
+}
+
+// HTTP client with automatic instrumentation
+// Note: otelhttp.DefaultClient, Get, Head, Post, PostForm were removed in contrib v1.40.0
+// Always create a custom client with otelhttp.NewTransport instead
+func setupHTTPClient() *http.Client {
+    return &http.Client{
+        Transport: otelhttp.NewTransport(http.DefaultTransport),
+    }
+}
+```
+
+### gRPC
+
+| Library | Package |
+|---------|---------|
+| gRPC | `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` |
+
+```go
+// gRPC server with automatic instrumentation (prefer stats handlers over interceptors)
+func setupGRPCServer() *grpc.Server {
+    return grpc.NewServer(
+        grpc.StatsHandler(otelgrpc.NewServerHandler()),
+    )
+}
+
+// gRPC client with automatic instrumentation
+func setupGRPCClient(target string) (*grpc.ClientConn, error) {
+    return grpc.NewClient(target,
+        grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+    )
+}
+
+// Override default span kind in gRPC (contrib v1.41.0+)
+func setupGRPCServerWithSpanKind() *grpc.Server {
+    return grpc.NewServer(
+        grpc.StatsHandler(otelgrpc.NewServerHandler(
+            otelgrpc.WithSpanKind(trace.SpanKindInternal),
+        )),
+    )
+}
+```
+
+### Database
+
+| Library | Package |
+|---------|---------|
+| database/sql | `go.opentelemetry.io/contrib/instrumentation/database/sql/otelsql` |
+| MongoDB | `go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo` |
+
+### AWS
+
+| Library | Package |
+|---------|---------|
+| AWS SDK v2 | `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws` |
+| Lambda | `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda` |
+
+### Logging Bridges
+
+| Logger | Package |
+|--------|---------|
+| zap | `go.opentelemetry.io/contrib/bridges/otelzap` |
+| slog | `go.opentelemetry.io/contrib/bridges/otelslog` |
+| logrus | `go.opentelemetry.io/contrib/bridges/otellogrus` |
+| zerolog | `go.opentelemetry.io/contrib/bridges/otelzerolog` |
+| logr | `go.opentelemetry.io/contrib/bridges/otellogr` |
+
+> **Logging bridge change (contrib v1.35.0):** otelzap and otelslog now emit `code.function` with the full package path-qualified function name (e.g., `github.com/user/pkg.MyFunc`) instead of just the function name. The `code.namespace` attribute is no longer emitted.
+
+```go
+// zap bridge setup
+import (
+    "go.opentelemetry.io/contrib/bridges/otelzap"
+    "go.opentelemetry.io/otel/log/global"
+    "go.uber.org/zap"
+    "go.uber.org/zap/zapcore"
+)
+
+func setupLogger() *zap.Logger {
+    // Create a tee core that logs to both stdout and OpenTelemetry
+    core := zapcore.NewTee(
+        zapcore.NewCore(
+            zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+            zapcore.AddSync(os.Stdout),
+            zapcore.InfoLevel,
+        ),
+        otelzap.NewCore("myservice",
+            otelzap.WithLoggerProvider(global.GetLoggerProvider())),
+    )
+    return zap.New(core)
+}
+```
+
+```go
+// slog bridge setup (Go 1.21+)
+import (
+    "log/slog"
+    "go.opentelemetry.io/contrib/bridges/otelslog"
+    "go.opentelemetry.io/otel/log/global"
+)
+
+func setupLogger() *slog.Logger {
+    handler := otelslog.NewHandler("myservice",
+        otelslog.WithLoggerProvider(global.GetLoggerProvider()))
+    return slog.New(handler)
+}
+```
+
+```go
+// logrus bridge setup
+import (
+    "github.com/sirupsen/logrus"
+    "go.opentelemetry.io/contrib/bridges/otellogrus"
+    "go.opentelemetry.io/otel/log/global"
+)
+
+func setupLogger() {
+    logrus.AddHook(otellogrus.NewHook("myservice",
+        otellogrus.WithLoggerProvider(global.GetLoggerProvider())))
+}
+```
+
+### Resource Detectors
+
+| Cloud | Package |
+|-------|---------|
+| AWS EC2 | `go.opentelemetry.io/contrib/detectors/aws/ec2` |
+| AWS ECS | `go.opentelemetry.io/contrib/detectors/aws/ecs` |
+| AWS EKS | `go.opentelemetry.io/contrib/detectors/aws/eks` |
+| AWS Lambda | `go.opentelemetry.io/contrib/detectors/aws/lambda` |
+| GCP | `go.opentelemetry.io/contrib/detectors/gcp` |
+| Azure VM | `go.opentelemetry.io/contrib/detectors/azure/azurevm` |
+
+### Propagators
+
+| Propagator | Package |
+|------------|---------|
+| Environment carrier | `go.opentelemetry.io/contrib/propagators/envcar` (new in v1.42.0) |
+
+## Manual Instrumentation Patterns
+
+Use these patterns when no contrib instrumentation library exists for the target.
+
+### HTTP Client with Semconv Attributes
+
+```go
+func (c *CustomClient) CallExternalAPI(ctx context.Context, endpoint string) error {
+    ctx, span := c.tracer.Start(ctx, "GET",
+        trace.WithSpanKind(trace.SpanKindClient),
+        trace.WithAttributes(
+            semconv.HTTPRequestMethodGet,
+            semconv.URLFull(endpoint)))
+    defer span.End()
+
+    resp, err := c.httpClient.Get(endpoint)
+    if err != nil {
+        return fmt.Errorf("making request: %w", err)
+    }
+    defer resp.Body.Close()
+
+    span.SetAttributes(semconv.HTTPResponseStatusCode(resp.StatusCode))
+    return nil
+}
+```
+
+### Database Operation with Semconv
+
+```go
+func (r *Repository) CreateUser(ctx context.Context, userData *UserData) (*User, error) {
+    ctx, span := r.tracer.Start(ctx, "INSERT users",
+        trace.WithAttributes(
+            semconv.DBSystem("postgresql"),
+            semconv.DBNamespace(r.dbName),
+            semconv.DBOperation("INSERT"),
+            semconv.DBSQLTable("users")))
+    defer span.End()
+
+    query := `INSERT INTO users (email, name, tier) VALUES ($1, $2, $3) RETURNING id, created_at`
+
+    var user User
+    err := r.db.QueryRow(ctx, query, userData.Email, userData.Name, userData.Tier).
+        Scan(&user.ID, &user.CreatedAt)
+
+    if err != nil {
+        span.SetAttributes(attribute.String("error.type", classifyDBError(err)))
+        return nil, fmt.Errorf("inserting user: %w", err)
+    }
+
+    span.SetAttributes(
+        attribute.String("user.id", user.ID),
+        attribute.String("user.tier", userData.Tier),
+    )
+
+    return &user, nil
+}
+
+func classifyDBError(err error) string {
+    if strings.Contains(err.Error(), "unique constraint") {
+        return "duplicate_key"
+    }
+    if strings.Contains(err.Error(), "connection") {
+        return "connection_error"
+    }
+    return "unknown"
+}
+```
+
+### Message Queue Producer/Consumer with Semconv
+
+```go
+func (p *Publisher) PublishOrderEvent(ctx context.Context, order *Order) error {
+    ctx, span := p.tracer.Start(ctx, "send queue.orders",
+        trace.WithSpanKind(trace.SpanKindProducer),
+        trace.WithAttributes(
+            semconv.MessagingSystem("nats"),
+            semconv.MessagingOperationTypePublish,
+            semconv.MessagingDestinationName("orders"),
+            attribute.String("order.id", order.ID)))
+    defer span.End()
+
+    message, err := json.Marshal(order)
+    if err != nil {
+        return fmt.Errorf("marshaling order: %w", err)
+    }
+
+    if err := p.client.Publish("orders", message); err != nil {
+        return fmt.Errorf("publishing message: %w", err)
+    }
+
+    span.SetAttributes(attribute.Int("message.size", len(message)))
+
+    return nil
+}
+
+func (c *Consumer) HandleOrderEvent(ctx context.Context, msg []byte) error {
+    ctx, span := c.tracer.Start(ctx, "consume queue.orders",
+        trace.WithSpanKind(trace.SpanKindConsumer),
+        trace.WithAttributes(
+            semconv.MessagingSystem("nats"),
+            semconv.MessagingOperationTypeReceive,
+            semconv.MessagingDestinationName("orders")))
+    defer span.End()
+
+    var order Order
+    if err := json.Unmarshal(msg, &order); err != nil {
+        span.SetStatus(codes.Error, "message parsing failed")
+        return fmt.Errorf("unmarshaling order: %w", err)
+    }
+
+    span.SetAttributes(attribute.String("order.id", order.ID))
+
+    if err := c.processOrder(ctx, &order); err != nil {
+        return fmt.Errorf("processing order: %w", err)
+    }
+
+    return nil
+}
+```
+
+### Background Job
+
+```go
+func (w *Worker) ProcessBatch(ctx context.Context, batchID string) error {
+    ctx, span := w.tracer.Start(ctx, "process batch",
+        trace.WithAttributes(
+            attribute.String("batch.id", batchID),
+            attribute.String("worker.id", w.id)))
+    defer span.End()
+
+    items, err := w.repo.GetBatchItems(ctx, batchID)
+    if err != nil {
+        return fmt.Errorf("fetching batch items: %w", err)
+    }
+
+    span.SetAttributes(attribute.Int("batch.size", len(items)))
+
+    processed := 0
+    for _, item := range items {
+        if err := w.processItem(ctx, item); err != nil {
+            var rec log.Record
+            rec.SetTimestamp(time.Now())
+            rec.SetSeverity(log.SeverityWarn)
+            rec.SetBody(log.StringValue("item processing failed"))
+            rec.AddAttributes(
+                log.String("item.id", item.ID),
+                log.String("error", err.Error()),
+            )
+            w.logger.Emit(ctx, rec)
+            continue
+        }
+        processed++
+    }
+
+    span.SetAttributes(
+        attribute.Int("batch.processed", processed),
+        attribute.Int("batch.failed", len(items)-processed),
+    )
+
+    return nil
+}
+```
+
+## Enriching Spans from Instrumentation Libraries
+
+When an instrumentation library (otelhttp, otelgin, otelmux, etc.) already creates spans, use `trace.SpanFromContext(ctx)` to add attributes to the existing span. Do not create a new span.
+
+```go
+func (h *Handler) CreateOrder(w http.ResponseWriter, r *http.Request) {
+    // Span already created by instrumentation library (otelhttp, otelgin, etc.)
+    ctx := r.Context()
+
+    // Add business attributes to existing span
+    span := trace.SpanFromContext(ctx)
+    span.SetAttributes(
+        attribute.String("business.operation", "order_creation"),
+        attribute.String("customer.tier", extractCustomerTier(r)))
+
+    order, err := h.service.CreateOrder(ctx, extractOrderData(r))
+    if err != nil {
+        span.SetStatus(codes.Error, "order creation failed")
+        http.Error(w, "Failed to create order", http.StatusInternalServerError)
+        return
+    }
+
+    span.SetAttributes(attribute.String("order.id", order.ID))
+
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(order)
+}
+```

--- a/skills/opentelemetry-go/references/performance.md
+++ b/skills/opentelemetry-go/references/performance.md
@@ -1,0 +1,480 @@
+# OpenTelemetry Go Performance Tuning
+
+Performance tuning reference for OpenTelemetry Go SDK. Covers sampling, batch processing, metric readers, attribute allocation, exporter configuration, and pipeline reliability.
+
+---
+
+## Performance Impact by Signal
+
+| Signal | Unsampled Overhead | Sampled Overhead | Primary Cost |
+|--------|-------------------|------------------|--------------|
+| Traces | Near-zero (noop span) | Moderate | Allocations, export I/O |
+| Metrics | N/A (always collected) | N/A | Aggregation, cardinality |
+| Logs | Near-zero if `Enabled()` false | Low-moderate | Serialization, export I/O |
+
+## Default Configuration Values
+
+| Parameter | Default | Environment Variable |
+|-----------|---------|---------------------|
+| Batch span queue size | 2048 | -- |
+| Batch span export size | 512 | `OTEL_TRACES_EXPORTER_MAX_EXPORT_BATCH_SIZE` |
+| Batch schedule delay | 5s | `OTEL_TRACES_EXPORTER_BATCH_SCHEDULE_DELAY` |
+| Batch export timeout | 30s | `OTEL_TRACES_EXPORTER_TIMEOUT` |
+| Span attribute limit | 128 | `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` |
+| Span event limit | 128 | `OTEL_SPAN_EVENT_COUNT_LIMIT` |
+| Span link limit | 128 | `OTEL_SPAN_LINK_COUNT_LIMIT` |
+| Attribute value length limit | Unlimited | `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` |
+| Metric export interval | 60s | `OTEL_METRIC_EXPORT_INTERVAL` |
+| Metric export timeout | 30s | `OTEL_METRIC_EXPORT_TIMEOUT` |
+| OTLP export timeout | 10s | `OTEL_EXPORTER_OTLP_TIMEOUT` |
+
+---
+
+## Sampling
+
+Sampling is the single most impactful performance lever for traces. Unsampled spans create noop instances with virtually zero overhead -- no allocations for attributes, events, or links.
+
+### Head Sampling Configuration
+
+Configure a sampler at the `TracerProvider` level to decide before span processing whether to record:
+
+```go
+// Sample 10% of traces
+sampler := sdktrace.TraceIDRatioBased(0.1)
+
+// Composite: respect upstream sampling decisions, ratio-sample the rest
+sampler := sdktrace.ParentBased(
+    sdktrace.TraceIDRatioBased(0.1),
+    // Remote parent sampled -> always sample (honor upstream)
+    // Remote parent not sampled -> never sample
+)
+
+tp := sdktrace.NewTracerProvider(
+    sdktrace.WithSampler(sampler),
+    sdktrace.WithBatcher(exporter),
+)
+```
+
+### AlwaysRecord Sampler (v1.40.0+)
+
+The `AlwaysRecord` sampler wraps another sampler and ensures spans are always recorded (attributes, events, status are captured) even when the inner sampler decides not to sample (export). This is useful with tail sampling in a Collector: spans carry full data for the Collector to make sampling decisions, but unsampled spans are not exported by the SDK.
+
+```go
+// Record all spans but only export 10% -- useful with Collector tail sampling
+sampler := sdktrace.AlwaysRecord(sdktrace.TraceIDRatioBased(0.1))
+```
+
+### Sampling Decision Impact
+
+```
+AlwaysSample       -> Full span lifecycle: allocation + recording + export
+AlwaysRecord(0.1)  -> All spans recorded, 10% exported
+TraceIDRatioBased(0.1) -> 90% of spans become noop (near-zero cost)
+NeverSample        -> All spans noop (useful for load testing)
+```
+
+`AlwaysSample` records and exports every span. `TraceIDRatioBased(0.1)` makes 90% of spans noop with near-zero cost. `ParentBased` wrapping respects upstream sampling decisions. `NeverSample` makes all spans noop, which is useful for benchmarking application-only performance.
+
+> **Tail sampling**: For decision-making based on complete traces (error status, latency thresholds), use the Collector's tail sampling processor instead of SDK-level sampling. SDK head sampling combined with Collector tail sampling is a common production pattern.
+
+---
+
+## Batch Processor Tuning
+
+The `BatchSpanProcessor` buffers spans in a queue and exports them asynchronously in batches.
+
+### How It Works
+
+```
+Application goroutine          BatchSpanProcessor goroutine
+       |                                |
+   span.End() --enqueue-->  channel queue (MaxQueueSize)
+       |                                |
+       |                         timer fires (ScheduleDelay)
+       |                         OR batch full (MaxExportBatchSize)
+       |                                |
+       |                        --export batch--> Exporter
+```
+
+### Tuning for Throughput
+
+For high-volume services (>10k spans/second):
+
+```go
+bsp := sdktrace.NewBatchSpanProcessor(exporter,
+    sdktrace.WithMaxQueueSize(4096),       // Absorb bursts (default: 2048)
+    sdktrace.WithMaxExportBatchSize(1024), // Fewer network calls (default: 512)
+    sdktrace.WithBatchTimeout(10*time.Second), // Allow larger batches (default: 5s)
+)
+```
+
+### Tuning for Latency
+
+For services where trace delivery speed matters (debugging, alerting):
+
+```go
+bsp := sdktrace.NewBatchSpanProcessor(exporter,
+    sdktrace.WithMaxExportBatchSize(128),       // Export smaller batches faster
+    sdktrace.WithBatchTimeout(2*time.Second),   // Export more frequently
+)
+```
+
+### Queue Full Behavior
+
+When the queue fills, new spans are dropped silently by default. Telemetry loss is preferable to application slowdown in this design.
+
+`WithBlockOnQueueFull()` changes this behavior to backpressure the application goroutine, blocking on `span.End()` until queue space is available.
+
+The SDK exposes internal metrics for monitoring queue depth.
+
+### SimpleSpanProcessor
+
+`SimpleSpanProcessor` exports spans synchronously on `span.End()`. It adds latency to every span ending. It is deterministic, which makes it useful for tests and development. Short-lived CLI tools may also use it to ensure spans are exported before exit.
+
+```go
+ssp := sdktrace.NewSimpleSpanProcessor(exporter)
+```
+
+---
+
+## Metric Reader Tuning
+
+### PeriodicReader Configuration
+
+The `PeriodicReader` collects and exports metrics on a fixed interval.
+
+```go
+reader := sdkmetric.NewPeriodicReader(exporter,
+    sdkmetric.WithInterval(30*time.Second), // More frequent than default 60s
+    sdkmetric.WithTimeout(15*time.Second),  // Timeout per export
+)
+```
+
+Interval tradeoffs:
+- 60s (default): Standard for dashboards and alerting
+- 15-30s: Near-real-time monitoring, higher export overhead
+- 5-10s: High-frequency use cases, significant overhead
+
+The reader internally uses `sync.Pool` to recycle `ResourceMetrics` objects, reducing GC pressure during collection cycles.
+
+### Views for Cardinality Control
+
+Views filter attributes before aggregation, reducing the number of unique time series.
+
+#### Attribute Filter
+
+```go
+// Drop a high-cardinality attribute from a specific metric
+dropUserID := sdkmetric.NewView(
+    sdkmetric.Instrument{Name: "http.server.request.duration"},
+    sdkmetric.Stream{
+        AttributeFilter: func(kv attribute.KeyValue) bool {
+            return kv.Key != "user.id" // Exclude user.id from aggregation
+        },
+    },
+)
+```
+
+An allowlist-style filter keeps only specified attributes:
+
+```go
+sdkmetric.Stream{
+    AttributeFilter: func(kv attribute.KeyValue) bool {
+        return kv.Key == "http.request.method" || kv.Key == "http.response.status_code"
+    },
+}
+```
+
+#### Drop Metric
+
+```go
+// Drop an entire metric
+dropMetric := sdkmetric.NewView(
+    sdkmetric.Instrument{Name: "runtime.*"},
+    sdkmetric.Stream{Aggregation: sdkmetric.AggregationDrop{}},
+)
+```
+
+#### Applying Views
+
+```go
+mp := sdkmetric.NewMeterProvider(
+    sdkmetric.WithReader(reader),
+    sdkmetric.WithView(dropUserID, dropMetric),
+)
+```
+
+Metric attribute cardinality is the product of unique values across all recorded attributes. Attributes like user IDs or request IDs are unbounded and produce one time series per unique value. Attributes like HTTP method (~10 values) or status code (~50 values) are bounded.
+
+---
+
+## Attribute Allocation Patterns
+
+Attributes are one of the primary sources of allocations in instrumented code.
+
+### Pre-allocating Attribute Sets
+
+For attributes used across many measurements, construct them once:
+
+```go
+var (
+    methodGET  = attribute.String("http.request.method", "GET")
+    methodPOST = attribute.String("http.request.method", "POST")
+    status2xx  = attribute.Int("http.response.status_code", 200)
+    status4xx  = attribute.Int("http.response.status_code", 400)
+    status5xx  = attribute.Int("http.response.status_code", 500)
+)
+
+func handleRequest(ctx context.Context, method string, status int) {
+    // Reuse pre-allocated attributes -- no allocation per call
+    counter.Add(ctx, 1, metric.WithAttributes(methodGET, status2xx))
+}
+```
+
+Constructing `attribute.String(...)` or `attribute.Int(...)` inline on every call allocates on every call.
+
+### Slice Capacity
+
+When building dynamic attribute sets, pre-allocating slice capacity eliminates repeated reallocations:
+
+```go
+attrs := make([]attribute.KeyValue, 0, 4)
+attrs = append(attrs, attribute.String("service.name", svcName))
+attrs = append(attrs, attribute.String("deployment.environment.name", env))
+if region != "" {
+    attrs = append(attrs, attribute.String("cloud.region", region))
+}
+```
+
+A `nil` slice (`var attrs []attribute.KeyValue`) reallocates on the first and subsequent appends as it grows.
+
+### Span Attribute Limits
+
+The SDK enforces configurable limits on span attributes, events, and links. When limits are exceeded, the oldest items are evicted (FIFO):
+
+```go
+tp := sdktrace.NewTracerProvider(
+    sdktrace.WithSpanLimits(sdktrace.SpanLimits{
+        AttributeCountLimit:         64,  // Default: 128
+        EventCountLimit:             32,  // Default: 128
+        LinkCountLimit:              16,  // Default: 128
+        AttributePerEventCountLimit: 16,  // Default: 128
+        AttributePerLinkCountLimit:  16,  // Default: 128
+        AttributeValueLengthLimit:   256, // Default: Unlimited. Truncates long strings.
+    }),
+)
+```
+
+`AttributeValueLengthLimit` truncates string values (stack traces, SQL queries, request bodies) that would otherwise consume unbounded memory.
+
+---
+
+## Exporter Configuration
+
+### gRPC vs HTTP
+
+| Aspect | gRPC | HTTP/protobuf |
+|--------|------|---------------|
+| Connection overhead | Single long-lived connection | New connection per export (or HTTP/2 reuse) |
+| Default port | 4317 | 4318 |
+| Compression | Optional gzip | Optional gzip |
+| Best for | Persistent connections, high throughput | Firewalls, load balancers, simpler infra |
+
+### Compression
+
+Compression reduces bandwidth at the cost of CPU.
+
+gRPC:
+
+```go
+import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+
+exporter, err := otlptracegrpc.New(ctx,
+    otlptracegrpc.WithCompressor("gzip"),
+)
+```
+
+HTTP:
+
+```go
+import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+
+exporter, err := otlptracehttp.New(ctx,
+    otlptracehttp.WithCompression(otlptracehttp.GzipCompression),
+)
+```
+
+### Retry Defaults
+
+The OTLP exporters use exponential backoff with jitter:
+
+| Parameter | Default |
+|-----------|---------|
+| Enabled | true |
+| Initial interval | 5s |
+| Max interval | 30s |
+| Max elapsed time | 1min |
+
+Retries honor `Retry-After` headers from the backend.
+
+### Timeout Tuning
+
+```go
+// Lower timeout: fail fast
+exporter, err := otlptracegrpc.New(ctx,
+    otlptracegrpc.WithTimeout(5*time.Second), // Default: 10s
+)
+
+// Higher timeout: allow more time for large batches
+exporter, err := otlptracegrpc.New(ctx,
+    otlptracegrpc.WithTimeout(30*time.Second),
+)
+```
+
+---
+
+## Log Signal Performance
+
+### Enabled() Early Exit
+
+The Logs API supports an `Enabled()` check for skipping expensive log construction when the log level is below threshold or when a processor filters it:
+
+```go
+logger := otellog.GetLoggerProvider().Logger("my-service")
+
+if logger.Enabled(ctx, log.EnabledParameters{Severity: log.SeverityInfo}) {
+    var rec log.Record
+    rec.SetBody(log.StringValue(expensiveStringBuild()))
+    rec.SetSeverity(log.SeverityInfo)
+    logger.Emit(ctx, rec)
+}
+```
+
+### log.Record Value Type
+
+`log.Record` is a struct value type (not an interface). Passing it by value keeps it stack-allocated, avoiding heap allocation:
+
+```go
+var rec log.Record
+rec.SetBody(log.StringValue("operation completed"))
+rec.SetSeverity(log.SeverityInfo)
+rec.AddAttributes(log.String("component", "handler"))
+logger.Emit(ctx, rec)
+```
+
+---
+
+## Context Propagation Performance
+
+### Extract Once per Boundary
+
+W3C Trace Context propagation involves parsing and formatting fixed-format headers. The overhead is minimal. Extract once per request boundary:
+
+```go
+ctx = otel.GetTextMapPropagator().Extract(ctx, propagation.HeaderCarrier(r.Header))
+```
+
+Extracting multiple times for the same request performs redundant parsing with no benefit.
+
+### Baggage Overhead
+
+Baggage is propagated across all service boundaries via HTTP headers. Every key-value pair in baggage adds to every outgoing request's header size:
+
+```go
+bag, _ := baggage.New(
+    baggageMember("tenant.id", tenantID),
+)
+ctx = baggage.ContextWithBaggage(ctx, bag)
+```
+
+Large values (e.g., full request bodies) or PII in baggage are propagated to every downstream service in every request.
+
+---
+
+## Graceful Shutdown
+
+Proper shutdown ensures buffered telemetry is flushed before the process exits. Shutdown order: providers first (which flush their processors), then exporters.
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+defer cancel()
+
+if err := tp.Shutdown(ctx); err != nil {
+    slog.Error("trace provider shutdown failed", "error", err)
+}
+if err := mp.Shutdown(ctx); err != nil {
+    slog.Error("metric provider shutdown failed", "error", err)
+}
+if err := lp.Shutdown(ctx); err != nil {
+    slog.Error("log provider shutdown failed", "error", err)
+}
+```
+
+---
+
+## Telemetry Pipeline Reliability
+
+The OpenTelemetry SDK is designed so that telemetry failures do not crash or block the application:
+
+- **Span creation never returns an error** -- it returns a noop span on failure
+- **Metric recording never returns an error** -- measurements are silently dropped on failure
+- **Export failures are retried** -- then dropped after max elapsed time
+- **Queue overflow drops spans** -- the application is not blocked (unless `WithBlockOnQueueFull` is used)
+
+---
+
+## Monitoring the Pipeline
+
+The SDK exposes internal metrics about its own health:
+
+| Metric | Meaning |
+|--------|---------|
+| `otel.sdk.trace.spans_exported` | Spans successfully exported |
+| `otel.sdk.trace.spans_dropped` | Spans dropped (queue full, export failure) |
+| Exporter errors in logs | Export failures with error details |
+
+### ForceFlush
+
+`ForceFlush` synchronously exports all buffered data:
+
+```go
+if err := tp.ForceFlush(ctx); err != nil {
+    slog.Warn("failed to flush traces", "error", err)
+}
+```
+
+As of v1.42.0, `TracerProvider.ForceFlush` iterates through all `SpanProcessor` instances and joins their errors together, instead of stopping at the first error. All processors get a chance to flush even if one fails.
+
+`ForceFlush` in the request hot path synchronously exports all buffered data, adding latency to that request.
+
+---
+
+## Synchronous Instrument Enabled()
+
+As of v1.40.0, all synchronous metric instruments (`Int64Counter`, `Float64Counter`, `Int64UpDownCounter`, `Float64UpDownCounter`, `Int64Histogram`, `Float64Histogram`, `Int64Gauge`, `Float64Gauge`) expose an `Enabled()` method. This allows skipping expensive metric value computation when the instrument is not recording:
+
+```go
+histogram, _ := meter.Float64Histogram("expensive.metric")
+
+attrs := metric.WithAttributes(attribute.String("region", region))
+if histogram.Enabled(ctx, attrs) {
+    value := computeExpensiveValue() // Only called when instrument is active
+    histogram.Record(ctx, value, attrs)
+}
+```
+
+This is the metric equivalent of `Logger.Enabled()` for logs. When combined with Views that drop metrics, `Enabled()` returns `false` for dropped instruments.
+
+---
+
+## SDK Performance Improvements
+
+As of v1.40.0, the SDK includes significant performance improvements:
+
+- Concurrent histogram measurements: uses `sync.Map` and atomics instead of mutex (2-4x improvement)
+- Concurrent synchronous gauge measurements: uses `sync.Map` and atomics
+- Concurrent exponential histogram measurements: defers count computation until collection
+- `HistogramReservoir` exemplar sampling: 4x concurrent performance improvement
+- `FixedSizeReservoir` exemplar sampling: optimized with atomics
+
+The HTTP instrumentation libraries (`otelhttp`, `otelgin`, `otelmux`, `otelecho`, `otelhttptrace`, `otelrestful`) include reduced allocations for common request protocols.

--- a/skills/opentelemetry-go/references/sdk-setup.md
+++ b/skills/opentelemetry-go/references/sdk-setup.md
@@ -1,0 +1,323 @@
+# OpenTelemetry Go SDK Setup
+
+## Dependencies
+
+```go
+import (
+    "context"
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/log/global"
+    "go.opentelemetry.io/otel/propagation"
+    semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+    otelconf "go.opentelemetry.io/contrib/otelconf/v0.3.0"
+    "go.opentelemetry.io/contrib/bridges/otelzap"
+)
+```
+
+> **Migration note (contrib v1.35.0):** The `go.opentelemetry.io/contrib/config` module is deprecated. Use `go.opentelemetry.io/contrib/otelconf` instead. The API is identical — only the import path changes.
+
+## Provider Setup
+
+```go
+package telemetry
+
+import (
+    "context"
+    "errors"
+    "fmt"
+    "os"
+
+    "github.com/google/uuid"
+    "go.opentelemetry.io/contrib/bridges/otelzap"
+    otelconf "go.opentelemetry.io/contrib/otelconf/v0.3.0"
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/log"
+    "go.opentelemetry.io/otel/log/global"
+    "go.opentelemetry.io/otel/metric"
+    "go.opentelemetry.io/otel/propagation"
+    semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+    "go.opentelemetry.io/otel/trace"
+    "go.uber.org/zap"
+    "go.uber.org/zap/zapcore"
+)
+
+// Providers holds the OpenTelemetry providers and logger
+type Providers struct {
+    TracerProvider trace.TracerProvider
+    MeterProvider  metric.MeterProvider
+    LoggerProvider log.LoggerProvider
+    Logger         *zap.Logger
+    Closer         func(ctx context.Context) error
+}
+
+// SetupTelemetry initializes OpenTelemetry providers from configuration
+func SetupTelemetry(ctx context.Context, serviceName, version, configFile string) (*Providers, error) {
+    providers, err := providersFromConfig(ctx, serviceName, version, configFile)
+    if err != nil {
+        return nil, err
+    }
+
+    // Set global providers
+    otel.SetTracerProvider(providers.TracerProvider)
+    otel.SetMeterProvider(providers.MeterProvider)
+    global.SetLoggerProvider(providers.LoggerProvider)
+    
+    // Set up context propagation, needed until this is fixed: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/6712
+    otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+        propagation.TraceContext{},
+        propagation.Baggage{},
+    ))
+
+    return providers, nil
+}
+
+// providersFromConfig creates providers from YAML configuration file
+func providersFromConfig(ctx context.Context, scope, version, cfgFile string) (*Providers, error) {
+    b, err := os.ReadFile(cfgFile)
+    if err != nil {
+        if errors.Is(err, os.ErrNotExist) {
+            // Return default providers if config doesn't exist
+            logger := zap.Must(zap.NewProduction())
+            logger.Warn("OpenTelemetry config file not found, using no-op providers", 
+                zap.String("config_file", cfgFile))
+            return &Providers{
+                TracerProvider: trace.NewNoOpTracerProvider(),
+                MeterProvider:  metric.NewNoOpMeterProvider(),
+                LoggerProvider: log.NewNoOpLoggerProvider(),
+                Logger:         logger,
+                Closer:         func(ctx context.Context) error { return nil },
+            }, nil
+        }
+        return nil, fmt.Errorf("failed to read config file %s: %w", cfgFile, err)
+    }
+
+    // Expand environment variables in config
+    b = []byte(os.ExpandEnv(string(b)))
+
+    // Parse OpenTelemetry configuration
+    conf, err := otelconf.ParseYAML(b)
+    if err != nil {
+        return nil, err
+    }
+
+    // Set resource attributes
+    if conf.Resource == nil {
+        conf.Resource = &otelconf.Resource{}
+    }
+    if conf.Resource.Attributes == nil {
+        conf.Resource.Attributes = []otelconf.AttributeNameValue{}
+    }
+
+    // Add service metadata
+    conf.Resource.Attributes = insertAttribute(conf.Resource.Attributes, 
+        string(semconv.ServiceVersionKey), version)
+    conf.Resource.Attributes = insertAttribute(conf.Resource.Attributes, 
+        string(semconv.ServiceInstanceIDKey), uuid.New().String())
+
+    // Create SDK
+    sdk, err := otelconf.NewSDK(
+        otelconf.WithContext(ctx), 
+        otelconf.WithOpenTelemetryConfiguration(*conf),
+    )
+    if err != nil {
+        return nil, err
+    }
+
+    // Create zap logger with OpenTelemetry bridge
+    core := zapcore.NewTee(
+        zapcore.NewCore(
+            zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), 
+            zapcore.AddSync(os.Stdout), 
+            zapcore.InfoLevel,
+        ),
+        otelzap.NewCore(scope, otelzap.WithLoggerProvider(global.GetLoggerProvider())),
+    )
+
+    return &Providers{
+        TracerProvider: sdk.TracerProvider(),
+        MeterProvider:  sdk.MeterProvider(),
+        LoggerProvider: sdk.LoggerProvider(),
+        Logger:         zap.New(core),
+        Closer:         sdk.Shutdown,
+    }, nil
+}
+
+func insertAttribute(attrs []otelconf.AttributeNameValue, name, value string) []otelconf.AttributeNameValue {
+    for _, attr := range attrs {
+        if attr.Name == name {
+            return attrs
+        }
+    }
+    return append(attrs, otelconf.AttributeNameValue{Name: name, Value: value})
+}
+```
+
+## Global Provider Registration
+
+After creating the providers, register them globally so instrumentation libraries and application code can access them via the OpenTelemetry API:
+
+```go
+otel.SetTracerProvider(providers.TracerProvider)
+otel.SetMeterProvider(providers.MeterProvider)
+global.SetLoggerProvider(providers.LoggerProvider)
+```
+
+Set up context propagation for distributed tracing:
+
+```go
+otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+    propagation.TraceContext{},
+    propagation.Baggage{},
+))
+```
+
+> **Note:** Explicit propagator setup is needed as a workaround until [contrib issue #6712](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/6712) is resolved. The declarative configuration should handle this automatically once that issue is fixed.
+
+## Service Integration
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "os"
+    "os/signal"
+    "syscall"
+
+    "myservice/internal/telemetry"
+)
+
+func main() {
+    ctx := context.Background()
+
+    // Setup telemetry
+    providers, err := telemetry.SetupTelemetry(ctx, 
+        telemetry.ServiceName, 
+        telemetry.ServiceVersion,
+        "configs/otel.yaml")
+    if err != nil {
+        log.Fatalf("Failed to setup telemetry: %v", err)
+    }
+
+    // Graceful shutdown
+    defer func() {
+        shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+        defer cancel()
+        if err := providers.Closer(shutdownCtx); err != nil {
+            providers.Logger.Error("Failed to shutdown telemetry", zap.Error(err))
+        }
+    }()
+
+    // Start your application
+    app := NewApp(providers.Logger)
+    if err := app.Run(ctx); err != nil {
+        providers.Logger.Fatal("Application failed", zap.Error(err))
+    }
+}
+
+type App struct {
+    logger *zap.Logger
+    tracer trace.Tracer
+    meter  metric.Meter
+}
+
+func NewApp(logger *zap.Logger) *App {
+    return &App{
+        logger: logger,
+        tracer: otel.Tracer(telemetry.Scope),
+        meter:  otel.Meter(telemetry.Scope),
+    }
+}
+
+func (a *App) Run(ctx context.Context) error {
+    ctx, span := a.tracer.Start(ctx, "app startup")
+
+    a.logger.Info("Application starting")
+    
+    // Application logic here
+    
+    span.End() // Close span before blocking
+    
+    // Wait for shutdown signal
+    sigChan := make(chan os.Signal, 1)
+    signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+    <-sigChan
+
+    a.logger.Info("Application shutting down")
+    return nil
+}
+```
+
+## Configuration File
+
+Example OpenTelemetry configuration file (`configs/otel.yaml`):
+
+```yaml
+file_format: "0.3"
+resource:
+  schema_url: https://opentelemetry.io/schemas/1.26.0
+  attributes:
+    - name: service.name
+      value: "user-service"
+    - name: deployment.environment.name
+      value: "development"
+
+propagator:
+  composite: [ tracecontext, baggage ]
+
+tracer_provider:
+  processors:
+    - batch:
+        timeout: 1s
+        send_batch_size: 1024
+        exporter:
+          otlp:
+            protocol: http/protobuf
+            endpoint: "http://localhost:4318"
+
+meter_provider:
+  readers:
+    - periodic:
+        interval: 30s
+        exporter:
+          otlp:
+            protocol: http/protobuf
+            endpoint: "http://localhost:4318"
+
+logger_provider:
+  processors:
+    - batch:
+        exporter:
+          otlp:
+            protocol: http/protobuf
+            endpoint: "http://localhost:4318"
+```
+
+## Declarative Configuration with otelconf
+
+The `otelconf` package (`go.opentelemetry.io/contrib/otelconf`) implements the language-agnostic OpenTelemetry declarative configuration schema in Go. It parses a YAML configuration file conforming to the OpenTelemetry configuration schema and creates fully configured SDK providers.
+
+The full YAML schema is covered by the `opentelemetry-sdk-configuration` skill.
+
+Key functions:
+
+```go
+// Parse a YAML configuration file
+conf, err := otelconf.ParseYAML(yamlBytes)
+
+// Create an SDK instance from the parsed configuration
+sdk, err := otelconf.NewSDK(
+    otelconf.WithContext(ctx),
+    otelconf.WithOpenTelemetryConfiguration(*conf),
+)
+
+// Access providers from the SDK
+tracerProvider := sdk.TracerProvider()
+meterProvider := sdk.MeterProvider()
+loggerProvider := sdk.LoggerProvider()
+
+// Shut down all providers, flushing pending telemetry
+err = sdk.Shutdown(ctx)
+```


### PR DESCRIPTION
## Summary

- Add `opentelemetry-go` skill with mechanics-only reference content for the OpenTelemetry Go API, SDK, and instrumentation libraries
- SKILL.md contains current versions (v1.42.0), 12 gotchas/breaking changes, and progressive disclosure routing to 4 reference files
- Reference files cover: API surface, SDK setup with otelconf, contrib library catalog, and performance tuning
- Update README.md org references from niwoerner to ollygarden and add new skill to the table

Resolves OTEL-216

## Test plan

- [ ] Verify SKILL.md is under 500 lines per agent skills spec
- [ ] Verify no opinion content (best practices, checklists, when-to-instrument guidance) leaked into any file
- [ ] Verify all reference file paths in SKILL.md point to existing files
- [ ] Verify skill name in frontmatter matches directory name
- [ ] Verify README.md install commands use ollygarden org

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenTelemetry Go skill to expand instrumentation and observability guidance.

* **Documentation**
  * New comprehensive Go docs: API reference, instrumentation library usage, performance tuning, SDK setup examples, and breaking-changes/gotchas.
  * Updated CLI install examples to point to the new GitHub repository/owner and demonstrate skill installation via --skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->