### PR TITLE
ci: use Blacksmith runners for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   tool-tests:
-    runs-on: ubuntu-22.04
+    runs-on: blacksmith
 
     steps:
       - name: Checkout Repo
@@ -43,7 +43,7 @@ jobs:
         run: go test ./tools/otel-agent-tools/...
 
   check-links:
-    runs-on: ubuntu-22.04
+    runs-on: blacksmith
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/reconcile-otel-versions.yml
+++ b/.github/workflows/reconcile-otel-versions.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   reconcile:
-    runs-on: ubuntu-22.04
+    runs-on: blacksmith
 
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
## Summary
- Switch `ci.yml` (`tool-tests`, `check-links`) and `reconcile-otel-versions.yml` (`reconcile`) from `ubuntu-22.04` to `blacksmith` runners
- Matches the convention already in use in the raincatcher repo

Refs: [OTEL-221](https://linear.app/ollygarden/issue/OTEL-221/use-blacksmith-runners-for-github-actions-workflows)

## Test plan
- [ ] CI runs green on the new runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD runner environments to optimize build and validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->