### PR TITLE
fix(span-events-to-logs): use SetEventName and soften stacktrace in Go

### DIFF
--- a/skills/general/span-events-to-logs-migration/SKILL.md
+++ b/skills/general/span-events-to-logs-migration/SKILL.md
@@ -32,7 +32,7 @@ See `references/deprecation-plan.md` for the full context.
 3. Apply the migration for each call site.
 - see `references/migration-patterns.md` for language-specific before/after patterns
 - ensure the replacement log record carries the correct span context, event name, attributes, and timestamp
-- for exceptions, ensure `exception.type`, `exception.message`, and `exception.stacktrace` attributes are preserved
+- for exceptions, preserve the applicable semconv attributes: `exception.type` and `exception.message` (at least one is required), plus `exception.stacktrace` when the language/error type makes it meaningful (in Go, omit it unless an error library preserves the origin stack -- do not call `runtime.Stack` at the emit site)
 
 4. If backward compatibility is needed, configure the SDK bridge.
 - see `references/backward-compat.md`
@@ -66,7 +66,7 @@ Include file references as evidence for every completed item.
 - `[ ]` All `RecordException` / `record_exception` / `recordException` call sites identified and classified.
 - `[ ]` A LoggerProvider is configured in the SDK setup (or already existed).
 - `[ ]` Each migrated event uses the Logs API with the correct event name and attributes.
-- `[ ]` Each migrated exception preserves `exception.type`, `exception.message`, and `exception.stacktrace`.
+- `[ ]` Each migrated exception preserves the applicable semconv attributes: `exception.type` and `exception.message` (at least one is required), plus `exception.stacktrace` when the language/error type makes it meaningful.
 - `[ ]` Migrated log records carry the active span context for trace correlation.
 - `[ ]` Call sites classified as "convert to span attributes" now use span attributes instead.
 - `[ ]` Call sites classified as "remove" have been removed with justification.

--- a/skills/general/span-events-to-logs-migration/references/migration-patterns.md
+++ b/skills/general/span-events-to-logs-migration/references/migration-patterns.md
@@ -20,16 +20,24 @@ After:
 logger := otel.GetLoggerProvider().Logger("my-package")
 record := log.Record{}
 record.SetTimestamp(time.Now())
+record.SetEventName("exception")
 record.SetSeverity(log.SeverityError)
+// exception.stacktrace is intentionally omitted: the Go error value does
+// not carry its origin stack, and capturing runtime.Stack here would
+// point at the emit site, not where the error arose. Per semconv, the
+// attribute is Recommended, not Required. If the project uses an error
+// library that preserves the origin stack (e.g., github.com/pkg/errors,
+// github.com/cockroachdb/errors), extract the stack from the error and
+// add an exception.stacktrace attribute. Do not call runtime.Stack here.
 record.AddAttributes(
-    log.String("event.name", "exception"),
     log.String("exception.type", fmt.Sprintf("%T", err)),
     log.String("exception.message", err.Error()),
-    log.String("exception.stacktrace", captureStack()),
 )
 logger.Emit(ctx, record)
 span.SetStatus(codes.Error, err.Error())
 ```
+
+Prefer `record.SetEventName(name)` over adding an `event.name` attribute in Go: it is a first-class field on `log.Record` and produces cleaner output in backends that special-case event records.
 
 ### General Event
 
@@ -45,8 +53,8 @@ After:
 logger := otel.GetLoggerProvider().Logger("my-package")
 record := log.Record{}
 record.SetTimestamp(time.Now())
+record.SetEventName("cache.miss")
 record.AddAttributes(
-    log.String("event.name", "cache.miss"),
     log.String("cache.key", key),
 )
 logger.Emit(ctx, record)
@@ -225,7 +233,7 @@ logger.LogWarning("validation.failure for field {Field} rule {Rule}", fieldName,
 
 ## Key Rules Across All Languages
 
-1. The `event.name` attribute on the log record replaces the event name from `AddEvent`.
+1. The event name replaces the name from `AddEvent`. Use the dedicated API when available (e.g., `record.SetEventName(...)` in Go); otherwise set an `event.name` attribute.
 2. All original attributes transfer to the log record attributes.
 3. The log record automatically inherits the active span context from `ctx` / the current context -- this is how trace correlation is maintained.
 4. `span.SetStatus` (or equivalent) is still set on the span for error cases -- the migration only moves event emission, not status.


### PR DESCRIPTION
## Summary
Applies findings from migrating the otel-in-practice repo with the `span-events-to-logs-migration` skill:

- **Go: prefer `record.SetEventName(...)`** over adding an `event.name` attribute. It is a first-class field on `log.Record` and produces cleaner output in backends that special-case event records.
- **Go: drop unconditional `exception.stacktrace`**. The Go `error` value does not carry its origin stack; calling `runtime.Stack` at the emit site captures the handler/service boundary, not the failing call. Per semconv, `exception.stacktrace` is Recommended, not Required — omit it unless the project uses an error library that preserves the origin stack.
- **Checklist: align with semconv**. `exception.type` and `exception.message` are what must be preserved (at least one required); `exception.stacktrace` is conditional on the language/error type.

Other languages are unchanged.

## Test plan
- [ ] Re-read `SKILL.md` and `references/migration-patterns.md` to confirm the Go examples compile mentally and the checklist wording matches semconv.
- [ ] Spot-check that Python/Java/JS/.NET sections are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined exception handling migration guidelines with more flexible field preservation requirements.
  * Updated Go code examples to use first-class event-name APIs instead of attribute-based approaches.
  * Improved guidance on conditional stack trace capture for Go errors based on library capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->