### PR TITLE
feat(ottl): add OpenTelemetry Transformation Language skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ descriptive (no prefix) for readability.
 | Skill | Path | Use When |
 | --- | --- | --- |
 | `otel-declarative-config` | `skills/general/declarative-config/` | Configuring OpenTelemetry SDK providers via a single YAML file (`otelconf`, `OTEL_CONFIG_FILE`, `file_format`). Points at the upstream schema, env-var substitution rules, and configuration precedence. |
+| `otel-ottl` | `skills/general/ottl/` | Authoring or reviewing OTTL statements for `transform`, `filter`, `routing`, and `tail_sampling` processors; debugging OTTL syntax and semantics; transforming traces, metrics, logs, and profiles in the Collector. |
 | `otel-sdk-versions` | `skills/general/sdk-versions/` | Choosing the latest compatible released OpenTelemetry SDK or package version for a language and finding setup docs or examples. |
 | `otel-semantic-conventions` | `skills/general/semantic-conventions/` | Selecting released semantic convention groups, attributes, and span naming rules; checking compliance; looking up exact upstream entries via the bundled query script. |
 | `otel-span-events-to-logs-migration` | `skills/general/span-events-to-logs-migration/` | Migrating instrumentation from the deprecated Span Event API (`AddEvent`, `RecordException`) to the Logs API following the OTEP 4430 deprecation plan. |

--- a/skills/general/ottl/SKILL.md
+++ b/skills/general/ottl/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: otel-ottl
+description: OpenTelemetry Transformation Language (OTTL) expert for writing and debugging telemetry transformations in the OpenTelemetry Collector. Use when authoring or reviewing `transform`, `filter`, `routing`, or `tail_sampling` processor configs, debugging OTTL syntax or semantics, transforming traces, metrics, logs, or profiles, or converting data-processing requirements into OTTL statements.
+---
+
+# OpenTelemetry Transformation Language (OTTL)
+
+OTTL is a domain-specific language for transforming telemetry inside the OpenTelemetry Collector. It is consumed by the `transform`, `filter`, `routing`, and `tail_sampling` processors (and a few others) in [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl).
+
+This skill targets `pkg/ottl` as of collector-contrib **v0.149.0**. Function and path availability before that version differs; check the upstream `pkg/ottl/ottlfuncs/README.md` and `pkg/ottl/contexts/*/README.md` for the exact set in any older release.
+
+## Statement syntax
+
+```ottl
+function(arguments) [where condition]
+```
+
+Every statement has exactly one **editor** (lowercase: `set`, `delete_key`, `append`, …) optionally guarded by a `where` clause whose body is a boolean expression. Conditions can call **converters** (uppercase: `Concat`, `IsMatch`, `ParseJSON`, …) which return values but do not mutate telemetry.
+
+```ottl
+set(span.attributes["env"], "prod") where resource.attributes["env"] == nil
+```
+
+## Workflow
+
+1. **Pick the processor.** `transform` rewrites; `filter` drops; `routing` fans out by pipeline; `tail_sampling` keeps/drops traces. The processor decides which contexts and function set are usable.
+2. **Pick the context.** `resource`, `scope`, `span`, `spanevent`, `metric`, `datapoint`, `log`, `profile`, `profilesample`. Operate at the lowest level that gives you the data — using `datapoint` to set attributes is much cheaper than walking through `metric.data_points` from the metric context.
+3. **Write statements.** Reach for `references/quick-reference.md` for common recipes; `references/contexts.md` for paths/enums; `references/functions.md` for the editor and converter catalog.
+4. **Set `error_mode`.** `ignore` (default) keeps the pipeline running and logs errors; `silent` does the same but quietly; `propagate` aborts on first failure (use only when you want a bad config to fail loud in tests).
+5. **Verify.** OTTL gotchas are the kind that pass the eye test (see [Common gotchas](#common-gotchas)). Use the [telemetrygen verification recipe](../telemetrygen/SKILL.md#verifying-a-collector-config) — `otelcol-contrib` + file exporter + telemetrygen — to confirm the snippet does what the prose claims before shipping.
+
+## Contexts at a glance
+
+OTTL paths are scoped by signal. Higher levels are reachable from lower ones (e.g., `resource.attributes` from a span statement); the reverse is not true.
+
+| Context | Common paths |
+|---------|--------------|
+| Resource | `resource.attributes["service.name"]`, `resource.metadata["X-Tenant-ID"]` |
+| Scope | `scope.name`, `scope.version`, `scope.attributes["…"]` |
+| Span | `span.name`, `span.kind`, `span.status.code`, `span.attributes["…"]`, `span.flags` |
+| Span Event | `spanevent.name`, `spanevent.attributes["…"]`, `spanevent.event_index` |
+| Metric | `metric.name`, `metric.unit`, `metric.type`, `metric.aggregation_temporality` |
+| DataPoint | `datapoint.value_double`, `datapoint.value_int`, `datapoint.attributes["…"]` |
+| Log | `log.body`, `log.body.string`, `log.severity_number`, `log.attributes["…"]` |
+| Profile | `profile.profile_id`, `profile.attributes["…"]` (Development) |
+
+Full path inventory plus enums in `references/contexts.md`.
+
+## Essential functions
+
+```ottl
+# Editors (mutate telemetry)
+set(target, value)
+delete_key(target, key)               # delete by exact key
+delete_matching_keys(target, regex)   # delete by regex
+delete_index(target, index)           # remove from a slice (v0.145+)
+keep_keys(target, [k1, k2])           # keep only these keys
+merge_maps(target, source, "upsert")  # "insert" | "update" | "upsert"
+truncate_all(target, max_len)         # UTF-8 safe by default in v0.148+
+replace_pattern(target, regex, replacement)
+
+# Converters (return values)
+Concat([a, b], "-")
+Split(s, ",")
+ToLowerCase(s) / ToUpperCase(s)
+IsMatch(s, "pattern")                 # bool
+String(v) / Int(v) / Double(v) / Bool(v)
+ParseJSON(s) / ParseKeyValue(s, "&", "=")
+URL(s)                                # parse URL components (v0.127+)
+ExtractPatterns(s, "(?P<name>…)")     # named captures → map
+ExtractGrokPatterns(s, "%{IP:client}") # Grok (v0.130+)
+IsInCIDR(ip, ["10.0.0.0/8"])          # CIDR membership (v0.146+)
+SHA256(v) / Murmur3Hash(v) / XXH3(v)  # hashing
+UUID() / UUIDv7()
+```
+
+Full catalog with signatures in `references/functions.md`.
+
+## Common patterns
+
+```ottl
+# Conditional set
+set(span.attributes["sampled"], true)
+    where (span.end_time_unix_nano - span.start_time_unix_nano) > 1000000000
+
+# Normalize a value
+set(span.attributes["http.method"],
+    ToUpperCase(String(span.attributes["http.method"])))
+
+# Parse a JSON log body into structured attributes
+set(log.attributes, ParseJSON(log.body.string))
+    where IsString(log.body) and IsMatch(log.body.string, "^\\s*\\{.*\\}\\s*$")
+
+# Mark errored HTTP spans
+set(span.status.code, STATUS_CODE_ERROR)
+    where IsInt(span.attributes["http.status_code"])
+      and Int(span.attributes["http.status_code"]) >= 400
+
+# Redact secrets by key pattern
+delete_matching_keys(span.attributes, "(?i).*(password|secret|token|apikey).*")
+
+# Hash PII rather than dropping it (preserves cardinality for analytics)
+set(span.attributes["user.email_hash"], SHA256(span.attributes["user.email"]))
+delete_key(span.attributes, "user.email")
+```
+
+More recipes (sampling, redaction, time math, parsing) in `references/quick-reference.md`.
+
+## Processor wiring
+
+```yaml
+processors:
+  transform:
+    error_mode: ignore        # ignore | silent | propagate
+    trace_statements:
+      - context: span
+        statements:
+          - set(span.attributes["processed"], true)
+    log_statements:
+      - context: log
+        statements:
+          - set(log.attributes["source"], "collector")
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(datapoint.attributes["env"], "prod")
+
+  filter:
+    error_mode: ignore
+    traces:
+      span:
+        - 'IsMatch(span.name, "^/health.*")'
+    logs:
+      log_record:
+        - 'log.severity_number < SEVERITY_NUMBER_WARN'
+
+  routing:
+    default_pipelines: [traces/default]
+    table:
+      - statement: 'route() where resource.attributes["env"] == "prod"'
+        pipelines: [traces/prod]
+      - statement: 'route() where span.status.code == STATUS_CODE_ERROR'
+        pipelines: [traces/errors]
+
+  tail_sampling:
+    policies:
+      - name: errors
+        type: ottl_condition
+        ottl_condition:
+          span:
+            - 'span.status.code == STATUS_CODE_ERROR'
+```
+
+## Common gotchas
+
+These mistakes pass YAML validation but break OTTL semantics. Most have cost real time in production rollouts.
+
+### `replace_pattern` backreferences need `$${1}` in YAML
+
+OTTL uses `${1}`, `${2}`, … for regex backreferences. The collector's YAML loader treats `$` as an env-var marker, so YAML `$$` becomes OTTL `$`. To produce `${1}` at the OTTL level, write `$${1}` in YAML. Writing `"$1REDACTED"` produces literal `$1REDACTED` with no replacement — silent failure.
+
+### Go RE2 has a repeat-count ceiling
+
+Patterns like `(.{1024}).*` fail to compile with "invalid repeat count". For length-based truncation, prefer `Substring` + `Len`:
+
+```ottl
+set(attributes["db.statement"], Substring(attributes["db.statement"], 0, 1024))
+    where attributes["db.statement"] != nil and Len(attributes["db.statement"]) > 1024
+```
+
+Or use `truncate_all` for whole maps (UTF-8 safe by default since v0.148):
+
+```ottl
+truncate_all(span.attributes, 1024)
+```
+
+### `attributes` processor ≠ `resource` processor
+
+The OTel `attributes` processor only operates on span/log/metric attributes. To touch a *resource* attribute use the `resource` processor or a `transform` processor with `context: resource`. A config like `attributes/strip_resource: actions: [...delete os.description...]` runs without error but doesn't change resource attributes — silent no-op.
+
+### `logdedup` paths use dot-notation only
+
+The processor accepts `include_fields` / `exclude_fields` (not `fields`). Paths must start with `attributes.` or `body.` and use dot-notation. Bracket notation (`attributes["service.name"]`) is rejected, and `resource[...]` paths are not addressable. Default behavior dedups on the full record, which is usually what's wanted.
+
+### `k8sattributes` cannot extract `k8s.cluster.name`
+
+The processor's `metadata` list is restricted to pod-level identity. Cluster name has to come from `resourcedetection` or a static `resource` processor that reads it from an env var.
+
+### Path syntax changed in v0.120
+
+In older configs you may see `span_event.*` — current syntax is `spanevent.*`. Cache paths now require the context prefix: write `span.cache["x"]` not just `cache["x"]`. Plain `cache` is only valid in profile/profilesample contexts where it's the documented path. Paste-from-old-config is the most common source of regressions.
+
+### `Base64Decode` is deprecated
+
+Use `Decode(value, "base64")` instead. The same `Decode` converter handles `base64-raw`, `base64-url`, `base64-raw-url`, and IANA character set encodings. Keep `Base64Decode` only if pinned to a pre-v0.141 collector.
+
+### `Bool` converter coercion is loose
+
+`Bool("true")`, `Bool("1")`, `Bool(1)` all return `true`; `Bool("false")`, `Bool("0")`, `Bool(0)`, `Bool(0.0)` return `false`. Anything else errors. Don't assume Python-like truthiness for arbitrary strings.
+
+### Verify before publishing
+
+YAML/OTTL gotchas like the above pass the eye test. Use the [telemetrygen verification recipe](../telemetrygen/SKILL.md#verifying-a-collector-config) (otelcol-contrib + file exporter + telemetrygen) to confirm the snippet does what the surrounding prose claims, especially before shipping to a customer or production.
+
+## Best practices
+
+1. **Validate inputs** before conversion: `where IsString(x)`, `where x != nil`.
+2. **Order conditions by selectivity** (cheap and most-selective first). `span.kind == SPAN_KIND_SERVER and IsMatch(...)` lets the kind check short-circuit before the regex runs.
+3. **Cache expensive operations** in `<context>.cache`: `set(span.cache["url_parts"], Split(span.attributes["http.url"], "/"))`, then read from cache.
+4. **Use the most specific context.** `datapoint` for metric-attribute work beats walking `metric.data_points` from the metric context.
+5. **Escape regex correctly.** Use `\\d+`, `\\.`, `\\s+` in OTTL strings (single backslash in YAML becomes a literal).
+6. **Prefer `keep_keys` to a long list of `delete_key`** when shaping output — easier to read, fails closed.
+
+## Versioning notes
+
+Recently added (still useful to know which release introduced them when supporting users on older collectors):
+
+| Feature | Since |
+|---------|-------|
+| Profile / ProfileSample contexts | v0.124 / v0.132 (Development) |
+| Cache paths require context prefix; `spanevent` rename | v0.120 (breaking) |
+| `delete_index` editor | v0.145 |
+| `span.flags` path | v0.145 |
+| `<context>.metadata` for client request metadata | v0.147 |
+| `truncate_all` UTF-8 safe default (`utf8_safe` parameter) | v0.148 (behavior change) |
+| `SpanID` / `TraceID` accept hex strings | v0.142 |
+| `flatten` `resolveConflicts` parameter | v0.139 |
+| `Base64Encode` | v0.147 |
+| `Decode`, deprecates `Base64Decode` | v0.141 |
+| `Bool` converter | v0.143 |
+| `ExtractGrokPatterns` | v0.130 |
+| `URL`, `UserAgent` | v0.127, v0.134 |
+| `IsInCIDR` | v0.146 |
+| `Murmur3Hash*`, `XXH3`, `XXH128` | v0.129, v0.135 |
+| `Sort`, `Index`, `SliceToMap` | v0.125, v0.126, v0.128 |
+| `UUIDv7`, `ParseSeverity`, `CommunityID` | v0.138, v0.133, v0.131 |
+
+## References
+
+- `references/contexts.md` — context paths and enums
+- `references/functions.md` — editors and converters with signatures
+- `references/quick-reference.md` — recipes, regex patterns, troubleshooting
+- Upstream: <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl>

--- a/skills/general/ottl/references/contexts.md
+++ b/skills/general/ottl/references/contexts.md
@@ -161,8 +161,7 @@ metric.metadata
 
 ```ottl
 # Normalize metric names to safe characters
-set(metric.name,
-    replace_all_patterns(metric.name, "value", "[^a-zA-Z0-9_]", "_"))
+set(metric.name, replace_pattern(metric.name, "[^a-zA-Z0-9_]", "_"))
 
 # Normalize legacy units
 set(metric.unit, "s") where metric.unit == "seconds"

--- a/skills/general/ottl/references/contexts.md
+++ b/skills/general/ottl/references/contexts.md
@@ -1,0 +1,338 @@
+# OTTL Contexts Reference
+
+Context paths and enums for collector-contrib **v0.149.0**. Higher-level contexts are reachable from lower ones (a span statement can read `resource.attributes`); the reverse is not true. Always pick the most specific context for the work — using `datapoint` to set metric-point attributes is much cheaper than walking through `metric.data_points` from the metric context.
+
+## Context hierarchy
+
+```
+Resource
+  └── Scope (instrumentation library)
+      ├── Span → Span Event
+      ├── Metric → DataPoint
+      ├── Log
+      └── Profile → Profile Sample
+```
+
+## Resource context
+
+```ottl
+resource.attributes                    # map
+resource.attributes["service.name"]
+resource.dropped_attributes_count
+resource.cache                         # transformation-scope scratchpad
+resource.cache["key"]
+resource.metadata["key"]               # client request metadata (v0.147+)
+```
+
+```ottl
+set(resource.attributes["environment"], "production")
+    where resource.attributes["environment"] == nil
+
+set(resource.attributes["service.name"],
+    ToLowerCase(resource.attributes["service.name"]))
+```
+
+## Scope (instrumentation scope) context
+
+```ottl
+scope.name
+scope.version
+scope.attributes
+scope.attributes["key"]
+scope.dropped_attributes_count
+scope.cache
+scope.cache["key"]
+```
+
+```ottl
+where not IsMatch(scope.name, "opentelemetry-.*")
+
+set(scope.attributes["quality"], "manual")
+    where scope.name == "manual-instrumentation"
+```
+
+> Older configs may use `instrumentation_scope.*`. The current canonical prefix is `scope.*`.
+
+## Span context (Beta)
+
+### Identity & relationships
+```ottl
+span.trace_id                    # bytes
+span.trace_id.string             # hex string
+span.span_id                     # bytes
+span.span_id.string              # hex string
+span.parent_span_id              # bytes
+span.parent_span_id.string       # hex string
+span.flags                       # W3C trace flags, uint32 (v0.145+)
+span.trace_state                 # W3C trace state
+span.trace_state["key"]
+```
+
+### Metadata
+```ottl
+span.name
+span.kind                        # int64
+span.kind.string                 # "Server" | "Client" | "Internal" | …
+span.status                      # status object
+span.status.code                 # int64 (use STATUS_CODE_* enums)
+span.status.message              # string
+```
+
+### Timing
+```ottl
+span.start_time_unix_nano        # int64
+span.end_time_unix_nano          # int64
+span.start_time                  # time.Time
+span.end_time                    # time.Time
+```
+
+### Data
+```ottl
+span.attributes
+span.attributes["http.method"]
+span.events                      # collection
+span.links                       # collection
+span.dropped_attributes_count
+span.dropped_events_count
+span.dropped_links_count
+span.metadata["key"]             # client request metadata (v0.147+)
+span.cache["key"]                # transformation cache
+```
+
+### Examples
+```ottl
+# Duration in ms
+set(span.attributes["duration_ms"],
+    (span.end_time_unix_nano - span.start_time_unix_nano) / 1000000)
+
+# Mark errored HTTP spans
+set(span.status.code, STATUS_CODE_ERROR)
+    where IsInt(span.attributes["http.status_code"])
+      and Int(span.attributes["http.status_code"]) >= 400
+
+# Identify root spans (preferred form, since v0.142 SpanID accepts hex strings too)
+set(span.attributes["is_root"], true)
+    where IsRootSpan()
+
+# Latency-and-kind sampling decision
+set(span.attributes["sampled"], true)
+    where span.kind == SPAN_KIND_SERVER
+      and (span.status.code == STATUS_CODE_ERROR
+           or (span.end_time_unix_nano - span.start_time_unix_nano) > 1000000000)
+```
+
+## Span Event context (Beta)
+
+```ottl
+spanevent.name
+spanevent.time_unix_nano
+spanevent.time                       # time.Time
+spanevent.attributes
+spanevent.attributes["key"]
+spanevent.dropped_attributes_count
+spanevent.event_index                # 0-based position within span (v0.120+)
+spanevent.cache["key"]
+# Span fields are reachable: span.name, span.attributes, …
+```
+
+```ottl
+where spanevent.name == "exception"
+
+set(spanevent.attributes["span.name"], span.name)
+
+set(spanevent.attributes["error.message"], "REDACTED")
+    where IsMatch(spanevent.attributes["error.message"], ".*password.*")
+```
+
+> Older configs may use `span_event.*`. The current path prefix is `spanevent.*`.
+
+## Metric context (Beta)
+
+```ottl
+metric.name
+metric.description
+metric.unit
+metric.type                          # int64 (use METRIC_DATA_TYPE_* enums)
+metric.aggregation_temporality       # int64
+metric.is_monotonic                  # bool
+metric.data_points                   # collection
+metric.metadata
+```
+
+```ottl
+# Normalize metric names to safe characters
+set(metric.name,
+    replace_all_patterns(metric.name, "value", "[^a-zA-Z0-9_]", "_"))
+
+# Normalize legacy units
+set(metric.unit, "s") where metric.unit == "seconds"
+set(metric.unit, "B") where metric.unit == "bytes"
+
+# Filter by type
+where metric.type == METRIC_DATA_TYPE_GAUGE
+```
+
+## DataPoint context
+
+```ottl
+datapoint.start_time_unix_nano
+datapoint.time_unix_nano
+datapoint.start_time                 # time.Time
+datapoint.time                       # time.Time
+datapoint.value_double
+datapoint.value_int
+datapoint.attributes
+datapoint.attributes["key"]
+datapoint.flags
+datapoint.exemplars                  # collection
+# Metric, scope, resource paths are reachable.
+```
+
+```ottl
+set(datapoint.attributes["value_range"], "high")
+    where datapoint.value_double > 1000
+
+# Rename an attribute
+set(datapoint.attributes["host.name"], datapoint.attributes["hostname"])
+delete_key(datapoint.attributes, "hostname")
+```
+
+## Log context (Beta)
+
+```ottl
+log.time_unix_nano
+log.observed_time_unix_nano
+log.time                             # time.Time
+log.observed_time                    # time.Time
+log.severity_number                  # int64 (use SEVERITY_NUMBER_* enums)
+log.severity_text
+log.body                             # any type
+log.body.string                      # body coerced to string
+log.body["key"]                      # if body is a map
+log.body[0]                          # if body is a list
+log.attributes
+log.attributes["key"]
+log.dropped_attributes_count
+log.metadata["key"]                  # client request metadata (v0.147+)
+log.flags
+log.trace_id / log.trace_id.string
+log.span_id  / log.span_id.string
+log.event_name                       # for event-shaped logs
+```
+
+```ottl
+# Parse JSON body into structured attributes
+set(log.attributes, ParseJSON(log.body.string))
+    where IsString(log.body) and IsMatch(log.body.string, "^\\s*\\{.*\\}\\s*$")
+
+# Normalize severity text
+set(log.severity_text, "ERROR")
+    where log.severity_number >= SEVERITY_NUMBER_ERROR
+
+# Trace correlation flag
+set(log.attributes["has_trace"], true)
+    where log.trace_id.string != "00000000000000000000000000000000"
+
+# Body-level redaction
+set(log.body, "REDACTED")
+    where IsMatch(log.body.string, ".*(password|secret|token).*")
+```
+
+## Profile context (Development, v0.124+)
+
+```ottl
+profile.profile_id
+profile.profile_id.string
+profile.attributes
+profile.attributes["key"]
+profile.dropped_attributes_count
+profile.time_unix_nano
+profile.time                          # time.Time
+profile.duration_unix_nano
+profile.duration
+profile.sample_type
+profile.sample_type.type
+profile.sample_type.unit
+profile.sample
+profile.period_type
+profile.period_type.type
+profile.period_type.unit
+profile.period
+profile.attribute_indices
+profile.original_payload_format
+profile.original_payload              # []byte
+cache["key"]
+```
+
+## Profile Sample context (Development, v0.132+)
+
+```ottl
+profilesample.values                  # []int64
+profilesample.attributes
+profilesample.attributes["key"]
+profilesample.link_index
+profilesample.timestamps_unix_nano    # []int64
+profilesample.timestamps              # []time.Time
+profilesample.attribute_indices
+cache["key"]
+```
+
+## Client request metadata (v0.147+)
+
+All contexts expose a `metadata` map for reading metadata attached to the inbound request (gRPC metadata, HTTP headers). It is *not* part of the telemetry payload — values come from the receiver. Keys are case-sensitive and the available set depends on the receiver and transport.
+
+```ottl
+span.metadata["X-Tenant-ID"]
+log.metadata["X-Scope-OrgID"]
+resource.metadata["Authorization"]
+datapoint.metadata["X-Custom-Header"]
+```
+
+Common uses: tenant routing, request-level enrichment, conditional drop based on caller identity.
+
+## Enums
+
+### Span kind
+```ottl
+SPAN_KIND_UNSPECIFIED  # 0
+SPAN_KIND_INTERNAL     # 1
+SPAN_KIND_SERVER       # 2
+SPAN_KIND_CLIENT       # 3
+SPAN_KIND_PRODUCER     # 4
+SPAN_KIND_CONSUMER     # 5
+```
+
+### Span status
+```ottl
+STATUS_CODE_UNSET  # 0
+STATUS_CODE_OK     # 1
+STATUS_CODE_ERROR  # 2
+```
+
+### Log severity
+```ottl
+SEVERITY_NUMBER_UNSPECIFIED  # 0
+SEVERITY_NUMBER_TRACE        # 1-4
+SEVERITY_NUMBER_DEBUG        # 5-8
+SEVERITY_NUMBER_INFO         # 9-12
+SEVERITY_NUMBER_WARN         # 13-16
+SEVERITY_NUMBER_ERROR        # 17-20
+SEVERITY_NUMBER_FATAL        # 21-24
+```
+
+### Metric aggregation temporality
+```ottl
+AGGREGATION_TEMPORALITY_UNSPECIFIED  # 0
+AGGREGATION_TEMPORALITY_DELTA        # 1
+AGGREGATION_TEMPORALITY_CUMULATIVE   # 2
+```
+
+### Metric data type
+```ottl
+METRIC_DATA_TYPE_NONE                  # 0
+METRIC_DATA_TYPE_GAUGE                 # 1
+METRIC_DATA_TYPE_SUM                   # 2
+METRIC_DATA_TYPE_HISTOGRAM             # 3
+METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM # 4
+METRIC_DATA_TYPE_SUMMARY               # 5
+```

--- a/skills/general/ottl/references/functions.md
+++ b/skills/general/ottl/references/functions.md
@@ -1,0 +1,367 @@
+# OTTL Functions Catalog
+
+Editor and converter reference for collector-contrib **v0.149.0**. Editors mutate telemetry; converters return values for use in expressions. See the upstream `pkg/ottl/ottlfuncs/README.md` for the authoritative source.
+
+## Editors (data manipulation)
+
+Editors are lowercase. Every OTTL statement contains exactly one.
+
+### `set`
+```ottl
+set(target, value)
+set(span.attributes["env"], "production")
+set(log.body, Concat([log.severity_text, ": ", log.body.string], ""))
+```
+
+### `append`
+```ottl
+append(target, value)
+append(target, values = ["tag1", "tag2"])
+append(span.attributes["tags"], "processed")
+```
+
+If `target` is a scalar, it is converted to a slice first.
+
+### `delete_key` / `delete_matching_keys` / `delete_index`
+```ottl
+delete_key(span.attributes, "internal.debug")
+delete_matching_keys(span.attributes, "(?i).*password.*")
+delete_index(log.attributes["tags"], 0)        # v0.145+, slice index
+```
+
+### `keep_keys` / `keep_matching_keys`
+```ottl
+keep_keys(span.attributes, ["http.method", "http.status_code", "http.route"])
+keep_matching_keys(span.attributes, "(?i)^http\\..*")
+```
+
+### `flatten`
+```ottl
+flatten(target)
+flatten(target, prefix, depth, resolveConflicts?)   # v0.139+
+flatten(log.body)
+flatten(span.attributes, "nested", 2)
+flatten(log.attributes, resolveConflicts = true)
+```
+
+### `limit`
+```ottl
+limit(target, count, priority_keys[])
+limit(span.attributes, 10, ["http.method", "http.status_code"])
+```
+
+### `merge_maps`
+```ottl
+merge_maps(target, source, "insert" | "update" | "upsert")
+merge_maps(span.attributes, ParseJSON(span.attributes["meta"]), "upsert")
+```
+
+- `insert` — only set keys not already in target
+- `update` — only overwrite keys already in target
+- `upsert` — both
+
+### `truncate_all`
+```ottl
+truncate_all(target, max_length)
+truncate_all(target, max_length, utf8_safe = false)   # v0.148+
+truncate_all(span.attributes, 256)
+```
+
+UTF-8 safe by default since v0.148 — truncates at character boundaries, so the result may be slightly shorter than `max_length`. Pass `utf8_safe = false` for the previous byte-level behavior.
+
+### `replace_match` / `replace_all_matches`
+```ottl
+replace_match(target, pattern, replacement, function?, format?)
+replace_all_matches(target, pattern, replacement, function?, format?)
+replace_match(span.name, "GET ", "")
+replace_all_matches(log.body, "/user/*/id/*", "/user/{userId}/id/{id}")
+```
+
+Glob patterns (not regex). Use `replace_pattern`/`replace_all_patterns` for regex.
+
+### `replace_pattern` / `replace_all_patterns`
+```ottl
+replace_pattern(target, regex, replacement, function?, format?)
+replace_all_patterns(target, "key" | "value", regex, replacement, function?, format?)
+
+# Strip query string
+replace_pattern(attributes["http.url"], "\\?.*$", "")
+
+# Redact a token query parameter — note the $${1} backreference escape
+replace_pattern(attributes["http.url"], "([?&]token=)[^&]+", "$${1}REDACTED")
+
+# Map-wide patterns over keys or values
+replace_all_patterns(span.attributes, "value", "\\d{16}", "[REDACTED]")
+replace_all_patterns(span.attributes, "key",   "^kube_", "k8s.")
+```
+
+**Backreferences in YAML.** OTTL uses `${1}`, `${2}`, … The collector's YAML loader treats `$` as an env-var marker, so a single `$` in YAML produces nothing in the OTTL string. Write `$${1}` in YAML to emit `${1}` in OTTL. Writing `"$1REDACTED"` produces a literal `$1REDACTED` — silent failure.
+
+**RE2 repeat-count limit.** Patterns like `^(.{1024}).*` fail to compile with "invalid repeat count". For length-based truncation, use `Substring` + `Len` instead:
+
+```ottl
+set(attributes["db.statement"], Substring(attributes["db.statement"], 0, 1024))
+    where attributes["db.statement"] != nil
+      and Len(attributes["db.statement"]) > 1024
+```
+
+---
+
+## String converters
+
+### `Concat`, `Split`, `Substring`
+```ottl
+Concat(["user", user_id, "action"], "-")     # "user-123-action"
+Split(path, "/")                              # ["", "api", "v1", "users"]
+Split(path, "/")[1]                           # "api"
+Substring(span.span_id.string, 0, 8)          # first 8 chars
+```
+
+### Case
+```ottl
+ToLowerCase(s) / ToUpperCase(s)
+ToCamelCase(s) / ToSnakeCase(s)
+ConvertCase(s, "lower" | "upper" | "camel" | "snake")
+```
+
+### Trim
+```ottl
+Trim(s, cutset?)
+TrimPrefix(s, prefix)        # v0.124+
+TrimSuffix(s, suffix)        # v0.124+
+```
+
+### Prefix/suffix tests
+```ottl
+HasPrefix(s, prefix)         # bool
+HasSuffix(s, suffix)         # bool
+where HasPrefix(span.name, "internal.")
+```
+
+### `Replace` (literal, non-regex)
+```ottl
+Replace(target, old, new, count?)
+Replace(log.body.string, "ERROR", "ERR", 1)
+```
+
+### `Format`
+```ottl
+Format("user=%s req=%d", [user, count])      # printf-style
+```
+
+---
+
+## Type conversion
+
+```ottl
+String(v)                # any -> string
+Int(v)                   # any -> int64
+Double(v)                # any -> float64
+Bool(v)                  # v0.143+; loose coercion (see below)
+ParseInt(s, base)        # ParseInt("ff", 16) -> 255
+Hex(bytes)               # bytes -> hex string
+```
+
+**`Bool` coercion is loose, not Pythonic.** `Bool("true")`, `Bool("1")`, `Bool(1)` → `true`; `Bool("false")`, `Bool("0")`, `Bool(0)`, `Bool(0.0)` → `false`. Other values error. Don't assume `Bool("yes")` or `Bool("anything-non-empty")` returns true.
+
+---
+
+## Type checking
+
+```ottl
+IsString(v) / IsInt(v) / IsDouble(v) / IsBool(v)
+IsList(v) / IsMap(v)
+IsInCIDR(ip_string, ["10.0.0.0/8", "192.168.0.0/16"])   # v0.146+
+```
+
+`IsInCIDR` returns `false` for invalid IP strings — useful in conditions: `where IsInCIDR(attributes["client.ip"], ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"])`.
+
+---
+
+## Pattern matching
+
+### `IsMatch`
+```ottl
+IsMatch(target, pattern)     # bool
+where IsMatch(span.name, "^GET /api/.*")
+where not IsMatch(span.name, ".*health.*")
+```
+
+### `ExtractPatterns`
+```ottl
+ExtractPatterns(target, "(?P<user>\\w+)/(?P<action>\\w+)")
+# Returns map keyed by the named groups.
+```
+
+Named capture groups required — unnamed groups are not surfaced as map keys.
+
+### `ExtractGrokPatterns` (v0.130+)
+```ottl
+ExtractGrokPatterns(log.body, "%{IP:client_ip} %{WORD:method} %{URIPATHPARAM:path}")
+ExtractGrokPatterns(log.body, "%{URI}", true)                         # named only
+ExtractGrokPatterns(log.body, "%{MYPATTERN}", true,
+                   ["MYPATTERN=%{IP}:%{INT}"])                         # custom defs
+```
+
+Built-in pattern library covers HTTP, syslog, paths, IPs, dates, etc. Cheaper than expressing the same thing as a raw regex.
+
+---
+
+## Data parsing
+
+```ottl
+ParseJSON(s)                                  # JSON string -> map | list
+ParseCSV(s, headers, delimiter?, headerDelim?, mode?)
+ParseKeyValue(s, pair_delim?, kv_delim?)      # ParseKeyValue("a=1&b=2", "&", "=")
+ParseXML(s) / ParseSimplifiedXML(s)
+ParseSeverity(value, mapping)                 # map values -> SEVERITY_NUMBER_*
+URL(s)                                        # v0.127+; { scheme, domain, port, path, query, fragment, … }
+UserAgent(s)                                  # v0.134+; { user_agent.name, .version, os.name, os.version, … }
+```
+
+```ottl
+# Conditional JSON parsing
+set(log.attributes, ParseJSON(log.body.string))
+    where IsString(log.body) and IsMatch(log.body.string, "^\\s*\\{.*\\}\\s*$")
+
+# URL parsing
+set(span.attributes["http.host"], URL(span.attributes["http.url"])["domain"])
+```
+
+---
+
+## XML
+
+```ottl
+GetXML(target, xpath)                         # select elements
+InsertXML(target, xpath, value)
+RemoveXML(target, xpath)
+ConvertAttributesToElementsXML(target, xpath?)
+ConvertTextToElementsXML(target, xpath?, elementName?)
+```
+
+---
+
+## Collections
+
+```ottl
+Len(target)                                   # works for string, list, map
+Keys(map) / Values(map)                       # -> list
+ContainsValue(list, value)                    # bool
+Index(target, value)                          # v0.126+; -1 if not found
+Sort(list, "asc" | "desc")                    # v0.125+
+SliceToMap(list, [keyPath]?, [valuePath]?)    # v0.128+; turn objects into a map
+```
+
+```ottl
+SliceToMap(resource.attributes["items"], ["name"])                     # key by .name
+SliceToMap(resource.attributes["items"], ["name"], ["value"])          # explicit value
+```
+
+---
+
+## Date/time
+
+```ottl
+Now()                                         # current time
+Time(s, format, location?, locale?)           # locale added v0.136
+FormatTime(t, format)
+Duration(s)                                   # "1h30m" -> time.Duration
+TruncateTime(t, duration)
+Unix(seconds, nanoseconds?)
+UnixSeconds(t) / UnixMilli(t) / UnixMicro(t) / UnixNano(t)
+Year(t) / Month(t) / Day(t) / Hour(t) / Minute(t) / Second(t) / Nanosecond(t) / Weekday(t)
+Hours(d) / Minutes(d) / Seconds(d) / Milliseconds(d) / Microseconds(d) / Nanoseconds(d)
+```
+
+---
+
+## Hashing & encoding
+
+```ottl
+SHA256(v) / SHA512(v)
+SHA1(v) / MD5(v)                              # cryptographically weak; avoid for security
+FNV(v)                                        # int64
+Murmur3Hash(v) / Murmur3Hash128(v)            # v0.129+
+XXH3(v) / XXH128(v)                           # v0.135+; very fast
+Decode(value, encoding)                       # v0.141+; "base64", "base64-raw", "base64-url", "base64-raw-url", IANA charsets
+Base64Encode(v)                               # v0.147+
+Base64Decode(v)                               # DEPRECATED — use Decode(v, "base64")
+Hex(bytes)
+```
+
+---
+
+## OpenTelemetry-specific
+
+```ottl
+SpanID(bytes | hex_string)                    # hex strings accepted v0.142+
+TraceID(bytes | hex_string)                   # same
+ProfileID(bytes | hex_string)                 # v0.124+
+IsRootSpan()                                  # span context only
+IsValidLuhn(s)                                # credit card checksum
+CommunityID(srcIP, srcPort, dstIP, dstPort, protocol?, seed?)   # v0.131+; network flow hash
+IsInCIDR(ip, [networks])                      # v0.146+
+ToKeyValueString(map, delim?, pair_delim?, sort?)
+```
+
+---
+
+## Identifier generation
+
+```ottl
+UUID()
+UUIDv7()                                      # v0.138+; time-ordered
+```
+
+`UUIDv7` is preferable to `UUID()` when the resulting value is used as a primary key or sort key, because v7 is monotonic-ish and storage-friendly.
+
+---
+
+## Math
+
+```ottl
+Log(value)                                    # natural logarithm
+```
+
+OTTL's basic arithmetic operators (`+`, `-`, `*`, `/`) cover most needs; `Log` is the rare named math converter.
+
+---
+
+## Utility
+
+```ottl
+UUID() / UUIDv7()
+```
+
+---
+
+## Function patterns
+
+### Safe type conversion
+```ottl
+set(span.attributes["count_int"], Int(span.attributes["count"]))
+    where IsString(span.attributes["count"])
+      and IsMatch(span.attributes["count"], "^\\d+$")
+```
+
+### Chained string operations
+```ottl
+set(span.attributes["normalized"],
+    ToLowerCase(Trim(span.attributes["value"], " ")))
+```
+
+### Conditional parsing into cache
+```ottl
+set(log.cache["parsed"], ParseJSON(log.body.string))
+    where IsString(log.body) and IsMatch(log.body.string, "^\\s*\\{.*\\}\\s*$")
+```
+
+Then read from `log.cache["parsed"]` in subsequent statements without paying the parse cost again.
+
+### Hash-based sampling
+```ottl
+set(span.attributes["sampled"], true)
+    where FNV(span.trace_id.string) % 100 < 10        # 10%
+# Murmur3Hash or XXH3 work too and are faster on long inputs.
+```

--- a/skills/general/ottl/references/functions.md
+++ b/skills/general/ottl/references/functions.md
@@ -74,7 +74,7 @@ UTF-8 safe by default since v0.148 — truncates at character boundaries, so the
 replace_match(target, pattern, replacement, function?, format?)
 replace_all_matches(target, pattern, replacement, function?, format?)
 replace_match(span.name, "GET ", "")
-replace_all_matches(log.body, "/user/*/id/*", "/user/{userId}/id/{id}")
+replace_all_matches(span.attributes, "/user/*/id/*", "/user/{userId}/id/{id}")
 ```
 
 Glob patterns (not regex). Use `replace_pattern`/`replace_all_patterns` for regex.
@@ -87,7 +87,7 @@ replace_all_patterns(target, "key" | "value", regex, replacement, function?, for
 # Strip query string
 replace_pattern(attributes["http.url"], "\\?.*$", "")
 
-# Redact a token query parameter — note the $${1} backreference escape
+# Redact a token query parameter (YAML form; in a raw OTTL string use ${1})
 replace_pattern(attributes["http.url"], "([?&]token=)[^&]+", "$${1}REDACTED")
 
 # Map-wide patterns over keys or values
@@ -301,7 +301,6 @@ ProfileID(bytes | hex_string)                 # v0.124+
 IsRootSpan()                                  # span context only
 IsValidLuhn(s)                                # credit card checksum
 CommunityID(srcIP, srcPort, dstIP, dstPort, protocol?, seed?)   # v0.131+; network flow hash
-IsInCIDR(ip, [networks])                      # v0.146+
 ToKeyValueString(map, delim?, pair_delim?, sort?)
 ```
 

--- a/skills/general/ottl/references/quick-reference.md
+++ b/skills/general/ottl/references/quick-reference.md
@@ -1,0 +1,368 @@
+# OTTL Quick Reference
+
+Recipes, regex patterns, and a troubleshooting table. Pair with `contexts.md` for paths and `functions.md` for full signatures.
+
+## Common patterns
+
+### Attribute management
+
+```ottl
+# Set attribute
+set(span.attributes["environment"], "production")
+
+# Set if missing
+set(span.attributes["version"], "unknown")
+    where span.attributes["version"] == nil
+
+# Copy from resource
+set(span.attributes["service"], resource.attributes["service.name"])
+
+# Rename
+set(span.attributes["host.name"], span.attributes["hostname"])
+delete_key(span.attributes, "hostname")
+
+# Drop sensitive keys
+delete_matching_keys(span.attributes, "(?i).*(password|secret|token|apikey).*")
+
+# Whitelist (fail-closed)
+keep_keys(span.attributes, ["http.method", "http.status_code", "http.route"])
+```
+
+### String manipulation
+
+```ottl
+set(span.attributes["method"], ToUpperCase(String(span.attributes["http.method"])))
+set(span.attributes["short_id"], Substring(span.span_id.string, 0, 8))
+set(span.attributes["service"], Split(resource.attributes["service.name"], "-")[0])
+set(log.body, Concat([log.severity_text, ": ", log.body.string], ""))
+set(log.body, Trim(log.body.string, " \t\n"))
+```
+
+### Data parsing
+
+```ottl
+# JSON body -> attributes
+set(log.attributes, ParseJSON(log.body.string))
+    where IsString(log.body) and IsMatch(log.body.string, "^\\s*\\{.*\\}\\s*$")
+
+# Query string -> map
+set(span.attributes["params"],
+    ParseKeyValue(span.attributes["http.query"], "&", "="))
+
+# URL parts (v0.127+)
+set(span.attributes["http.host"], URL(span.attributes["http.url"])["domain"])
+
+# User agent (v0.134+)
+set(span.attributes["client.os"],
+    UserAgent(span.attributes["http.user_agent"])["os.name"])
+
+# Grok (v0.130+) — much cleaner than the equivalent regex
+set(log.attributes,
+    ExtractGrokPatterns(log.body.string,
+                        "%{IP:client_ip} %{WORD:method} %{URIPATHPARAM:path}"))
+```
+
+### Error / status detection
+
+```ottl
+# HTTP errors
+set(span.status.code, STATUS_CODE_ERROR)
+    where IsInt(span.attributes["http.status_code"])
+      and Int(span.attributes["http.status_code"]) >= 400
+
+# Exception spans
+set(span.status.code, STATUS_CODE_ERROR)
+set(span.status.message, span.attributes["exception.message"])
+    where span.attributes["exception.type"] != nil
+
+# Slow spans
+set(span.attributes["slow"], true)
+    where (span.end_time_unix_nano - span.start_time_unix_nano) > 1000000000
+```
+
+### Filter conditions
+
+```ottl
+# Skip health checks
+where not IsMatch(span.name, ".*(health|ready|alive).*")
+
+# Errors only
+where log.severity_number >= SEVERITY_NUMBER_ERROR
+
+# Server spans only
+where span.kind == SPAN_KIND_SERVER
+
+# Drop traffic from internal CIDRs
+where IsInCIDR(span.attributes["client.address"],
+               ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"])
+```
+
+### Sampling
+
+```ottl
+# Hash-based 10% — XXH3 is faster than FNV on long inputs
+set(span.attributes["sampled"], true)
+    where XXH3(span.trace_id.string) % 100 < 10
+
+# Always-sample errors
+set(span.attributes["sampled"], true)
+    where span.status.code == STATUS_CODE_ERROR
+
+# Latency-based
+set(span.attributes["sampled"], true)
+    where (span.end_time_unix_nano - span.start_time_unix_nano) > 1000000000
+```
+
+### Time operations
+
+```ottl
+# Duration in ms
+set(span.attributes["duration_ms"],
+    (span.end_time_unix_nano - span.start_time_unix_nano) / 1000000)
+
+# Format timestamp
+set(log.attributes["formatted_time"], FormatTime(log.time, "%Y-%m-%d %H:%M:%S"))
+
+# Stamp processing time
+set(span.attributes["processed_at"], Now())
+
+# Hour bucket
+set(log.attributes["hour"], Hour(log.time))
+```
+
+### Redaction
+
+```ottl
+# Credit cards
+replace_all_patterns(log.attributes, "value",
+                     "\\b(?:\\d{4}[\\s-]?){3}\\d{4}\\b",
+                     "****-****-****-****")
+
+# Emails
+replace_all_patterns(log.attributes, "value",
+                     "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+                     "[REDACTED_EMAIL]")
+
+# IPv4
+replace_all_patterns(log.attributes, "value",
+                     "\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b",
+                     "[REDACTED_IP]")
+
+# Hash, don't drop — preserves cardinality for analytics
+set(span.attributes["user.email_hash"], SHA256(span.attributes["user.email"]))
+delete_key(span.attributes, "user.email")
+```
+
+## Processor configuration
+
+### `transform`
+
+```yaml
+processors:
+  transform:
+    error_mode: ignore        # ignore | silent | propagate
+    trace_statements:
+      - context: span
+        statements:
+          - set(span.attributes["processed"], true)
+    log_statements:
+      - context: log
+        statements:
+          - set(log.attributes["source"], "collector")
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(datapoint.attributes["env"], "prod")
+```
+
+### `filter`
+
+```yaml
+processors:
+  filter:
+    error_mode: ignore
+    traces:
+      span:
+        - 'IsMatch(span.name, "^/health.*")'
+        - 'span.kind == SPAN_KIND_INTERNAL'
+    logs:
+      log_record:
+        - 'log.severity_number < SEVERITY_NUMBER_WARN'
+```
+
+### `routing`
+
+```yaml
+processors:
+  routing:
+    default_pipelines: [traces/default]
+    table:
+      - statement: 'route() where resource.attributes["env"] == "prod"'
+        pipelines: [traces/prod]
+      - statement: 'route() where span.status.code == STATUS_CODE_ERROR'
+        pipelines: [traces/errors]
+```
+
+### `tail_sampling`
+
+```yaml
+processors:
+  tail_sampling:
+    policies:
+      - name: errors
+        type: ottl_condition
+        ottl_condition:
+          span:
+            - 'span.status.code == STATUS_CODE_ERROR'
+      - name: slow
+        type: ottl_condition
+        ottl_condition:
+          span:
+            - '(span.end_time_unix_nano - span.start_time_unix_nano) > 1000000000'
+```
+
+## Regular expressions
+
+### Common patterns
+
+```ottl
+"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"                          # email
+"\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b"                          # IPv4
+"\\b(?:\\d{4}[\\s-]?){3}\\d{4}\\b"                                          # credit card
+"\\b\\d{3}-\\d{3}-\\d{4}\\b"                                                # US phone
+"https?://[^\\s]+"                                                          # URL
+"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"  # UUID
+"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z?"                 # ISO 8601
+"^\\{.*\\}$"                                                                # JSON object
+"^\\d+$"                                                                    # digits only
+```
+
+### Escape rules
+
+In OTTL strings, escape regex metacharacters with double backslash. Single-backslash YAML chars get eaten before OTTL sees them.
+
+| You want in regex | Write in OTTL string |
+|-------------------|---------------------|
+| `\d` | `\\d` |
+| `\s` | `\\s` |
+| `\w` | `\\w` |
+| `\.` | `\\.` |
+| `\*` | `\\*` |
+| `\+` | `\\+` |
+
+**Backreference escape (YAML).** OTTL `${1}` must be written as `$${1}` in YAML — the loader treats `$` as an env-var marker. `"$1REDACTED"` becomes a literal string at the OTTL level, no replacement.
+
+**RE2 repeat-count limit.** `(.{1024}).*` fails to compile. Use `Substring` + `Len` for length truncation:
+
+```ottl
+set(attributes["x"], Substring(attributes["x"], 0, 1024))
+    where attributes["x"] != nil and Len(attributes["x"]) > 1024
+```
+
+## Debugging
+
+### Enable debug logging
+
+```yaml
+service:
+  telemetry:
+    logs:
+      level: debug
+```
+
+### Add probes
+
+```ottl
+# Track that a statement ran
+set(span.attributes["ottl.processed"], true)
+set(span.attributes["ottl.timestamp"], Now())
+
+# 0.1% sampled debug snapshot
+set(span.attributes["debug.original_name"], span.name)
+    where XXH3(span.trace_id.string) % 1000 == 0
+```
+
+### Validate before transforming
+
+```ottl
+where IsString(span.attributes["count"])
+  and IsMatch(span.attributes["count"], "^\\d+$")
+
+where span.attributes["value"] != nil
+
+where Len(String(log.body)) > 0
+```
+
+## Performance
+
+**Do**
+
+- Order conditions by selectivity (cheap and most-discriminating first).
+- Use early filtering to drop work at the smallest scope.
+- Cache expensive function results in `<context>.cache`.
+- Pick the most specific context (operate on `datapoint`, not on `metric.data_points`).
+- Batch attribute pruning with `keep_keys` rather than many `delete_key` statements.
+
+**Don't**
+
+- Repeat expensive function calls inside the same statement set.
+- Run complex regex on large bodies.
+- Process telemetry that a cheaper filter could drop earlier in the pipeline.
+- Suppress error_mode noise (`silent`) without first verifying behavior.
+
+### Cache pattern
+
+```ottl
+set(span.cache["url_parts"], Split(span.attributes["http.url"], "/"))
+set(span.attributes["api_version"], span.cache["url_parts"][2])
+```
+
+### Early-filter ordering
+
+```ottl
+# Cheap kind check fails first; regex only runs for SERVER spans.
+where span.kind == SPAN_KIND_SERVER and IsMatch(span.name, "expensive.*")
+```
+
+## Troubleshooting
+
+### Common errors
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `nil value` | Path resolves to a missing field | Add `where path != nil` (or `IsString(path)` etc.) |
+| `type mismatch` | Wrong types in arithmetic / function args | Convert with `Int`, `Double`, `String` after type-checking |
+| `invalid regex` | Unescaped metacharacter | Double-escape: `\\d`, `\\.`, `\\s` |
+| `division by zero` | `/` with a zero divisor | Add `where divisor != 0` |
+| Backreferences appear literal | YAML ate the `$` | Use `$${1}` in YAML for OTTL `${1}` |
+| `attributes` processor doesn't touch resource | Wrong processor | Use `resource` processor or `transform` with `context: resource` |
+| `cache["x"]` errors in span context | Cache requires a context prefix since v0.120 | Write `span.cache["x"]` |
+| `Bool("yes")` errors | `Bool` only accepts true/false/1/0 inputs | Use `IsMatch` with an explicit pattern, or check with `where` |
+| `Base64Decode` deprecation warning | v0.141+ moved to generic decoder | Use `Decode(value, "base64")` |
+
+### Checklist before shipping
+
+1. Syntax: parens balanced, strings closed, regex escapes doubled.
+2. Types: type-check before conversion (`IsString`, `IsInt`).
+3. Existence: nil-guard paths that may be absent.
+4. Logic: dry-run with the [telemetrygen verification recipe](../../telemetrygen/SKILL.md#verifying-a-collector-config) — generate a known input, capture the file-exporter output, confirm the transformation. The eye test misses too many gotchas.
+5. Performance: most-selective `where` clause first.
+
+### Safe transformation skeletons
+
+```ottl
+# Safe JSON parse
+set(log.cache["parsed"], ParseJSON(log.body.string))
+    where IsString(log.body)
+      and IsMatch(log.body.string, "^\\s*[\\{\\[].*[\\}\\]]\\s*$")
+
+# Safe numeric conversion
+set(span.attributes["count_int"], Int(span.attributes["count"]))
+    where IsString(span.attributes["count"])
+      and IsMatch(span.attributes["count"], "^-?\\d+$")
+
+# Safe duration calc
+set(span.attributes["duration_ns"],
+    span.end_time_unix_nano - span.start_time_unix_nano)
+    where span.end_time_unix_nano > span.start_time_unix_nano
+```


### PR DESCRIPTION
## Summary

- Adds `otel-ottl` skill at `skills/general/ottl/` (SKILL.md + three references) covering OTTL for `transform`, `filter`, `routing`, and `tail_sampling` processors.
- Aligns with collector-contrib **v0.149.0**: new paths (`span.flags`, `<context>.metadata`), new editor (`delete_index`), new converters (`Decode`, `ExtractGrokPatterns`, `URL`, `UserAgent`, `IsInCIDR`, `Murmur3Hash*`, `XXH3`, `UUIDv7`, …), behavior changes (`truncate_all` UTF-8 safe by default, `SpanID`/`TraceID` accept hex strings), and the `Base64Decode` → `Decode` deprecation.
- Cross-links to the `telemetrygen` "Verifying a collector config" recipe so users can dry-run configs against a real `otelcol-contrib` + file exporter before shipping.

Refs: [E-1905](https://linear.app/ollygarden/issue/E-1905/port-ottl-skill-into-opentelemetry-agent-skills)

## Test plan

- [ ] Skim `SKILL.md` end-to-end for voice/structure parity with `telemetrygen` and `weaver`.
- [ ] Spot-check `references/contexts.md` enums and path names against `pkg/ottl/contexts/*/README.md`.
- [ ] Spot-check `references/functions.md` signatures (especially the v0.140+ converters) against `pkg/ottl/ottlfuncs/README.md`.
- [ ] Run one of the `quick-reference.md` redaction examples through the telemetrygen verification recipe to confirm the snippet works as written.
- [ ] Confirm README table entry placement (alphabetical between `otel-declarative-config` and `otel-sdk-versions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive OTTL (OpenTelemetry Collector Transformation Language) skill documentation with practical guides, function catalogs, context references, and quick-reference cheat sheets to help users write and configure telemetry transformation statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->