### PR TITLE
feat(collector): add otel-collector skill with log_dedup and interval

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,11 @@
   },
   "plugins": [
     {
+      "name": "otel-collector",
+      "source": "./skills/otel-collector",
+      "description": "OpenTelemetry Collector component configuration: config keys, defaults, validation rules, signal support, stability, and gotchas. Progressive disclosure via components/<type>.md; currently covers log_dedup and interval processors."
+    },
+    {
       "name": "otel-declarative-config",
       "source": "./skills/otel-declarative-config",
       "description": "OpenTelemetry declarative YAML configuration for SDK setup (otelconf, OTEL_CONFIG_FILE, file_format). Points at upstream schema, env-var substitution, and configuration precedence."

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ skills/
   otel-js/
     SKILL.md
     references/
+  otel-collector/
+    SKILL.md
+    components/        # one file per Collector component (log_dedup, interval, …)
   otel-declarative-config/
   otel-ottl/
   otel-sdk-versions/
@@ -74,6 +77,7 @@ Language-agnostic skills:
 
 | Skill | Path | Use When |
 | --- | --- | --- |
+| `otel-collector` | `skills/otel-collector/` | Configuring OpenTelemetry Collector components — config keys, defaults, validation, signal support, stability, and gotchas. Progressive disclosure via `components/<type>.md`; currently covers `log_dedup` and `interval` processors. |
 | `otel-declarative-config` | `skills/otel-declarative-config/` | Configuring OpenTelemetry SDK providers via a single YAML file (`otelconf`, `OTEL_CONFIG_FILE`, `file_format`). Points at the upstream schema, env-var substitution rules, and configuration precedence. |
 | `otel-ottl` | `skills/otel-ottl/` | Authoring or reviewing OTTL statements for `transform`, `filter`, `routing`, and `tail_sampling` processors; debugging OTTL syntax and semantics; transforming traces, metrics, logs, and profiles in the Collector. |
 | `otel-sdk-versions` | `skills/otel-sdk-versions/` | Choosing the latest compatible released OpenTelemetry SDK or package version for a language and finding setup docs or examples. |

--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: otel-collector
+description: OpenTelemetry Collector component configuration. Use when authoring, reviewing, or debugging Collector YAML for a specific receiver, processor, exporter, connector, or extension — config keys, defaults, validation rules, signal support, stability levels, and component-level gotchas. Triggers on questions about specific components such as `log_dedup` / `logdedup`, `interval` (metric aggregation), and other Collector components covered in `components/`.
+---
+
+# OpenTelemetry Collector
+
+This skill covers the configuration surface of individual OpenTelemetry Collector components. It targets [opentelemetry-collector](https://github.com/open-telemetry/opentelemetry-collector) and [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib).
+
+It does **not** cover OTTL expressions (see `otel-ottl`), declarative SDK configuration (`otel-declarative-config`), or end-to-end pipeline design choices. Reach for those skills when the question is about transformation language, SDK setup, or pipeline composition.
+
+## Workflow
+
+1. **Identify the component.** Find the `type` in the user's config or question (`log_dedup`, `interval`, `otlp`, …). Note that several components were renamed to snake_case in v0.150.0–v0.151.0 with deprecated aliases preserved — see [Recent renames](#recent-renames).
+2. **Load the component page.** If the component is in the [Component index](#component-index), read `components/<name>.md` for the full config reference, examples, gotchas, and anti-patterns. Do not load pages you don't need.
+3. **If the component is not indexed**, say so explicitly and fall back to the upstream README under `processor/<name>/`, `receiver/<name>/`, `exporter/<name>/`, `connector/<name>/`, or `extension/<name>/` in [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib). Don't invent config keys from memory — Collector components evolve quickly.
+4. **Apply Collector-wide conventions.** Named instances (`type/name`), stability levels, and pipeline placement rules in [Collector-wide conventions](#collector-wide-conventions) apply to every component.
+5. **Verify.** Use `telemetrygen` (see the `otel-telemetrygen` skill) plus a `debug` or `file` exporter to confirm the component behaves as the docs claim — Alpha-stability components are common in this space, and behavior changes between releases.
+
+## Component index
+
+Pages live in `components/`. Each page is self-contained: when to use / when not, full config reference, examples, troubleshooting, anti-patterns.
+
+| Type | File | Kind | Signals | Stability | Summary |
+|------|------|------|---------|-----------|---------|
+| `log_dedup` | `components/log_dedup.md` | processor | logs | Alpha | Deduplicates identical log records over a time window; emits one aggregated log with a count. Renamed from `logdedup` in v0.151.0; alias preserved. |
+| `interval` | `components/interval.md` | processor | metrics | Alpha | Buffers cumulative monotonic metrics (and optionally gauges/summaries) and emits the latest value once per interval. Delta and non-monotonic sums pass through unchanged. |
+
+## Collector-wide conventions
+
+### Named instances
+
+Every component type supports the `type/name` pattern so the same type can be configured more than once. The pipeline references the named form:
+
+```yaml
+processors:
+  log_dedup/health-checks:
+    interval: 30s
+    conditions:
+      - 'attributes["log.type"] == "health_check"'
+  log_dedup/access-logs:
+    interval: 10s
+
+service:
+  pipelines:
+    logs/health:
+      processors: [log_dedup/health-checks]
+    logs/access:
+      processors: [log_dedup/access-logs]
+```
+
+### Stability levels
+
+Components publish a stability level per signal. Treat these as load-bearing when recommending production use:
+
+| Level | Use in |
+|-------|--------|
+| Development | Tests and prototypes only — breaking changes expected. |
+| Alpha | Limited, non-critical workloads — config keys can still change. |
+| Beta | Production viable — breaking changes rare. |
+| Stable | Production — backward compatibility guaranteed. |
+
+The components currently indexed here (`log_dedup`, `interval`) are **Alpha**. Surface that to the user when they ask about production readiness.
+
+### Recent renames
+
+Many components were renamed to snake_case in v0.150.0–v0.151.0. The legacy names remain as deprecated aliases — old configs keep working but new configs should use the new names. Check the upstream component README for the exact rename version before flagging a config as broken.
+
+Examples: `logdedup` → `log_dedup`, `hostmetrics` → `host_metrics`, `spanmetrics` → `span_metrics`, `servicegraph` → `service_graph`, `k8sattributes` → `k8s_attributes`, plus several `_log` and `_check` receivers.
+
+### Pipeline placement
+
+Two rules of thumb that apply across components:
+
+- `memory_limiter` belongs first in any processor list, before anything that allocates buffers (`log_dedup`, `transform`, `tail_sampling`, …).
+- Batching is now done by the exporter's `sending_queue.batch`, not by a separate `batch` processor. Don't add `batch` to new pipelines.
+
+## Adding a new component to this skill
+
+When extending coverage:
+
+1. Create `components/<type>.md`. Use the existing pages as a template — frontmatter is **not** required on component pages, only on `SKILL.md`.
+2. Each component page should cover: when to use / when not, config reference table with defaults and validation rules, at least one working YAML example, troubleshooting for common symptoms, and anti-patterns.
+3. Add a row to the [Component index](#component-index) above.
+4. Update the description trigger phrases in this file's frontmatter if the new component introduces a clearly distinct user-facing keyword.

--- a/skills/otel-collector/components/interval.md
+++ b/skills/otel-collector/components/interval.md
@@ -1,0 +1,176 @@
+# `interval` processor
+
+Buffers cumulative metrics and emits the latest value once per interval. Reduces metric point volume from chatty sources while preserving the most recent reading per series.
+
+| | |
+|-|-|
+| Kind | processor |
+| Signals | metrics |
+| Stability | Alpha |
+| Distributions | contrib, k8s |
+| Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor` |
+| Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/intervalprocessor> |
+
+## What it does to each metric type
+
+| Metric type | Default behavior | Pass-through option |
+|-------------|------------------|---------------------|
+| Cumulative monotonic sum | Aggregated (only latest value per series emitted per interval) | — |
+| Cumulative monotonic histogram | Aggregated | — |
+| Cumulative monotonic exponential histogram | Aggregated | — |
+| Gauge | Aggregated (lossy — see below) | `pass_through.gauge: true` |
+| Summary | Aggregated (lossy — see below) | `pass_through.summary: true` |
+| Delta (any) | Passed through unchanged, immediately | — (always pass-through) |
+| Non-monotonic sum | Passed through unchanged, immediately | — (always pass-through) |
+
+### What "lossy" means here
+
+- Monotonic cumulative series: you lose **precision** (intermediate values), not totals — the final cumulative value still represents the full count.
+- Gauges and summaries: actual **data loss**. A value that rose and fell back inside the interval is reduced to whatever the last reading happened to be. If the up-and-down matters (latency spikes, queue depth bursts), set `pass_through.gauge: true` / `pass_through.summary: true` to keep them flowing as-is.
+
+## When to use
+
+Use it when:
+- A receiver scrapes or emits cumulative metrics far more often than your backend needs (e.g., Prometheus receiver at 1s for a backend that ingests at 60s).
+- You want to smooth bursty ingest into a fixed cadence downstream.
+- Backend cost scales with point count and you have many slow-changing series.
+
+Avoid it when:
+- The pipeline carries mostly delta metrics — they bypass the processor entirely and you've added a stateful component for nothing.
+- Gauge spikiness matters and you can't set `pass_through.gauge: true` for the relevant signals.
+- The collector restarts often — buffered state is in-memory only and is lost on restart (see [State and restart behavior](#state-and-restart-behavior)).
+
+## Configuration
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `interval` | duration | `60s` | Emission cadence. After each emission, internal state is cleared. |
+| `pass_through.gauge` | bool | `false` | If `true`, gauges are forwarded unchanged instead of buffered. |
+| `pass_through.summary` | bool | `false` | If `true`, summaries are forwarded unchanged instead of buffered. |
+
+Upstream documents no explicit validation rules. The Collector will reject an unparseable `interval` duration at startup.
+
+> **Doc typo, upstream:** the README's configuration block shows `summary: <boo>l`. It's a typo for `<bool>` — the parameter is a plain boolean.
+
+## State and restart behavior
+
+- Internal state is keyed by metric name + attribute set and is held entirely in memory.
+- After each emission the buffer is cleared. **If no new points arrive in the next interval, nothing is emitted for that series in that interval.**
+- The state is not persisted — a collector restart drops every buffered point. For monotonic cumulative metrics this is usually fine (the next scrape carries the running total); for buffered gauges/summaries the most recent value is simply lost until the next sample.
+
+## Behavior example
+
+Source metrics arriving into the processor:
+
+| Time | Metric | Temporality | Attributes | Value |
+|------|--------|-------------|------------|------:|
+| 0 | `test_metric` | Cumulative | `labelA: foo` | 4.0 |
+| 2 | `test_metric` | Cumulative | `labelA: bar` | 3.1 |
+| 4 | `other_metric` | Delta | `fruitType: orange` | 77.4 |
+| 6 | `test_metric` | Cumulative | `labelA: foo` | 8.2 |
+| 8 | `test_metric` | Cumulative | `labelA: foo` | 12.8 |
+| 10 | `test_metric` | Cumulative | `labelA: bar` | 6.4 |
+
+`other_metric` (delta) is forwarded immediately. At the next interval boundary, only the latest value per series is forwarded:
+
+| Time | Metric | Temporality | Attributes | Value |
+|------|--------|-------------|------------|------:|
+| 8 | `test_metric` | Cumulative | `labelA: foo` | 12.8 |
+| 10 | `test_metric` | Cumulative | `labelA: bar` | 6.4 |
+
+Then state is cleared.
+
+## Examples
+
+### Default — aggregate cumulative, drop gauge spikes
+
+```yaml
+processors:
+  interval:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, interval]
+      exporters: [otlphttp]
+```
+
+### Keep gauges spiky, smooth everything else
+
+```yaml
+processors:
+  interval:
+    interval: 30s
+    pass_through:
+      gauge: true
+      summary: true
+```
+
+Use this when your gauges represent things you can't afford to flatten — request latency, queue depth, current connections.
+
+### Multiple intervals for different pipelines
+
+```yaml
+processors:
+  interval/fast:
+    interval: 15s
+  interval/slow:
+    interval: 5m
+
+service:
+  pipelines:
+    metrics/realtime:
+      receivers: [otlp]
+      processors: [memory_limiter, interval/fast]
+      exporters: [otlp/dashboard]
+    metrics/longterm:
+      receivers: [otlp]
+      processors: [memory_limiter, interval/slow]
+      exporters: [otlp/warehouse]
+```
+
+## Troubleshooting
+
+**Nothing comes out of the processor.**
+- All upstream metrics are delta or non-monotonic sums — those would already pass through but produce no buffered emission. Confirm a cumulative monotonic metric reaches the processor.
+- No new samples arrived in the most recent interval — state is cleared at emission, so a silent source means a silent output. Reduce the source's scrape gap or increase `interval`.
+
+**Gauge spikes disappeared from dashboards.**
+- Aggregation flattened them. Set `pass_through.gauge: true`.
+
+**Memory growth.**
+- Cardinality issue. The processor stores one entry per unique (metric, attribute set). Filter or drop high-cardinality attributes upstream (`transform` / `attributes` processor) before reaching `interval`.
+
+**Output cadence is irregular after a restart.**
+- Expected. The first interval after startup may emit less than usual because state was empty. Subsequent intervals settle once the upstream resends.
+
+## Anti-patterns
+
+**Stacking `interval` with delta-only metrics.**
+
+```yaml
+# BAD — adds a stateful component for no benefit; deltas pass through anyway
+processors:
+  interval:
+service:
+  pipelines:
+    metrics:
+      processors: [interval]
+```
+
+If the source emits only deltas, remove the processor.
+
+**Using it as a backpressure / rate-limit substitute.**
+
+`interval` reduces *point count* per series at emission boundaries; it does not throttle. Use `memory_limiter` (and the exporter's `sending_queue`) for backpressure.
+
+**Aggregating spiky gauges silently.**
+
+The default aggregates gauges and summaries. If you didn't explicitly think about it, flip `pass_through.gauge: true` until you have — losing a latency spike is harder to debug than ingesting one extra point per minute.
+
+## Related
+
+- `batch` / exporter `sending_queue.batch` — batches by size/time, does not collapse per-series points. Complementary, not a replacement.
+- `metricstransform`, `transform` — rewrite metrics; do not aggregate over time.
+- `cumulativetodelta` — converts temporality. Often paired with `interval` so cumulative-source metrics reach a delta-only backend as one delta per interval.

--- a/skills/otel-collector/components/log_dedup.md
+++ b/skills/otel-collector/components/log_dedup.md
@@ -1,0 +1,247 @@
+# `log_dedup` processor
+
+Aggregates identical log records over a time window and emits a single log with a `log_count` attribute.
+
+| | |
+|-|-|
+| Kind | processor |
+| Signals | logs |
+| Stability | Alpha (processor); Development (telemetry metric `otelcol_dedup_processor_aggregated_logs`) |
+| Distributions | contrib, k8s |
+| Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor` |
+| Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/logdedupprocessor> |
+
+## Rename in v0.151.0
+
+The type was renamed `logdedup` → `log_dedup` to match snake_case. The legacy name is a deprecated alias. New configs should use `log_dedup`; existing `logdedup` configs keep working.
+
+## When to use
+
+Use it when:
+- The pipeline carries high-volume repetitive logs (health checks, polling, retry storms, connection errors).
+- You want to reduce backend storage cost while preserving frequency information.
+- You care about first/last observed timestamps of a recurring event, not every individual occurrence.
+
+Avoid it when:
+- Every entry must be preserved (audit, compliance, security logs).
+- Sub-second precision per occurrence is required.
+- The backend already deduplicates — you'll deduplicate twice.
+- Each log carries a unique identifier or timestamp that makes every record unique (use `exclude_fields` to fix this, or skip the processor).
+
+## Configuration
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `interval` | duration | `10s` | Aggregation window. Must be `> 0`. Counter resets after each emission. |
+| `log_count_attribute` | string | `log_count` | Attribute name for the duplicate count. Must be non-empty. |
+| `timezone` | string | `UTC` | IANA timezone for `first_observed_timestamp`/`last_observed_timestamp` (e.g., `America/New_York`). |
+| `conditions` | []string | `[]` | OTTL log-context expressions. Empty = deduplicate all logs. Non-empty = only deduplicate matches; non-matching logs pass through unchanged. |
+| `include_fields` | []string | `[]` | Whitelist of fields used to compute log identity. Mutually exclusive with `exclude_fields`. |
+| `exclude_fields` | []string | `[]` | Fields removed before hashing **and** stripped from emitted logs. Mutually exclusive with `include_fields`. |
+
+### Validation rules
+
+- `include_fields` and `exclude_fields` cannot both be set.
+- Field paths must start with `body.` or `attributes.`.
+- The entire `body` cannot be included or excluded — only nested fields when `body` is a map.
+- Use `.` as the nesting delimiter. Escape literal dots in keys with `\` (e.g., `attributes.host\.name`).
+- `timezone` must resolve in the IANA database.
+
+### Fallback behavior
+
+If `include_fields` is set but none of the listed fields exist on a record, the processor falls back to comparing all fields (body, attributes, severity).
+
+## What gets matched
+
+Two log records are considered identical when **all** of these match exactly: resource attributes, instrumentation scope (name, version, attributes), log body (content and type), log attributes, and severity (number and text). The processor stores a 64-bit hash per unique combination.
+
+`include_fields` / `exclude_fields` customize which parts of the record feed the hash.
+
+## What gets emitted
+
+At the end of each `interval`, one log per unique hash is emitted with:
+- The original body, attributes, severity, resource.
+- `log_count` (or the configured name) — duplicate count, int.
+- `first_observed_timestamp` — RFC3339 string in the configured timezone.
+- `last_observed_timestamp` — RFC3339 string in the configured timezone.
+- `Timestamp` and `ObservedTimestamp` set to **emission time** (not original log time).
+
+Counter resets after emission.
+
+## OTTL context for `conditions`
+
+`conditions` runs in the [OTTL log context](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottllog): `body`, `attributes["…"]`, `resource.attributes["…"]`, `severity_number`, `severity_text`, plus all OTTL converters. See the `otel-ottl` skill for full path and function inventories.
+
+## Examples
+
+### Defaults
+
+```yaml
+processors:
+  log_dedup:
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, log_dedup]
+      exporters: [otlphttp]
+```
+
+### Exclude volatile fields
+
+```yaml
+processors:
+  log_dedup:
+    interval: 30s
+    exclude_fields:
+      - body.timestamp
+      - attributes.request_id
+      - attributes.trace_id
+      - attributes.span_id
+```
+
+Records that differ only in those fields are treated as duplicates.
+
+### Deduplicate only errors
+
+```yaml
+processors:
+  log_dedup:
+    interval: 60s
+    conditions:
+      - severity_number >= SEVERITY_NUMBER_ERROR
+```
+
+INFO/WARN/DEBUG logs pass through immediately. Only ERROR+ are buffered.
+
+### Whitelist match keys
+
+```yaml
+processors:
+  log_dedup:
+    interval: 60s
+    include_fields:
+      - attributes.error_code
+      - attributes.service.name
+      - body.error_message
+```
+
+Groups all errors with the same code from the same service, regardless of every other attribute.
+
+### Per-source named instances
+
+```yaml
+processors:
+  log_dedup/access:
+    interval: 10s
+    conditions:
+      - 'attributes["log.type"] == "access"'
+  log_dedup/health:
+    interval: 30s
+    conditions:
+      - 'attributes["log.type"] == "health_check"'
+
+service:
+  pipelines:
+    logs:
+      processors: [memory_limiter, log_dedup/access, log_dedup/health]
+```
+
+## Memory model
+
+- One entry per unique hash for the duration of the interval.
+- High-cardinality fields (`request_id`, `trace_id`, timestamps) blow up memory — exclude them or use `conditions` to scope what's deduplicated.
+- Long intervals accumulate more unique entries; short intervals emit faster with smaller buffers.
+
+## Telemetry
+
+The processor emits a histogram `otelcol_dedup_processor_aggregated_logs` with the count of logs aggregated per emission. Useful for tuning. The metric is currently **Development** stability — the name or shape can change between releases.
+
+## Troubleshooting
+
+**No logs are deduplicated.**
+- `conditions` may exclude everything — comment them out to confirm.
+- Every record may have a unique identifier (`request_id`, body timestamp). Add those to `exclude_fields`.
+- Records may arrive slower than `interval` allows duplicates to form — increase `interval`.
+
+**Memory grows without bound.**
+- High-cardinality unique fields in the hash input — narrow with `exclude_fields` or `include_fields`.
+- Interval too long for the volume — reduce it.
+- Scope what's deduplicated with `conditions`.
+
+**Logs arrive in bursts matching the interval.**
+- Expected. The processor emits at interval boundaries. Reduce `interval` for lower latency, or move repetitive logs into a dedicated pipeline so other logs aren't held back.
+
+**Different resources/severities aren't being grouped.**
+- Resource attributes and severity are always part of the hash — there is no option to ignore them. Use a `resource` or `transform` processor upstream to normalize them first if that's the goal.
+
+## Validation errors
+
+| Error | Fix |
+|-------|-----|
+| `cannot define both exclude_fields and include_fields` | Choose one. |
+| `an excludefield must start with body or attributes` | Prefix every path with `body.` or `attributes.`. |
+| `cannot exclude the entire body` | Only nested fields are exclud-able (e.g., `body.timestamp`). |
+
+## Anti-patterns
+
+**Indiscriminate dedup.**
+
+```yaml
+# BAD — critical events get hidden behind log_count
+processors:
+  log_dedup:
+    interval: 60s
+```
+
+Scope with `conditions` so audit, security, and one-off error logs pass through individually:
+
+```yaml
+processors:
+  log_dedup:
+    conditions:
+      - 'attributes["log.type"] == "health_check"'
+      - 'attributes["log.type"] == "heartbeat"'
+```
+
+**`include_fields` that includes unique IDs.**
+
+```yaml
+# BAD — request_id makes every record unique; nothing dedupes
+processors:
+  log_dedup:
+    include_fields:
+      - attributes.error_code
+      - attributes.request_id
+```
+
+Include only identifying fields, never per-record identifiers.
+
+**Very long intervals.**
+
+```yaml
+# BAD — 30 minutes of in-memory buffering, large bursty emissions
+processors:
+  log_dedup:
+    interval: 30m
+```
+
+Prefer shorter intervals plus aggressive `exclude_fields` for cardinality control.
+
+**Forgetting timezone for ops teams.**
+
+```yaml
+# Confusing if the team operates in PST
+processors:
+  log_dedup:
+    timezone: UTC  # default
+```
+
+Set the timezone your operators read timestamps in.
+
+## Related processors
+
+- `groupbyattrs` — groups by attribute, does not deduplicate.
+- `transform` — can rewrite/strip fields via OTTL, does not aggregate.
+- `filter` — drops records, does not aggregate.


### PR DESCRIPTION
## Summary

- Adds a new language-agnostic `otel-collector` skill that covers OpenTelemetry Collector component configuration via progressive disclosure: `SKILL.md` holds a lean entry + component index, and each component gets its own self-contained page under `components/`.
- Initial coverage: **`log_dedup` processor** (sourced from `telemetrydrops/ai-context`, includes the v0.151.0 `logdedup` → `log_dedup` rename note) and **`interval` processor** (sourced from upstream contrib, includes the per-metric-type behavior matrix and state-clearing caveat).
- Registers the skill in `README.md` (structure tree + skills table) and `.claude-plugin/marketplace.json`.

## Structure

```
skills/otel-collector/
  SKILL.md
  components/
    log_dedup.md
    interval.md
```

`SKILL.md` also includes an "Adding a new component" section so future expansion is templated — the goal is to grow this to dozens of components without inflating the loaded context.

Refs [E-2006](https://linear.app/ollygarden/issue/E-2006/add-otel-collector-skill-with-progressive-disclosure-log-dedup).

## Test plan

- [ ] `npx skills add https://github.com/ollygarden/opentelemetry-agent-skills/tree/jpkroehling/e-2006-add-otel-collector-skill/skills/otel-collector` installs cleanly.
- [ ] Skill activates on prompts mentioning `log_dedup`, `logdedup`, `interval processor`, or "Collector component configuration".
- [ ] `SKILL.md` description triggers only when relevant — does not over-fire on generic OTTL / SDK config questions (those should still route to `otel-ottl` / `otel-declarative-config`).
- [ ] `components/log_dedup.md` and `components/interval.md` are self-contained — agents loading just the per-component page can produce a working config without `SKILL.md` in context.
- [ ] Marketplace entry shows up in `/plugin install` listing after `marketplace add`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced OpenTelemetry Collector skill with configuration guidance for Collector components, currently covering `log_dedup` (log aggregation) and `interval` (metric buffering) processors.

* **Documentation**
  * Added comprehensive component documentation including configuration options, behavior patterns, examples, troubleshooting guides, and anti-patterns for both processors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ollygarden/opentelemetry-agent-skills/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->