### PR TITLE
[codex] Clarify declarative config file_format source

### DIFF
--- a/skills/otel-declarative-config/SKILL.md
+++ b/skills/otel-declarative-config/SKILL.md
@@ -10,6 +10,7 @@ programmatic SDK setup with a single YAML file. One file configures all SDK comp
 provider, meter provider, logger provider, propagators, and resource.
 
 For the current per-language SDK status, fetch the SDK compatibility matrix (see Sources of Truth).
+Use it to understand implementation coverage, not as the only source for YAML literals.
 
 ## Sources of Truth
 
@@ -20,7 +21,7 @@ embedded copies. Cache results for the conversation; refetch only on schema-rela
 | Fact | Fetch |
 |---|---|
 | Latest schema release tag | `gh release view --repo open-telemetry/opentelemetry-configuration --json tagName,publishedAt` |
-| SDK ↔ schema compatibility matrix | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/main/language-support-status.md` |
+| SDK ↔ schema compatibility matrix (coverage advisory, not authoritative for literal `file_format`) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/main/language-support-status.md` |
 | Field-by-field schema docs | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/main/schema-docs.md` |
 | Compiled JSON Schema (validate generated YAML against this) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/main/opentelemetry_configuration.json` |
 | Canonical full example | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/main/examples/otel-sdk-config.yaml` |
@@ -29,10 +30,25 @@ embedded copies. Cache results for the conversation; refetch only on schema-rela
 
 **Workflow when generating YAML:**
 
-1. Fetch `language-support-status.md` → pick the `file_format` string for the target SDK version.
-2. Fetch `examples/otel-sdk-config.yaml` → use as the structural template.
-3. Overlay the user's specific values (service name, endpoint, sampling, headers).
-4. If validation matters, fetch `opentelemetry_configuration.json` and validate the result.
+1. Identify the exact runtime/package/agent version that will parse the file.
+2. Fetch that runtime/package source, docs, or test fixtures and confirm the accepted
+   `file_format` literal. If this conflicts with `language-support-status.md`, the
+   runtime/package wins.
+3. Fetch `examples/otel-sdk-config.yaml` → use as the structural template only after
+   adapting the `file_format` and fields to the selected runtime/package.
+4. Overlay the user's specific values (service name, endpoint, sampling, headers).
+5. If validation matters, fetch `opentelemetry_configuration.json` and validate the result,
+   then still verify against the selected runtime/package because SDK implementations may
+   lag or differ from the schema repository.
+
+The `latestSupportedFileFormat` values in `language-support-status.md` are schema/version
+coverage metadata. Do not mechanically copy values like `1.0.0-rc.3` into YAML unless the
+target SDK parser, agent docs, or package fixtures prove that exact literal is accepted.
+
+Terminology trap: schema coverage identifiers and YAML `file_format` literals are related,
+but not interchangeable. A matrix entry may use a semver-shaped value such as
+`1.0.0-rc.3`, while an SDK parser may accept a config literal such as `1.0-rc.3` or
+`1.0`. Generated YAML must use the parser-accepted literal.
 
 For language-specific package versions and SDK API surface, see the Sources of Truth section
 in each language's `otel-<lang>` skill (`otel-go`, `otel-java`, `otel-js`).

--- a/skills/otel-go/references/declarative-setup.md
+++ b/skills/otel-go/references/declarative-setup.md
@@ -15,14 +15,17 @@ skill. For Go-specific facts:
 | Latest `otelconf` module tag | `gh api repos/open-telemetry/opentelemetry-go-contrib/git/matching-refs/tags/otelconf -q '.[-1].ref'` |
 | `otelconf` CHANGELOG (which schema rc each release supports, breaking changes) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-go-contrib/main/CHANGELOG.md` |
 | Current API surface (`SDK` methods, options) | `WebFetch https://pkg.go.dev/go.opentelemetry.io/contrib/otelconf` |
+| Current parser fixtures (`file_format` examples) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-go-contrib/main/otelconf/testdata/v1.0.0.yaml` |
 | Latest `go.opentelemetry.io/otel` core release | `gh api repos/open-telemetry/opentelemetry-go/releases/latest -q '.tag_name'` |
 
 ## Choosing an Import Path
 
 The `otelconf` repo ships two flavors of the package:
 
-- **Root** `go.opentelemetry.io/contrib/otelconf` — tracks the current schema (file_format
-  `1.0.0-rc.x` or later). Active development. Includes `sdk.Propagator()` for installing
+- **Root** `go.opentelemetry.io/contrib/otelconf` — tracks the current schema. Active
+  development. Confirm the accepted `file_format` literal from the selected module's
+  parser fixtures, not from the generic language support matrix alone. Includes
+  `sdk.Propagator()` for installing
   propagators from YAML.
 - **Schema-pinned** `go.opentelemetry.io/contrib/otelconf/v0.3.0` — frozen at file_format
   `"0.3"` (a 2024 schema). Has no `Propagator()` method; propagators must be installed
@@ -55,10 +58,10 @@ import (
 For the canonical structure, fetch `examples/otel-sdk-config.yaml` from the schema repo
 (see the `otel-declarative-config` skill's Sources of Truth). The minimal example below
 illustrates the Go-specific quirk; the exact `file_format` string and exporter field names
-should come from upstream.
+should come from the selected `otelconf` module's package fixtures/source.
 
 ```yaml
-# file_format: pick from language-support-status.md based on your otelconf version
+# file_format: use the exact literal accepted by the selected otelconf module
 resource:
   attributes:
     - name: service.name

--- a/skills/otel-java/SKILL.md
+++ b/skills/otel-java/SKILL.md
@@ -24,6 +24,7 @@ For Java-specific facts:
 | Latest BOM (`opentelemetry-bom`) | `gh api repos/open-telemetry/opentelemetry-java/releases/latest -q '.tag_name'` |
 | Latest Javaagent | `gh api repos/open-telemetry/opentelemetry-java-instrumentation/releases/latest -q '.tag_name'` |
 | Javaagent declarative-config docs (current activation flag, supported `file_format`) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/configuration/` |
+| Javaagent declarative-config smoke fixture (parser truth for current main) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/smoke-tests/src/test/resources/declarative-config.yaml` |
 | Javaagent CHANGELOG (when each schema rc landed) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/CHANGELOG.md` |
 | Spring Boot starter docs | `WebFetch https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/` |
 

--- a/skills/otel-java/references/declarative-setup.md
+++ b/skills/otel-java/references/declarative-setup.md
@@ -16,6 +16,7 @@ skill. For Java-specific facts:
 | Latest BOM (`opentelemetry-bom`) | `gh api repos/open-telemetry/opentelemetry-java/releases/latest -q '.tag_name'` |
 | Latest Javaagent | `gh api repos/open-telemetry/opentelemetry-java-instrumentation/releases/latest -q '.tag_name'` |
 | Javaagent declarative-config docs (current activation flag, supported `file_format`) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/configuration/` |
+| Javaagent declarative-config smoke fixture (parser truth for current main) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/smoke-tests/src/test/resources/declarative-config.yaml` |
 | Javaagent CHANGELOG (when each schema rc landed) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/CHANGELOG.md` |
 | Spring Boot starter docs | `WebFetch https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/` |
 
@@ -38,8 +39,8 @@ java -javaagent:opentelemetry-javaagent.jar \
 ```
 
 Declarative config support landed in Javaagent 2.26.0. Newer agent versions track newer
-schema versions — fetch the agent CHANGELOG (see Sources of Truth) to confirm which
-`file_format` your agent accepts.
+schema versions. Confirm the exact `file_format` literal from the Javaagent docs or test
+fixtures for the selected agent version, not from the generic language support matrix alone.
 
 When `-Dotel.config.file` is set, all other `-Dotel.*` properties are ignored except
 agent-only properties (see Key API Facts).
@@ -49,13 +50,13 @@ For the autoconfigure SDK extension (no Javaagent), the same flag works, plus th
 
 ## YAML Config
 
-For the canonical structure and the correct `file_format` string for your agent version,
-fetch `examples/otel-sdk-config.yaml` and `language-support-status.md` (see the
-`otel-declarative-config` skill's Sources of Truth). The minimal example below illustrates
-the Java-specific quirk.
+For the canonical structure, fetch `examples/otel-sdk-config.yaml` (see the
+`otel-declarative-config` skill's Sources of Truth). For the correct `file_format` string,
+use the selected Javaagent parser/docs/fixtures. The generic language support matrix is
+coverage metadata and may not be the exact YAML literal accepted by the Javaagent.
 
 ```yaml
-# file_format: pick from language-support-status.md based on your Javaagent version
+# file_format: use the exact literal accepted by the selected Javaagent version
 resource:
   attributes:
     - name: service.name

--- a/skills/otel-js/references/declarative-setup.md
+++ b/skills/otel-js/references/declarative-setup.md
@@ -19,6 +19,8 @@ skill. For JS-specific facts:
 | Latest `@opentelemetry/sdk-node` | `npm view @opentelemetry/sdk-node version` |
 | Latest `@opentelemetry/auto-instrumentations-node` | `npm view @opentelemetry/auto-instrumentations-node version` |
 | Package status / breaking changes | `WebFetch https://www.npmjs.com/package/@opentelemetry/configuration` |
+| File config parser for current source (`file_format` acceptance) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/configuration/src/FileConfigFactory.ts` |
+| File config fixtures for current source | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/configuration/test/fixtures/sdk-config.yaml` |
 | `sdk-node` CHANGELOG | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/opentelemetry-sdk-node/CHANGELOG.md` |
 | Node.js getting-started docs | `WebFetch https://opentelemetry.io/docs/languages/js/getting-started/nodejs/` |
 
@@ -40,13 +42,13 @@ The config file must have a `.yaml` or `.yml` extension.
 
 ## YAML Config
 
-For the canonical structure and the correct `file_format` string for your `@opentelemetry/configuration`
-version, fetch `examples/otel-sdk-config.yaml` and `language-support-status.md` (see the
-`otel-declarative-config` skill's Sources of Truth). The minimal example below illustrates
-the JS-specific quirk.
+For the canonical structure, fetch `examples/otel-sdk-config.yaml` (see the
+`otel-declarative-config` skill's Sources of Truth). For the correct `file_format` string,
+inspect the installed `@opentelemetry/configuration` package or its matching source/fixtures.
+Package releases may accept a different literal than the generic language support matrix.
 
 ```yaml
-# file_format: pick from language-support-status.md based on your @opentelemetry/configuration version
+# file_format: use the exact literal accepted by the installed @opentelemetry/configuration parser
 resource:
   attributes:
     - name: service.name


### PR DESCRIPTION
## Summary

Clarifies that OpenTelemetry declarative config compatibility matrix values describe schema/version coverage and should not be copied mechanically as YAML `file_format` literals.

## Root Cause

Agents were instructed to fetch `language-support-status.md` and pick `latestSupportedFileFormat` for generated YAML. That can produce invalid configs because the matrix may use semver-shaped coverage identifiers such as `1.0.0-rc.3`, while SDK parsers accept literals such as `1.0-rc.3` or `1.0`.

## Changes

- Marks the compatibility matrix as coverage advisory, not authoritative for literal `file_format` values.
- Requires checking the exact runtime/package/agent parser, docs, or fixtures for the accepted YAML literal.
- Adds Javaagent smoke fixture guidance.
- Updates Java, JS, and Go declarative setup references to use package/runtime-specific sources.

## Validation

- Checked local `@opentelemetry/configuration@0.216.0`, which accepts `1.0-rc.3`.
- Checked OpenTelemetry JS main parser and fixture, which use `1.0`.
- Checked Javaagent smoke fixture, which uses `1.0`.
- Checked Go `otelconf` fixture, which uses `1.0-rc.2` while the matrix reports schema coverage separately.
- Ran `git diff --check` locally before publishing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced declarative configuration guidance for OpenTelemetry Go, Java, and JavaScript SDKs with clearer sources of truth and setup workflows.
  * Improved file_format configuration instructions to ensure parser compatibility across SDK versions.
  * Added step-by-step YAML generation process with emphasis on version-specific validation and terminology clarifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ollygarden/opentelemetry-agent-skills/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->