### PR TITLE
otel-collector: canonical component-page template + refactor existing pages

### DIFF
--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -79,7 +79,16 @@ Two rules of thumb that apply across components:
 
 When extending coverage:
 
-1. Create `components/<type>.md`. Use the existing pages as a template — frontmatter is **not** required on component pages, only on `SKILL.md`.
-2. Each component page should cover: when to use / when not, config reference table with defaults and validation rules, at least one working YAML example, troubleshooting for common symptoms, and anti-patterns.
-3. Add a row to the [Component index](#component-index) above.
-4. Update the description trigger phrases in this file's frontmatter if the new component introduces a clearly distinct user-facing keyword.
+1. **Create `components/<type>.md`.** Component pages carry no frontmatter — only `SKILL.md` has frontmatter.
+2. **Follow the canonical 8-section template, in this order:**
+   1. **Header metadata table** — kind, signals, per-signal stability, distributions, `type` name, Go module, upstream README link, and a rename note if the component was renamed.
+   2. **Description** — what the component does and the mechanism behind it.
+   3. **Main use-cases** — "Use when" / "Avoid when".
+   4. **Typical config** — minimal working YAML inside a `service.pipelines` block, plus the full config-reference table (key, type, default, validation).
+   5. **Verification** — a `telemetrygen` + `debug`/`file` exporter recipe that proves the documented behavior; cross-reference the `otel-telemetrygen` skill.
+   6. **Advanced use-cases** — named instances, multi-pipeline setups, combinations, and edge configs.
+   7. **Known quirks** — gotchas, stability caveats, memory model, a validation-error→fix table, anti-patterns, and troubleshooting.
+   8. **Related components** — cross-links to related pages.
+3. **Use `components/log_dedup.md` and `components/interval.md` as reference implementations** of this template.
+4. **Add a row to the [Component index](#component-index)** above.
+5. **Update the description trigger phrases** in this file's frontmatter if the new component introduces a clearly distinct user-facing keyword.

--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -15,7 +15,7 @@ It does **not** cover OTTL expressions (see `otel-ottl`), declarative SDK config
 2. **Load the component page.** If the component is in the [Component index](#component-index), read `components/<name>.md` for the full config reference, examples, gotchas, and anti-patterns. Do not load pages you don't need.
 3. **If the component is not indexed**, say so explicitly and fall back to the upstream README under `processor/<name>/`, `receiver/<name>/`, `exporter/<name>/`, `connector/<name>/`, or `extension/<name>/` in [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib). Don't invent config keys from memory — Collector components evolve quickly.
 4. **Apply Collector-wide conventions.** Named instances (`type/name`), stability levels, and pipeline placement rules in [Collector-wide conventions](#collector-wide-conventions) apply to every component.
-5. **Verify.** Use `telemetrygen` (see the `otel-telemetrygen` skill) plus a `debug` or `file` exporter to confirm the component behaves as the docs claim — Alpha-stability components are common in this space, and behavior changes between releases.
+5. **Verify.** Run the component page's **Verification** recipe — `telemetrygen` (see the `otel-telemetrygen` skill) plus a `debug` or `file` exporter — to confirm the component behaves as the docs claim. Alpha- and Development-stability components are common here, and behavior changes between releases. See [Verification harness](#verification-harness) for how to run a recipe end-to-end.
 
 ## Component index
 
@@ -75,6 +75,16 @@ Two rules of thumb that apply across components:
 - `memory_limiter` belongs first in any processor list, before anything that allocates buffers (`log_dedup`, `transform`, `tail_sampling`, …).
 - Batching is now done by the exporter's `sending_queue.batch`, not by a separate `batch` processor. Don't add `batch` to new pipelines.
 
+### Verification harness
+
+Each component page's **Verification** section gives a config, a `telemetrygen` command, and the expected output. To run any of them:
+
+1. Save the YAML to a file and start a collector that bundles the component — for components in the `contrib`/`k8s` distributions, `otelcol-contrib --config <file>.yaml`; for components not in any distribution, build a custom collector with the [OpenTelemetry Collector Builder (OCB)](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) first.
+2. Send telemetry with `telemetrygen` (see the `otel-telemetrygen` skill).
+3. Watch the `debug` exporter's stdout (or the `file` exporter's output) for the expected result.
+
+The Verification configs are **minimal repros**: they omit `memory_limiter` and other production scaffolding on purpose, to isolate the component under test. Don't copy them verbatim into production.
+
 ## Adding a new component to this skill
 
 When extending coverage:
@@ -85,7 +95,7 @@ When extending coverage:
    2. **Description** — what the component does and the mechanism behind it.
    3. **Main use-cases** — "Use when" / "Avoid when".
    4. **Typical config** — minimal working YAML inside a `service.pipelines` block, plus the full config-reference table (key, type, default, validation).
-   5. **Verification** — a `telemetrygen` + `debug`/`file` exporter recipe that proves the documented behavior; cross-reference the `otel-telemetrygen` skill.
+   5. **Verification** — a `telemetrygen` + `debug`/`file` exporter recipe that proves the documented behavior; cross-reference the `otel-telemetrygen` skill. **Verify every `telemetrygen` flag against that skill — never assert a flag that doesn't exist.** If `telemetrygen` can't produce the input the component needs, say so and point to an alternative (OTTL/`transform`, a custom emitter). Keep the config a minimal repro (see [Verification harness](#verification-harness)).
    6. **Advanced use-cases** — named instances, multi-pipeline setups, combinations, and edge configs.
    7. **Known quirks** — gotchas, stability caveats, memory model, a validation-error→fix table, anti-patterns, and troubleshooting.
    8. **Related components** — cross-links to related pages.

--- a/skills/otel-collector/components/interval.md
+++ b/skills/otel-collector/components/interval.md
@@ -3,6 +3,7 @@
 | | |
 |-|-|
 | Kind | processor |
+| Type | `interval` |
 | Signals | metrics |
 | Stability | Alpha |
 | Distributions | contrib, k8s |

--- a/skills/otel-collector/components/interval.md
+++ b/skills/otel-collector/components/interval.md
@@ -95,11 +95,11 @@ service:
       exporters: [debug]
 ```
 
-Generate cumulative-sum metrics frequently (see the `otel-telemetrygen` skill):
+Generate cumulative-sum metrics frequently (see the `otel-telemetrygen` skill). The explicit `--aggregation-temporality cumulative` is load-bearing — `interval` only aggregates cumulative series; delta sums pass through unchanged and would show no volume drop:
 
 ```bash
 telemetrygen metrics --otlp-insecure --otlp-endpoint localhost:4317 \
-  --metric-type Sum --rate 5 --duration 25s
+  --metric-type Sum --aggregation-temporality cumulative --rate 5 --duration 25s
 ```
 
 **What proves it worked:** instead of ~5 points/sec reaching `debug`, the exporter prints the metric roughly once per 10s interval (one latest value per series). Compare against the same run with the processor removed to see the volume drop.

--- a/skills/otel-collector/components/interval.md
+++ b/skills/otel-collector/components/interval.md
@@ -1,7 +1,5 @@
 # `interval` processor
 
-Buffers cumulative metrics and emits the latest value once per interval. Reduces metric point volume from chatty sources while preserving the most recent reading per series.
-
 | | |
 |-|-|
 | Kind | processor |
@@ -11,7 +9,11 @@ Buffers cumulative metrics and emits the latest value once per interval. Reduces
 | Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor` |
 | Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/intervalprocessor> |
 
-## What it does to each metric type
+## Description
+
+Buffers cumulative metrics and emits the latest value once per interval. Reduces metric point volume from chatty sources while preserving the most recent reading per series.
+
+### What it does to each metric type
 
 | Metric type | Default behavior | Pass-through option |
 |-------------|------------------|---------------------|
@@ -28,7 +30,7 @@ Buffers cumulative metrics and emits the latest value once per interval. Reduces
 - Monotonic cumulative series: you lose **precision** (intermediate values), not totals — the final cumulative value still represents the full count.
 - Gauges and summaries: actual **data loss**. A value that rose and fell back inside the interval is reduced to whatever the last reading happened to be. If the up-and-down matters (latency spikes, queue depth bursts), set `pass_through.gauge: true` / `pass_through.summary: true` to keep them flowing as-is.
 
-## When to use
+## Main use-cases
 
 Use it when:
 - A receiver scrapes or emits cumulative metrics far more often than your backend needs (e.g., Prometheus receiver at 1s for a backend that ingests at 60s).
@@ -40,49 +42,7 @@ Avoid it when:
 - Gauge spikiness matters and you can't set `pass_through.gauge: true` for the relevant signals.
 - The collector restarts often — buffered state is in-memory only and is lost on restart (see [State and restart behavior](#state-and-restart-behavior)).
 
-## Configuration
-
-| Key | Type | Default | Notes |
-|-----|------|---------|-------|
-| `interval` | duration | `60s` | Emission cadence. After each emission, internal state is cleared. |
-| `pass_through.gauge` | bool | `false` | If `true`, gauges are forwarded unchanged instead of buffered. |
-| `pass_through.summary` | bool | `false` | If `true`, summaries are forwarded unchanged instead of buffered. |
-
-Upstream documents no explicit validation rules. The Collector will reject an unparseable `interval` duration at startup.
-
-> **Doc typo, upstream:** the README's configuration block shows `summary: <boo>l`. It's a typo for `<bool>` — the parameter is a plain boolean.
-
-## State and restart behavior
-
-- Internal state is keyed by metric name + attribute set and is held entirely in memory.
-- After each emission the buffer is cleared. **If no new points arrive in the next interval, nothing is emitted for that series in that interval.**
-- The state is not persisted — a collector restart drops every buffered point. For monotonic cumulative metrics this is usually fine (the next scrape carries the running total); for buffered gauges/summaries the most recent value is simply lost until the next sample.
-
-## Behavior example
-
-Source metrics arriving into the processor:
-
-| Time | Metric | Temporality | Attributes | Value |
-|------|--------|-------------|------------|------:|
-| 0 | `test_metric` | Cumulative | `labelA: foo` | 4.0 |
-| 2 | `test_metric` | Cumulative | `labelA: bar` | 3.1 |
-| 4 | `other_metric` | Delta | `fruitType: orange` | 77.4 |
-| 6 | `test_metric` | Cumulative | `labelA: foo` | 8.2 |
-| 8 | `test_metric` | Cumulative | `labelA: foo` | 12.8 |
-| 10 | `test_metric` | Cumulative | `labelA: bar` | 6.4 |
-
-`other_metric` (delta) is forwarded immediately. At the next interval boundary, only the latest value per series is forwarded:
-
-| Time | Metric | Temporality | Attributes | Value |
-|------|--------|-------------|------------|------:|
-| 8 | `test_metric` | Cumulative | `labelA: foo` | 12.8 |
-| 10 | `test_metric` | Cumulative | `labelA: bar` | 6.4 |
-
-Then state is cleared.
-
-## Examples
-
-### Default — aggregate cumulative, drop gauge spikes
+## Typical config
 
 ```yaml
 processors:
@@ -95,6 +55,55 @@ service:
       processors: [memory_limiter, interval]
       exporters: [otlphttp]
 ```
+
+### Configuration reference
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `interval` | duration | `60s` | Emission cadence. After each emission, internal state is cleared. |
+| `pass_through.gauge` | bool | `false` | If `true`, gauges are forwarded unchanged instead of buffered. |
+| `pass_through.summary` | bool | `false` | If `true`, summaries are forwarded unchanged instead of buffered. |
+
+Upstream documents no explicit validation rules. The Collector will reject an unparseable `interval` duration at startup.
+
+> **Doc typo, upstream:** the README's configuration block shows `summary: <boo>l`. It's a typo for `<bool>` — the parameter is a plain boolean.
+
+## Verification
+
+`interval` ships in the `contrib` and `k8s` distributions.
+
+Config (`interval-verify.yaml`):
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+processors:
+  interval:
+    interval: 10s
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [interval]
+      exporters: [debug]
+```
+
+Generate cumulative-sum metrics frequently (see the `otel-telemetrygen` skill):
+
+```bash
+telemetrygen metrics --otlp-insecure --otlp-endpoint localhost:4317 \
+  --metric-type Sum --rate 5 --duration 25s
+```
+
+**What proves it worked:** instead of ~5 points/sec reaching `debug`, the exporter prints the metric roughly once per 10s interval (one latest value per series). Compare against the same run with the processor removed to see the volume drop.
+
+## Advanced use-cases
 
 ### Keep gauges spiky, smooth everything else
 
@@ -130,7 +139,37 @@ service:
       exporters: [otlp/warehouse]
 ```
 
-## Troubleshooting
+### Behavior example
+
+Source metrics arriving into the processor:
+
+| Time | Metric | Temporality | Attributes | Value |
+|------|--------|-------------|------------|------:|
+| 0 | `test_metric` | Cumulative | `labelA: foo` | 4.0 |
+| 2 | `test_metric` | Cumulative | `labelA: bar` | 3.1 |
+| 4 | `other_metric` | Delta | `fruitType: orange` | 77.4 |
+| 6 | `test_metric` | Cumulative | `labelA: foo` | 8.2 |
+| 8 | `test_metric` | Cumulative | `labelA: foo` | 12.8 |
+| 10 | `test_metric` | Cumulative | `labelA: bar` | 6.4 |
+
+`other_metric` (delta) is forwarded immediately. At the next interval boundary, only the latest value per series is forwarded:
+
+| Time | Metric | Temporality | Attributes | Value |
+|------|--------|-------------|------------|------:|
+| 8 | `test_metric` | Cumulative | `labelA: foo` | 12.8 |
+| 10 | `test_metric` | Cumulative | `labelA: bar` | 6.4 |
+
+Then state is cleared.
+
+## Known quirks
+
+### State and restart behavior
+
+- Internal state is keyed by metric name + attribute set and is held entirely in memory.
+- After each emission the buffer is cleared. **If no new points arrive in the next interval, nothing is emitted for that series in that interval.**
+- The state is not persisted — a collector restart drops every buffered point. For monotonic cumulative metrics this is usually fine (the next scrape carries the running total); for buffered gauges/summaries the most recent value is simply lost until the next sample.
+
+### Troubleshooting
 
 **Nothing comes out of the processor.**
 - All upstream metrics are delta or non-monotonic sums — those would already pass through but produce no buffered emission. Confirm a cumulative monotonic metric reaches the processor.
@@ -145,7 +184,7 @@ service:
 **Output cadence is irregular after a restart.**
 - Expected. The first interval after startup may emit less than usual because state was empty. Subsequent intervals settle once the upstream resends.
 
-## Anti-patterns
+### Anti-patterns
 
 **Stacking `interval` with delta-only metrics.**
 
@@ -169,7 +208,7 @@ If the source emits only deltas, remove the processor.
 
 The default aggregates gauges and summaries. If you didn't explicitly think about it, flip `pass_through.gauge: true` until you have — losing a latency spike is harder to debug than ingesting one extra point per minute.
 
-## Related
+## Related components
 
 - `batch` / exporter `sending_queue.batch` — batches by size/time, does not collapse per-series points. Complementary, not a replacement.
 - `metricstransform`, `transform` — rewrite metrics; do not aggregate over time.

--- a/skills/otel-collector/components/log_dedup.md
+++ b/skills/otel-collector/components/log_dedup.md
@@ -1,7 +1,5 @@
 # `log_dedup` processor
 
-Aggregates identical log records over a time window and emits a single log with a `log_count` attribute.
-
 | | |
 |-|-|
 | Kind | processor |
@@ -11,11 +9,30 @@ Aggregates identical log records over a time window and emits a single log with 
 | Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor` |
 | Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/logdedupprocessor> |
 
-## Rename in v0.151.0
+**Rename in v0.151.0:** the type was renamed `logdedup` → `log_dedup` to match snake_case. The legacy name is a deprecated alias. New configs should use `log_dedup`; existing `logdedup` configs keep working.
 
-The type was renamed `logdedup` → `log_dedup` to match snake_case. The legacy name is a deprecated alias. New configs should use `log_dedup`; existing `logdedup` configs keep working.
+## Description
 
-## When to use
+Aggregates identical log records over a time window and emits a single log with a `log_count` attribute. Instead of forwarding every occurrence of a repeated message, the processor counts duplicates seen within an `interval` and emits one representative record per unique combination at the end of the window.
+
+### What gets matched
+
+Two log records are considered identical when **all** of these match exactly: resource attributes, instrumentation scope (name, version, attributes), log body (content and type), log attributes, and severity (number and text). The processor stores a 64-bit hash per unique combination.
+
+`include_fields` / `exclude_fields` customize which parts of the record feed the hash.
+
+### What gets emitted
+
+At the end of each `interval`, one log per unique hash is emitted with:
+- The original body, attributes, severity, resource.
+- `log_count` (or the configured name) — duplicate count, int.
+- `first_observed_timestamp` — RFC3339 string in the configured timezone.
+- `last_observed_timestamp` — RFC3339 string in the configured timezone.
+- `Timestamp` and `ObservedTimestamp` set to **emission time** (not original log time).
+
+Counter resets after emission.
+
+## Main use-cases
 
 Use it when:
 - The pipeline carries high-volume repetitive logs (health checks, polling, retry storms, connection errors).
@@ -28,7 +45,21 @@ Avoid it when:
 - The backend already deduplicates — you'll deduplicate twice.
 - Each log carries a unique identifier or timestamp that makes every record unique (use `exclude_fields` to fix this, or skip the processor).
 
-## Configuration
+## Typical config
+
+```yaml
+processors:
+  log_dedup:
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, log_dedup]
+      exporters: [otlphttp]
+```
+
+### Configuration reference
 
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
@@ -51,42 +82,42 @@ Avoid it when:
 
 If `include_fields` is set but none of the listed fields exist on a record, the processor falls back to comparing all fields (body, attributes, severity).
 
-## What gets matched
+## Verification
 
-Two log records are considered identical when **all** of these match exactly: resource attributes, instrumentation scope (name, version, attributes), log body (content and type), log attributes, and severity (number and text). The processor stores a 64-bit hash per unique combination.
+`log_dedup` ships in the `contrib` and `k8s` distributions, so a stock contrib collector can run this.
 
-`include_fields` / `exclude_fields` customize which parts of the record feed the hash.
-
-## What gets emitted
-
-At the end of each `interval`, one log per unique hash is emitted with:
-- The original body, attributes, severity, resource.
-- `log_count` (or the configured name) — duplicate count, int.
-- `first_observed_timestamp` — RFC3339 string in the configured timezone.
-- `last_observed_timestamp` — RFC3339 string in the configured timezone.
-- `Timestamp` and `ObservedTimestamp` set to **emission time** (not original log time).
-
-Counter resets after emission.
-
-## OTTL context for `conditions`
-
-`conditions` runs in the [OTTL log context](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottllog): `body`, `attributes["…"]`, `resource.attributes["…"]`, `severity_number`, `severity_text`, plus all OTTL converters. See the `otel-ottl` skill for full path and function inventories.
-
-## Examples
-
-### Defaults
+Config (`dedup-verify.yaml`):
 
 ```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
 processors:
   log_dedup:
-
+    interval: 5s
+exporters:
+  debug:
+    verbosity: detailed
 service:
   pipelines:
     logs:
       receivers: [otlp]
-      processors: [memory_limiter, log_dedup]
-      exporters: [otlphttp]
+      processors: [log_dedup]
+      exporters: [debug]
 ```
+
+Generate many identical log records (see the `otel-telemetrygen` skill):
+
+```bash
+telemetrygen logs --otlp-insecure --otlp-endpoint localhost:4317 \
+  --logs 50 --body "health check ok" --duration 4s
+```
+
+**What proves it worked:** the `debug` exporter prints **one** aggregated log per 5s interval carrying a `log_count` attribute near 50 (plus `first_observed_timestamp` / `last_observed_timestamp`), not 50 separate records.
+
+## Advanced use-cases
 
 ### Exclude volatile fields
 
@@ -148,17 +179,23 @@ service:
       processors: [memory_limiter, log_dedup/access, log_dedup/health]
 ```
 
-## Memory model
+### OTTL context for `conditions`
+
+`conditions` runs in the [OTTL log context](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottllog): `body`, `attributes["…"]`, `resource.attributes["…"]`, `severity_number`, `severity_text`, plus all OTTL converters. See the `otel-ottl` skill for full path and function inventories.
+
+## Known quirks
+
+### Memory model
 
 - One entry per unique hash for the duration of the interval.
 - High-cardinality fields (`request_id`, `trace_id`, timestamps) blow up memory — exclude them or use `conditions` to scope what's deduplicated.
 - Long intervals accumulate more unique entries; short intervals emit faster with smaller buffers.
 
-## Telemetry
+### Telemetry
 
 The processor emits a histogram `otelcol_dedup_processor_aggregated_logs` with the count of logs aggregated per emission. Useful for tuning. The metric is currently **Development** stability — the name or shape can change between releases.
 
-## Troubleshooting
+### Troubleshooting
 
 **No logs are deduplicated.**
 - `conditions` may exclude everything — comment them out to confirm.
@@ -176,7 +213,7 @@ The processor emits a histogram `otelcol_dedup_processor_aggregated_logs` with t
 **Different resources/severities aren't being grouped.**
 - Resource attributes and severity are always part of the hash — there is no option to ignore them. Use a `resource` or `transform` processor upstream to normalize them first if that's the goal.
 
-## Validation errors
+### Validation errors
 
 | Error | Fix |
 |-------|-----|
@@ -184,7 +221,7 @@ The processor emits a histogram `otelcol_dedup_processor_aggregated_logs` with t
 | `an excludefield must start with body or attributes` | Prefix every path with `body.` or `attributes.`. |
 | `cannot exclude the entire body` | Only nested fields are exclud-able (e.g., `body.timestamp`). |
 
-## Anti-patterns
+### Anti-patterns
 
 **Indiscriminate dedup.**
 
@@ -240,7 +277,7 @@ processors:
 
 Set the timezone your operators read timestamps in.
 
-## Related processors
+## Related components
 
 - `groupbyattrs` — groups by attribute, does not deduplicate.
 - `transform` — can rewrite/strip fields via OTTL, does not aggregate.

--- a/skills/otel-collector/components/log_dedup.md
+++ b/skills/otel-collector/components/log_dedup.md
@@ -3,6 +3,7 @@
 | | |
 |-|-|
 | Kind | processor |
+| Type | `log_dedup` |
 | Signals | logs |
 | Stability | Alpha (processor); Development (telemetry metric `otelcol_dedup_processor_aggregated_logs`) |
 | Distributions | contrib, k8s |


### PR DESCRIPTION
Establishes a canonical 8-section template for `otel-collector` component pages and refactors the two existing pages onto it.

## What changed
- Refactored `components/log_dedup.md` and `components/interval.md` to the template: header metadata table · Description · Main use-cases · Typical config · **Verification** · Advanced use-cases · Known quirks · Related components. No information loss; the main addition is a runnable `telemetrygen` Verification section on each page.
- Rewrote `SKILL.md`'s "Adding a new component" section to document the template, with both pages as reference implementations.

Tracked in Linear **E-2198**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated verification workflow with clearer guidance and harness instructions for component testing.
  * Expanded component creation process with prescriptive template and reference implementations.
  * Enhanced processor documentation for interval and log_dedup with verification examples, configuration references, anti-patterns guidance, and improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->