### PR TITLE
otel-collector: add cardinality_guardian, tail_sampling, drain, redaction pages

### DIFF
--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: otel-collector
-description: OpenTelemetry Collector component configuration. Use when authoring, reviewing, or debugging Collector YAML for a specific receiver, processor, exporter, connector, or extension — config keys, defaults, validation rules, signal support, stability levels, and component-level gotchas. Triggers on questions about specific components such as `log_dedup` / `logdedup`, `interval` (metric aggregation), and other Collector components covered in `components/`.
+description: OpenTelemetry Collector component configuration. Use when authoring, reviewing, or debugging Collector YAML for a specific receiver, processor, exporter, connector, or extension — config keys, defaults, validation rules, signal support, stability levels, and component-level gotchas. Triggers on questions about specific components such as `log_dedup` / `logdedup`, `interval` (metric aggregation), `tail_sampling`, `cardinality_guardian`, `drain`, `redaction`, and other Collector components covered in `components/`.
 ---
 
 # OpenTelemetry Collector
@@ -25,6 +25,10 @@ Pages live in `components/`. Each page is self-contained: when to use / when not
 |------|------|------|---------|-----------|---------|
 | `log_dedup` | `components/log_dedup.md` | processor | logs | Alpha | Deduplicates identical log records over a time window; emits one aggregated log with a count. Renamed from `logdedup` in v0.151.0; alias preserved. |
 | `interval` | `components/interval.md` | processor | metrics | Alpha | Buffers cumulative monotonic metrics (and optionally gauges/summaries) and emits the latest value once per interval. Delta and non-monotonic sums pass through unchanged. |
+| `cardinality_guardian` | `components/cardinality_guardian.md` | processor | metrics | Development | Catches metric cardinality explosions by detecting abnormal per-label growth and stripping or tagging the offending label. Not in any distribution — build via OCB. |
+| `tail_sampling` | `components/tail_sampling.md` | processor | traces | Beta | Buffers whole traces and makes a single keep/drop decision after a wait window via policies. Requires a loadbalancing layer to scale across instances. |
+| `drain` | `components/drain.md` | processor | logs | Alpha | Clusters log bodies with the Drain algorithm and annotates each record with a derived template string. |
+| `redaction` | `components/redaction.md` | processor | traces, logs, metrics | Beta (traces), Alpha (logs/metrics) | Allow/block-list masking or removal of sensitive attribute keys and values, with hashing and URL/DB sanitizers. |
 
 ## Collector-wide conventions
 
@@ -60,7 +64,7 @@ Components publish a stability level per signal. Treat these as load-bearing whe
 | Beta | Production viable — breaking changes rare. |
 | Stable | Production — backward compatibility guaranteed. |
 
-The components currently indexed here (`log_dedup`, `interval`) are **Alpha**. Surface that to the user when they ask about production readiness.
+Stability now varies per component — and per signal for multi-signal components (e.g. `redaction` is Beta for traces but Alpha for logs/metrics). Don't assume a single level for the indexed set: check each page's header metadata table for the authoritative stability and surface it when the user asks about production readiness.
 
 ### Recent renames
 

--- a/skills/otel-collector/components/cardinality_guardian.md
+++ b/skills/otel-collector/components/cardinality_guardian.md
@@ -1,0 +1,197 @@
+# `cardinality_guardian` processor
+
+| | |
+|-|-|
+| Kind | processor |
+| Signals | metrics |
+| Stability | Development (contrib v0.152.0) |
+| Distributions | none — build into a custom collector via OCB |
+| Type | `cardinality_guardian` |
+| Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/cardinalityguardianprocessor` |
+| Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cardinalityguardianprocessor> |
+
+## Description
+
+Catches metric cardinality explosions by detecting abnormal per-`(metric, label key)` growth and stripping or tagging only the offending label, leaving the rest of the data point intact. A single runaway label — a request ID, a raw URL, a user-supplied tag — can multiply a metric's time-series count and blow up TSDB cost and query latency. When a label's new unique values in the current epoch exceed a threshold, the processor either:
+
+- **strips** the offending label from the data point (`tag_only: false`, the default), or
+- **tags** the data point with `otel.metric.overflow: true` and otherwise leaves it untouched (`tag_only: true`).
+
+Because only the bad label is removed — not the whole data point — dashboards and alerts that rely on other labels keep working while the explosion is neutralized.
+
+### How detection works
+
+The processor measures cardinality **growth**, not absolute cardinality. For each `(metric, label key)` it keeps a HyperLogLog sketch and, at the end of every epoch, promotes the current sketch to "previous" and starts fresh. The enforcement check compares the current epoch's unique-value estimate against the previous epoch's — only the **delta** is tested against the threshold. A metric that has already reached a large but stable label space is left alone; only metrics whose label space is actively *exploding* trigger enforcement.
+
+`MutatesData: true` — the processor takes ownership of the incoming `pmetric.Metrics`.
+
+## Main use-cases
+
+Use it when:
+
+- A metrics pipeline feeds a per-series-priced backend (managed Prometheus, Datadog) where one bad deploy can balloon cost.
+- You want a safety net that degrades gracefully (drop a label) instead of dropping whole metrics.
+- You want to route overflow series to cheap storage rather than discard them (`tag_only: true` plus a routing connector).
+
+Avoid it when:
+
+- You need deterministic, explicit label add/drop — use `metricstransform` or `transform` instead.
+- Your pipeline carries cumulative Sums/Histograms and you cannot run `tag_only: true` — stripping a label collapses series identity and silently corrupts `rate()`/`increase()` (see Known quirks).
+- You need to bound *absolute* cardinality; this processor only reacts to per-epoch growth, so a one-time large-but-stable label space is never enforced.
+
+## Typical config
+
+```yaml
+processors:
+  cardinality_guardian:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, cardinality_guardian]
+      exporters: [prometheusremotewrite]
+```
+
+### Configuration reference
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `max_cardinality_delta_per_epoch` | int | `100` | Max new unique values per `(metric, label key)` per epoch. Must be `> 0`. Global threshold; overridable per metric. |
+| `epoch_duration_seconds` | int | `300` | Epoch (sliding window) rotation interval. Must be `>= 10`. Shorter = more sensitive but noisier; longer = smoother but slower to react. |
+| `tag_only` | bool | `false` | `false` strips the offending label; `true` keeps it and adds `otel.metric.overflow: true`. `true` is the production-safe mode (see Known quirks). |
+| `never_drop_labels` | []string | `[http.status_code, region]` | Label keys never stripped or tagged regardless of growth. O(1) exempt-list, read only at startup. |
+| `metric_overrides` | map[string]int | `nil` | Per-metric delta overrides. Each value must be `> 0`; empty metric names are rejected at validation. Unspecified metrics use the global default. |
+| `top_offenders_count` | int | `10` | Number of highest-delta `(metric, label)` pairs reported via gauge. `0` disables. Range `0`–`500`. Snapshot computed once per epoch (no hot-path cost). |
+| `max_tracker_count` | int | `0` | Max concurrent trackers. `0` = unlimited. Range `0`–`10,000,000`. Once reached, new pairs pass through untracked and increment `..._trackers_rejected`. |
+| `estimated_cost_per_metric_month` | float64 | `0.05` | Dollar value per series prevented, for the savings counter. `0` disables. Must be `>= 0`. Does not affect enforcement. |
+| `drop_log_max_per_epoch` | int | `10` | Cap on per-epoch "dropping attribute" warning logs. `0` = no cap (logs every drop, not recommended at scale). Must be `>= 0`. |
+
+Validation runs at pipeline construction; any out-of-range field prevents startup.
+
+## Verification
+
+`cardinality_guardian` is not bundled in any distribution — build a custom collector that includes `processor/cardinalityguardianprocessor` via the OpenTelemetry Collector Builder (OCB) first.
+
+Config (`cardguard-verify.yaml`):
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+processors:
+  cardinality_guardian:
+    max_cardinality_delta_per_epoch: 5
+    epoch_duration_seconds: 10
+    tag_only: true
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [cardinality_guardian]
+      exporters: [debug]
+```
+
+Emit metrics whose attribute set explodes — many unique values for one label key within an epoch. **`telemetrygen` cannot do this directly:** its `--telemetry-attributes key="value"` flag sets one fixed value, so every data point carries the *same* label value and no per-epoch growth is ever observed. The experimental `--unique-timeseries` flag varies the timeseries but does not let you target a specific named label key with a growing value space. To exercise the processor you need varying values on one label key, which means either:
+
+- Prepend a `transform`/OTTL `metrics` statement upstream in the same pipeline that rewrites a label to an exploding value (e.g. derive it from a high-cardinality source), so the input shape grows over the epoch; see the `otel-ottl` skill for `set(...)` on metric attributes, or
+- Use a small custom emitter (a few lines with the metrics SDK) that increments a counter while setting `runaway="value-N"` with `N` incrementing per export.
+
+A constant-attribute run is still useful as a baseline — it should produce **no** overflow tagging, confirming stable label spaces are left alone:
+
+```bash
+telemetrygen metrics --otlp-insecure --otlp-endpoint localhost:4317 \
+  --metric-type Sum --rate 50 --duration 30s --telemetry-attributes 'runaway="value-N"'
+```
+
+**What proves it worked (`tag_only: true`):** once a label crosses the per-epoch delta, the `debug` exporter shows the offending data points carrying `otel.metric.overflow: true` while other labels remain intact; the internal metric `otelcol_processor_cardinality_labels_stripped` increments. With a constant label value (the `telemetrygen` baseline above) nothing is tagged — that confirms growth, not absolute cardinality, is what triggers enforcement.
+
+## Advanced use-cases
+
+### Tag-and-route to cheap storage (production-safe)
+
+Keep the offending series but split it off to cheap storage with the `routingconnector`, avoiding the single-writer problem:
+
+```yaml
+processors:
+  cardinality_guardian:
+    tag_only: true
+connectors:
+  routing:
+    default_pipelines: [metrics/clean]
+    table:
+      - condition: 'attributes["otel.metric.overflow"] == true'
+        pipelines: [metrics/overflow]
+service:
+  pipelines:
+    metrics/in:
+      receivers: [otlp]
+      processors: [cardinality_guardian]
+      exporters: [routing]
+    metrics/clean:
+      receivers: [routing]
+      exporters: [prometheusremotewrite]
+    metrics/overflow:
+      receivers: [routing]
+      exporters: [file]   # cheap cold storage
+```
+
+### Per-metric overrides
+
+A legitimately wide metric (high but expected cardinality) can be given a looser threshold so it is not enforced at the global level:
+
+```yaml
+processors:
+  cardinality_guardian:
+    max_cardinality_delta_per_epoch: 100
+    metric_overrides:
+      http.server.request.duration: 5000
+```
+
+### Bounding memory with `max_tracker_count`
+
+Each `(metric, label)` pair holds a HyperLogLog sketch. On a pipeline with a huge metric/label fan-out, set `max_tracker_count` to cap memory. Once the cap is hit, new pairs pass through untracked and `otelcol_processor_cardinality_trackers_rejected` increments — watch that counter to know whether the cap is too low.
+
+### Interpreting the internal telemetry
+
+| Metric | Type | Use |
+|--------|------|-----|
+| `otelcol_processor_cardinality_trackers_active` | Gauge | Active `(metric, label)` trackers across all shards. |
+| `otelcol_processor_cardinality_labels_stripped` | Counter | Labels stripped or tagged. Alert on `rate(...[5m])` for spike detection. |
+| `otelcol_processor_cardinality_top_offenders` | Gauge | Top-N highest-delta pairs (`metric_name`, `label_key` attributes) — find the exact pair exploding. |
+| `otelcol_processor_cardinality_trackers_rejected` | Counter | New pairs ignored after hitting `max_tracker_count`. |
+| `otelcol_processor_cardinality_savings_estimated` | Counter | Estimated dollar value of series prevented from reaching the TSDB. |
+
+## Known quirks
+
+### Single-writer violation in enforcement mode (`tag_only: false`)
+
+This is the headline gotcha. In enforcement mode, stripping a label can collapse multiple data points onto the **same series identity**. Cumulative backends (Prometheus and similar) interpret the overlapping cumulative values as **counter resets**, silently corrupting `rate()` and `increase()` for affected Sum and Histogram metrics — the numbers look plausible but are wrong, with no error surfaced anywhere.
+
+**Fix / recommendation:** run `tag_only: true` plus a routing connector (see Advanced use-cases) in production until a downstream spatial-reaggregation processor exists. Reserve `tag_only: false` for gauges or for pipelines you have verified are safe.
+
+Add the labels your dashboards group by (`service.name`, `environment`, etc.) to `never_drop_labels` so enforcement can never break them.
+
+### Nothing gets stripped despite an obvious explosion
+
+The check is on per-epoch *delta*, not absolute cardinality. If the explosion happened before the processor started (steady state), no delta is observed. Lower `epoch_duration_seconds` or restart to re-baseline. Also confirm the label is not in `never_drop_labels`.
+
+### Development stability
+
+Introduced at **Development** stability in contrib v0.152.0. Configuration and behavior may change without a deprecation period — pin the collector version and re-check defaults on upgrade.
+
+### Not in any distribution
+
+Not bundled in the `contrib` or `k8s` distributions. You must build a custom collector that includes `processor/cardinalityguardianprocessor` via the OpenTelemetry Collector Builder (OCB).
+
+## Related components
+
+- [`metricstransform`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor) — deterministic label add/drop and aggregation across attribute combinations.
+- [`transform`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor) — OTTL-based per-metric attribute manipulation and filtering.
+- [`filter`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor) — drop whole metrics/data points by OTTL condition.
+- [`routingconnector`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector) — route the `otel.metric.overflow`-tagged stream to a separate pipeline when running in `tag_only` mode.

--- a/skills/otel-collector/components/cardinality_guardian.md
+++ b/skills/otel-collector/components/cardinality_guardian.md
@@ -3,10 +3,10 @@
 | | |
 |-|-|
 | Kind | processor |
+| Type | `cardinality_guardian` |
 | Signals | metrics |
 | Stability | Development (contrib v0.152.0) |
 | Distributions | none — build into a custom collector via OCB |
-| Type | `cardinality_guardian` |
 | Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/cardinalityguardianprocessor` |
 | Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cardinalityguardianprocessor> |
 

--- a/skills/otel-collector/components/drain.md
+++ b/skills/otel-collector/components/drain.md
@@ -1,0 +1,221 @@
+# `drain` processor
+
+| | |
+|-|-|
+| Kind | processor |
+| Signals | logs |
+| Stability | Alpha (processor); Development (telemetry metrics `otelcol_processor_drain_*`) |
+| Distributions | contrib, k8s |
+| Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/drainprocessor` |
+| Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/drainprocessor> |
+
+The `type` is `drain`. Logs support is Alpha since v0.151.0; configuration keys and behavior may change between releases.
+
+## Description
+
+Applies the [Drain](https://pinjiahe.github.io/papers/ICWS17.pdf) log-clustering algorithm to each log record, derives a **template string** (e.g. `user <*> logged in from <*>`), and writes it to a configurable attribute (`log.record.template` by default). The template becomes a stable key for grouping, filtering, routing, or sampling whole classes of logs.
+
+The processor **annotates only** — it does not drop, aggregate, reorder, or otherwise modify the flow of logs. To act on the derived template (for example, dropping a noisy log class), pair it with a `filter` processor or `routing` connector downstream.
+
+### How the parse-tree works
+
+Drain tokenizes each log line and walks a **fixed-depth parse tree** (depth set by `tree_depth`). Lines with similar token structure land in the same **cluster**; each cluster carries a template. As more logs arrive, the template is refined — tokens that vary across a cluster's members become `<*>` wildcards while stable tokens are kept verbatim. The algorithm is deterministic: given the same configuration and a representative sample of log forms, the same token structure always yields the same template. Because of this, independent collector instances converge on identical templates once each has seen enough lines.
+
+## Main use-cases
+
+Use it when:
+- You want to group high-volume, semi-structured logs into a small number of stable patterns.
+- You need a stable key for downstream filtering, routing, or sampling of log classes.
+- Your log bodies are free-form strings (or a structured body with a clear message field).
+- You want to identify the noisiest log patterns before deciding what to drop.
+
+Avoid it when:
+- Your logs are already fully structured with a reliable event identifier — use that attribute directly.
+- You need exact, hand-authored templates with no early-training variance — seed them, or template upstream.
+- Bodies are large JSON blobs with no single message field — templating the serialized map produces low-value templates (set `body_field`, or promote the message field upstream).
+
+## Typical config
+
+```yaml
+processors:
+  drain:
+    template_attribute: log.record.template
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, drain]
+      exporters: [otlphttp]
+```
+
+### Configuration reference
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `tree_depth` | int | `4` | Max depth of the Drain parse tree (`depth` in the paper). Higher = more specific templates. **Minimum: 3.** |
+| `merge_threshold` | float | `0.4` | Minimum fraction of tokens that must match an existing cluster for a line to merge into it rather than form a new cluster (`st` in the paper). Range `[0.0, 1.0]`. |
+| `max_node_children` | int | `100` | Maximum children per internal parse-tree node (`maxChild` in the paper). Bounds memory on high-cardinality token positions. |
+| `max_clusters` | int | `0` | Maximum clusters tracked; when exceeded, the least-recently-used cluster is evicted. `0` = unlimited. |
+| `extra_delimiters` | []string | `[]` | Additional token delimiters beyond whitespace (e.g. `[",", ":"]`). |
+| `body_field` | string | `""` | If set and the body is a map, the value of this **single top-level key** is templated instead of the full body. Full OTTL paths are not supported. `""` = use the full body string. |
+| `template_attribute` | string | `"log.record.template"` | Attribute key the derived template string is written to. |
+| `seed_templates` | []string | `[]` | Template strings pre-loaded at startup. Empty/whitespace-only entries are skipped. |
+| `seed_logs` | []string | `[]` | Raw example log lines trained on at startup. Empty/whitespace-only entries are skipped. |
+| `warmup_min_clusters` | int | `0` | Distinct clusters that must be observed before annotation starts. `0` disables warmup. |
+| `storage` | component ID | `""` | ID of a storage extension used to persist the tree across restarts. `""` = disabled. |
+| `save_interval` | duration | `0s` | Interval between periodic snapshot saves. `0s` = save on shutdown only. Requires `storage`. |
+
+### Validation rules
+
+- `tree_depth` must be `>= 3`.
+- `merge_threshold` must be in `[0.0, 1.0]`.
+- `warmup_min_clusters` must be `>= 0`.
+- `save_interval` must be `>= 0`.
+- `save_interval > 0` requires `storage` to be set.
+
+## Verification
+
+Confirm `drain` is in your distribution (check the component's metadata); build via OCB if it is not yet bundled.
+
+Config (`drain-verify.yaml`):
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+processors:
+  drain:
+    template_attribute: log.record.template
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [drain]
+      exporters: [debug]
+```
+
+Send log records that share structure but differ in values (see the `otel-telemetrygen` skill):
+
+```bash
+telemetrygen logs --otlp-insecure --otlp-endpoint localhost:4317 \
+  --logs 100 --body "user alice logged in from 10.0.0.1" --duration 5s
+```
+
+telemetrygen sends a **constant** body per invocation (`--body` defaults to `"the message"`), so a single run produces one template with no wildcards. To watch several distinct values collapse to one template (e.g. `user <*> logged in from <*>`), run the command a few times with different `--body` values — for example `"user bob logged in from 192.168.1.1"` and `"user carol logged in from 172.16.0.9"` — or point the pipeline at a real log source.
+
+**What proves it worked:** the `debug` exporter shows each record annotated with a `log.record.template` attribute holding the clustered template string (e.g. `user <*> logged in from <*>`).
+
+## Advanced use-cases
+
+### Persist the tree across restarts
+
+Without persistence the parse tree is rebuilt from scratch on every restart, so templates reset and warm up again. Back the processor with a storage extension and snapshot periodically:
+
+```yaml
+extensions:
+  file_storage:
+    directory: /var/lib/otelcol/drain
+
+processors:
+  drain:
+    storage: file_storage
+    save_interval: 5m
+
+service:
+  extensions: [file_storage]
+```
+
+On startup a valid snapshot is loaded (skipping `seed_templates`/`seed_logs`, and warmup if the loaded tree already satisfies `warmup_min_clusters`); `save_interval > 0` snapshots periodically; a final snapshot is always saved on shutdown. With a shared backend (Redis, a database) new instances inherit a tree trained by running instances, avoiding cold starts.
+
+### Tune cluster granularity
+
+```yaml
+processors:
+  drain:
+    tree_depth: 5          # higher → more specific templates
+    merge_threshold: 0.5   # higher → more specific templates
+```
+
+Raise `tree_depth`/`merge_threshold` for **more specific** templates (less over-merging); lower them for **more general** ones. Add `extra_delimiters` when tokens you want split are joined by non-whitespace characters such as `:` or `,`.
+
+### Suppress warmup before annotating
+
+```yaml
+processors:
+  drain:
+    warmup_min_clusters: 20
+```
+
+With `warmup_min_clusters > 0`, the processor trains on every record but does **not** write the template attribute until that many distinct clusters exist. Records still pass through immediately — no buffering, no added latency — they simply arrive unannotated during the warmup window (and are not retroactively annotated). This keeps unstable, half-trained templates from reaching downstream `filter`/`routing` rules.
+
+### Split structured tokens with `extra_delimiters`
+
+```yaml
+processors:
+  drain:
+    extra_delimiters: [":", ","]
+```
+
+Useful when values you want abstracted are glued to neighboring tokens by punctuation rather than whitespace.
+
+### Combine templates with downstream components
+
+Feed the derived template into a `filter` to drop a noisy class, a `routing` connector to fan log classes into separate pipelines, or a `log_dedup` processor to aggregate identical records with a count:
+
+```yaml
+processors:
+  drain:
+  filter/drop_noisy:
+    error_mode: ignore
+    logs:
+      log_record:
+        - attributes["log.record.template"] == "heartbeat ping <*>"
+        - attributes["log.record.template"] == "connected to <*>"
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [drain, filter/drop_noisy]
+      exporters: [otlp]
+```
+
+## Known quirks
+
+### Unbounded memory with `max_clusters: 0`
+
+The default `max_clusters: 0` means *unlimited* — active clusters and tree nodes grow with unique log patterns. On high-diversity streams this can grow without bound. Bound it with `max_clusters` (enables LRU eviction) and cap fan-out with `max_node_children`. Track `otelcol_processor_drain_clusters_active` for growth.
+
+### Warmup withholds templates
+
+When `warmup_min_clusters > 0`, the template attribute does not appear until that many clusters have been observed. If the attribute "never shows up", check `otelcol_processor_drain_clusters_active` against the threshold, or lower `warmup_min_clusters`. The warmup window is observable as `otelcol_processor_incoming_items - otelcol_processor_drain_log_records_annotated`.
+
+### Templates reset on restart without persistence
+
+The tree lives in memory. Without a `storage` extension, templates are rebuilt (and re-warmed) on every restart, and independent instances may disagree on a template during early training on low-volume or highly variable streams. Mitigate with `seed_templates`/`seed_logs`, `warmup_min_clusters`, or shared `storage`.
+
+### Structured (map) bodies
+
+If the body is a map, the full serialized form is templated by default, which yields low-value templates. Set `body_field` to the **single top-level** message key (full OTTL paths like `body["event"]["message"]` are not supported), or promote that field to a plain string body upstream (e.g. a `move` operator in the filelog receiver). The full body is used unchanged if the key is absent or the body is not a map.
+
+### Alpha stability and provisional attribute name
+
+The processor is **Alpha** — keys and behavior may change. The default `log.record.template` tracks a *proposed* (not yet adopted) semantic convention ([semantic-conventions#1283](https://github.com/open-telemetry/semantic-conventions/issues/1283), [#2064](https://github.com/open-telemetry/semantic-conventions/issues/2064)); pin `template_attribute` explicitly if you depend on the value. The internal metrics `otelcol_processor_drain_clusters_active` and `otelcol_processor_drain_log_records_annotated` are Development stability and may change or be removed.
+
+### Drain does not reduce volume
+
+It only annotates. Expecting `drain` alone to drop or aggregate logs is a common mistake — always add a `filter`/`routing` (or `log_dedup`) component downstream to act on the template.
+
+## Related components
+
+- `filter` — drop or keep logs by matching the derived template.
+- `routing` (connector) — route log classes to different pipelines by template.
+- `log_dedup` — aggregate identical logs with a count; complements template-based grouping.
+- `transform` — OTTL-based per-record transformations.
+- Storage extensions (e.g. `file_storage`) — back `storage` for snapshot persistence.

--- a/skills/otel-collector/components/drain.md
+++ b/skills/otel-collector/components/drain.md
@@ -3,13 +3,14 @@
 | | |
 |-|-|
 | Kind | processor |
+| Type | `drain` |
 | Signals | logs |
 | Stability | Alpha (processor); Development (telemetry metrics `otelcol_processor_drain_*`) |
 | Distributions | contrib, k8s |
 | Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/drainprocessor` |
 | Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/drainprocessor> |
 
-The `type` is `drain`. Logs support is Alpha since v0.151.0; configuration keys and behavior may change between releases.
+Logs support is Alpha since v0.151.0; configuration keys and behavior may change between releases.
 
 ## Description
 

--- a/skills/otel-collector/components/redaction.md
+++ b/skills/otel-collector/components/redaction.md
@@ -1,0 +1,236 @@
+# `redaction` processor
+
+| | |
+|-|-|
+| Kind | processor |
+| Signals | traces, logs, metrics |
+| Stability | Beta (traces); Alpha (logs, metrics) |
+| Distributions | contrib, k8s |
+| `type` | `redaction` |
+| Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor` |
+| Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor> |
+
+The trace path is Beta (production viable, breaking changes rare). The log and metric paths are Alpha — configuration and behavior may change between releases. The URL sanitizer and DB sanitizer are newer surface area; verify masking against representative data before relying on this processor as your only PII control.
+
+## Description
+
+An allow/block-list redaction processor that enforces a data-governance policy on the attributes flowing through a pipeline. It masks or removes sensitive attribute keys and values across span, log, and metric data points, and can additionally sanitize URLs and database query strings. Two mechanisms compose:
+
+1. **Allow-listing keys** — with `allowed_keys` set, any attribute key *not* on the list is deleted outright. This **fails closed**: an empty `allowed_keys` removes *all* attributes. Set `allow_all_keys: true` to keep every key and rely solely on value masking.
+2. **Masking values** — attribute values matching a `blocked_values` regex (or whose key matches a `blocked_key_patterns` regex) are masked with asterisks or replaced by a hash, even when the key itself is allowed.
+
+On top of attribute redaction it can **sanitize URLs** (strip high-cardinality path segments and query content) and **sanitize database queries** (SQL, Redis, Memcached, MongoDB, OpenSearch, Elasticsearch) so query text and span names don't leak literal values.
+
+The processor **modifies in place** — it never drops or reroutes telemetry. It only deletes/masks attributes and rewrites specific string values. Pair it with a downstream `filter` or routing component if you also need to drop whole records. For map-formatted log bodies, key allow-listing and value masking apply to the body too, with a separate `redaction.body.*` audit prefix.
+
+## Main use-cases
+
+Use it when:
+- Only an explicit allow list of attribute keys is permitted to leave a trust boundary (compliance, multi-tenant egress).
+- Known-sensitive values (credit cards, emails, tokens) appear in attribute values and must be masked or hashed before export.
+- URLs or DB query strings carry high-cardinality or sensitive content (IDs, tokens, literals) you want sanitized.
+- You want an audit trail of what was redacted, masked, or allowed through.
+
+Avoid it when:
+- You need general-purpose attribute editing (add/upsert/convert) — use `attributes` or `transform`.
+- You want to drop entire spans/logs/metrics — use `filter` (redaction never drops).
+- Your redaction logic needs arbitrary conditional transformation — OTTL in `transform` is more expressive (but does not fail closed).
+
+## Typical config
+
+```yaml
+processors:
+  redaction:
+    allow_all_keys: false
+    allowed_keys:
+      - http.method
+      - http.route
+      - http.status_code
+    blocked_values:
+      - '4[0-9]{12}(?:[0-9]{3})?'   # Visa-like card numbers
+    summary: info
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, redaction]
+      exporters: [otlp]
+```
+
+### Configuration reference
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `allow_all_keys` | bool | `false` | When `true`, the `allowed_keys` list is disabled and every key is kept. `blocked_values`/`blocked_key_patterns` still apply. |
+| `allowed_keys` | []string | `[]` | Keys to retain. **Fails closed** — an empty list removes *all* attributes. Any key not listed is deleted. |
+| `ignored_keys` | []string | `[]` | Keys that bypass all redaction checks (never removed, never masked). |
+| `ignored_key_patterns` | []string | `[]` | Regex patterns for keys to bypass all redaction. |
+| `blocked_key_patterns` | []string | `[]` | Regex patterns; matching keys have their **values masked** (the key is kept). |
+| `blocked_values` | []string | `[]` | Regex patterns matched against attribute **values**; matches are masked or hashed. |
+| `allowed_values` | []string | `[]` | Regex patterns for values considered safe. **Takes precedence** over `blocked_values` when both match. |
+| `redact_all_types` | bool | `false` | When `true`, non-string values are checked via their `AsString()` form against `blocked_values`. When `false`, only string values are checked. |
+| `hash_function` | string | `""` | Replace masked values with a hash instead of asterisks. One of `md5`, `sha1`, `sha3`, `hmac-sha256`, `hmac-sha512`. Empty = asterisk masking. |
+| `hmac_key` | string | `""` | Secret key for `hmac-sha256` / `hmac-sha512`. Supports env expansion (`${env:REDACTION_HMAC_KEY}`). |
+| `summary` | string | `info` | Audit verbosity: `debug` (key names + counts), `info` (counts only), `silent` (no audit attributes). |
+| `url_sanitizer.enabled` | bool | `false` | Enable URL sanitization. |
+| `url_sanitizer.attributes` | []string | `[]` | Attribute keys whose URL values are sanitized. |
+| `url_sanitizer.sanitize_span_name` | bool | `true` | Sanitize span names containing `/`. |
+| `db_sanitizer.sanitize_span_name` | bool | `true` | Sanitize database query span names. |
+| `db_sanitizer.<engine>.enabled` | bool | `false` | Enable per-engine query sanitization. `<engine>` is one of `sql`, `redis`, `memcached`, `mongo`, `opensearch`, `es`. |
+| `db_sanitizer.<engine>.attributes` | []string | `[]` | Attributes holding the query/command text for that engine. |
+
+## Verification
+
+`redaction` ships in the `contrib` and `k8s` distributions.
+
+Config (`redaction-verify.yaml`):
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+processors:
+  redaction:
+    allow_all_keys: true
+    blocked_values:
+      - '4[0-9]{12}(?:[0-9]{3})?'   # Visa-like card numbers
+    summary: info
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [redaction]
+      exporters: [debug]
+```
+
+Generate spans carrying an attribute value that matches the blocked pattern. The span-level attribute flag is `--telemetry-attributes` (resource-level `--otlp-attributes` would attach to the Resource, not the span); the value must be quoted (`key="value"`):
+
+```bash
+telemetrygen traces --otlp-insecure --otlp-endpoint localhost:4317 \
+  --traces 5 --telemetry-attributes 'cc_number="4111111111111111"'
+```
+
+**What proves it worked:** the `debug` exporter shows the matching value masked (replaced with asterisks, or hashed if `hash_function` is set) while non-matching attributes pass through; with `summary: info` the span carries a `redaction.masked.count` audit attribute (and, because nothing is removed under `allow_all_keys: true`, an `redaction.allowed.count`).
+
+## Advanced use-cases
+
+### Allowlist mode as a strict schema
+
+Set `allow_all_keys: false` and enumerate `allowed_keys` to define exactly which attribute keys may leave the boundary. Any key not on the list — including newly added, unanticipated attributes — is dropped by default. This is the strongest egress guarantee the processor offers.
+
+```yaml
+processors:
+  redaction:
+    allow_all_keys: false
+    allowed_keys:
+      - http.method
+      - http.route
+      - http.status_code
+      - service.version
+    ignored_keys:
+      - safe.attribute        # bypasses all checks
+```
+
+### Hashing for correlatable-but-masked values
+
+By default a masked value becomes a run of asterisks. Set `hash_function` when you need to **correlate** redacted values without revealing them — e.g. confirm two spans carry the same user id without storing the id. Use `hmac-sha256`/`hmac-sha512` with `hmac_key` so the hash is not a plain digest an attacker could rainbow-table.
+
+```yaml
+processors:
+  redaction:
+    allow_all_keys: true
+    blocked_values:
+      - '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'   # email
+    hash_function: hmac-sha256
+    hmac_key: ${env:REDACTION_HMAC_KEY}
+```
+
+### URL and DB query sanitization
+
+URL sanitization strips high-cardinality path segments (UUIDs, timestamps, numeric IDs) and query content from URL-valued attributes, preserving routing structure for grouping. DB sanitization rewrites query/command text (and optionally span names) so literals don't leak; it only fires on spans carrying `db.system`/`db.system.name` with `CLIENT` or `SERVER` span kind.
+
+```yaml
+processors:
+  redaction:
+    allow_all_keys: true
+    url_sanitizer:
+      enabled: true
+      attributes: [url.full, http.url]
+      sanitize_span_name: true
+    db_sanitizer:
+      sanitize_span_name: true
+      sql:
+        enabled: true
+        attributes: [db.statement, db.query.text]
+      redis:
+        enabled: true
+        attributes: [db.statement]
+```
+
+### `blocked_key_patterns` vs `blocked_values`
+
+- `blocked_key_patterns` matches **key names** (e.g. `.*token.*`); when a key matches, its value is masked but the key is kept.
+- `blocked_values` matches **value content** (e.g. a card-number regex) regardless of the key name.
+- To remove a key entirely rather than mask its value, leave it off `allowed_keys` (with key filtering enabled) instead of using `blocked_key_patterns`.
+
+### The audit summary
+
+When `summary` is not `silent`, the processor records what it did as attributes on each record (zero-count attributes are omitted):
+
+| Attribute | Verbosity | Description |
+|-----------|-----------|-------------|
+| `redaction.redacted.keys` | debug | Names of keys removed by allow-listing |
+| `redaction.redacted.count` | info | Count of removed keys |
+| `redaction.masked.keys` | debug | Names of keys whose values were masked |
+| `redaction.masked.count` | info | Count of masked values |
+| `redaction.allowed.keys` | debug | Names of keys that passed through |
+| `redaction.allowed.count` | info | Count of allowed attributes |
+| `redaction.ignored.count` | info | Count of ignored attributes |
+
+For map-formatted log bodies, the same metrics are recorded under a `redaction.body.*` prefix.
+
+## Known quirks
+
+### `allowed_keys` fails closed — the footgun
+
+With `allow_all_keys: false` (the default) and an empty `allowed_keys`, **every** attribute is dropped — allow-list semantics, not block-list. If attributes vanish unexpectedly, this is almost always why. Either enumerate the keys you want to keep in `allowed_keys`, or set `allow_all_keys: true` to disable key filtering and rely on value masking alone.
+
+### Evaluation order
+
+Attributes are evaluated in a fixed order:
+
+1. **Ignored keys** (`ignored_keys`, `ignored_key_patterns`) — always pass through untouched.
+2. **Key allow-listing** — with `allowed_keys` set (and `allow_all_keys: false`), keys not on the list are deleted.
+3. **Value matching** — surviving attributes have `blocked_values`/`blocked_key_patterns` applied. If a value matches both `blocked_values` and `allowed_values`, **`allowed_values` wins** and the value is kept.
+4. **Mask or hash** — marked values become asterisks, or a hash when `hash_function` is set.
+
+Key allow-listing is fail-closed; value matching is not. Relying only on `blocked_values` (with `allow_all_keys: true`) is a much weaker guarantee — value regexes can miss formats they weren't written for.
+
+### Masking vs. removal
+
+`blocked_key_patterns` masks the **value** of a matching key but keeps the key itself. To drop a key entirely, leave it off `allowed_keys` with key filtering enabled. `blocked_values` masks values, never removes keys.
+
+### Only string values by default
+
+`blocked_values` matches only string values unless `redact_all_types: true` is set, which checks non-string values via their `AsString()` form. Secrets stored in numeric or boolean values slip through otherwise.
+
+### `summary: debug` writes key names into telemetry
+
+`debug` verbosity records the redacted/masked/allowed **key names** as attributes. If a key name is itself sensitive, keep `summary: info` (counts only) in production and reserve `debug` for short-lived investigation.
+
+### Per-signal stability
+
+Traces are Beta; logs and metrics are Alpha. The URL sanitizer and DB sanitizer are newer surface area. Verify masking against representative log/metric data before relying on the processor as your only PII control on those signals.
+
+## Related components
+
+- `attributes` — general add/update/delete/hash of attributes (no fail-closed allow list).
+- `transform` — OTTL-based conditional transformation, including `replace_pattern` masking (does not fail closed).
+- `filter` — drops entire records (redaction never drops).
+- `resource` — manipulate resource-level attributes.

--- a/skills/otel-collector/components/redaction.md
+++ b/skills/otel-collector/components/redaction.md
@@ -3,10 +3,10 @@
 | | |
 |-|-|
 | Kind | processor |
+| Type | `redaction` |
 | Signals | traces, logs, metrics |
 | Stability | Beta (traces); Alpha (logs, metrics) |
 | Distributions | contrib, k8s |
-| `type` | `redaction` |
 | Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor` |
 | Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor> |
 

--- a/skills/otel-collector/components/tail_sampling.md
+++ b/skills/otel-collector/components/tail_sampling.md
@@ -1,0 +1,329 @@
+# `tail_sampling` processor
+
+| | |
+|-|-|
+| Kind | processor |
+| Signals | traces |
+| Stability | Beta |
+| Distributions | contrib, k8s |
+| `type` | `tail_sampling` |
+| Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor` |
+| Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor> |
+
+## Description
+
+Tail sampling buffers **all spans of a trace** (grouped automatically by `trace_id` — no `groupbytrace` needed), waits a configurable `decision_wait` for the trace to complete, then evaluates a set of policies against the **whole trace** to make a single keep/drop decision. Because the decision is made after the trace is (mostly) assembled, it can act on trace-wide signals: presence of an error on any span, total latency, span count, specific attributes, etc.
+
+This is the opposite of **head sampling** (e.g. `probabilistic_sampler`), which decides at the start of a trace based only on the trace ID — before any span content is known. Head sampling is cheap and stateless; tail sampling is content-aware but stateful, requires buffering, and adds latency.
+
+## Main use-cases
+
+Use it when:
+- You want to keep **all error traces** regardless of volume.
+- You want to keep **slow** traces (latency-based) while down-sampling fast successful ones.
+- You need different sampling rates per service, endpoint, tenant, or attribute.
+- You need sophisticated logic — combining conditions (`and`), tiered rate allocation (`composite`), or explicit noise removal (`drop`).
+
+Avoid it when:
+- Probabilistic head sampling already meets your needs (cheaper, no buffering, no co-location requirement).
+- You need the sampling decision at the edge/SDK before data reaches a collector.
+- You **cannot guarantee all spans of a trace reach the same collector instance** (see Known quirks).
+
+## Typical config
+
+```yaml
+processors:
+  tail_sampling:
+    decision_wait: 10s
+    num_traces: 50000
+    policies:
+      # Keep all error traces
+      - name: errors
+        type: status_code
+        status_code:
+          status_codes: [ERROR]
+      # Sample 10% of everything else
+      - name: baseline
+        type: probabilistic
+        probabilistic:
+          sampling_percentage: 10
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [tail_sampling]
+      exporters: [otlphttp]
+```
+
+### Configuration reference (top-level)
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `decision_wait` | duration | `30s` | Time from first span arrival before the decision is made. Buffers spans for this long. |
+| `decision_wait_after_root_received` | duration | `0s` | Decide this long after the root span arrives; `0` disables (only `decision_wait` is used). |
+| `num_traces` | int | `50000` | Max traces kept in memory. When full, the oldest are evicted (before decision) unless `block_on_overflow`. |
+| `expected_new_traces_per_sec` | int | `0` | Hint for pre-allocating the trace buffer; `0` disables pre-allocation. |
+| `sample_on_first_match` | bool | `false` | Stop evaluating and sample as soon as one policy matches. |
+| `block_on_overflow` | bool | `false` | Block ingest instead of dropping the oldest traces when `num_traces` is reached. |
+| `drop_pending_traces_on_shutdown` | bool | `false` | On shutdown, drop pending traces instead of deciding with partial data. |
+| `maximum_trace_size_bytes` | int | `0` | Traces larger than this are dropped immediately; `0` disables. |
+| `decision_cache.sampled_cache_size` | int | `0` | LRU cache of sampled trace IDs so late spans inherit the decision; `0` disables. |
+| `decision_cache.non_sampled_cache_size` | int | `0` | LRU cache of dropped trace IDs; `0` disables. |
+| `policies` | list | (required) | Sampling policies. At least one is required. |
+
+### Policy types
+
+Each policy has `name` and `type`, plus a config block named after the type.
+
+| `type` | Purpose |
+|--------|---------|
+| `always_sample` | Sample every trace (catch-all / debugging). No sub-config. |
+| `latency` | Sample by total trace duration (earliest start to latest end). |
+| `numeric_attribute` | Sample when a numeric span/resource attribute is within a range. |
+| `probabilistic` | Sample a fixed percentage of traces via trace-ID hash. |
+| `status_code` | Sample if any span has a matching status code. |
+| `string_attribute` | Sample by string span/resource attribute value (exact or regex). |
+| `rate_limiting` | Sample up to a maximum spans-per-second. |
+| `span_count` | Sample by number of spans in the trace. |
+| `trace_state` | Sample by W3C TraceState key/value. |
+| `boolean_attribute` | Sample by boolean attribute value. |
+| `ottl_condition` | Sample when OTTL conditions on spans/span-events match. |
+| `and` | Combine sub-policies with AND — all must match to sample. |
+| `composite` | Combine sub-policies with priority order and per-policy rate allocation. |
+| `drop` | Force-drop traces where all sub-policies match; takes precedence over sampling. |
+
+Key sub-fields for the common policies:
+
+```yaml
+# latency: minimum (and optional maximum) trace duration
+- name: slow
+  type: latency
+  latency:
+    threshold_ms: 1000
+    upper_threshold_ms: 5000   # optional; 0 = no upper bound
+
+# numeric_attribute: span or resource attribute within a range
+- name: http-errors
+  type: numeric_attribute
+  numeric_attribute:
+    key: http.response.status_code
+    min_value: 400
+    max_value: 599
+
+# string_attribute: exact or regex match
+- name: by-route
+  type: string_attribute
+  string_attribute:
+    key: http.route
+    values: ["/api/users", "^/api/.*"]
+    enabled_regex_matching: false   # treat values as regex when true
+    invert_match: false             # sample traces that do NOT match
+
+# status_code: OK / ERROR / UNSET
+- name: errors
+  type: status_code
+  status_code:
+    status_codes: [ERROR]
+
+# probabilistic: percentage via trace-ID hash
+- name: baseline
+  type: probabilistic
+  probabilistic:
+    sampling_percentage: 10.0
+
+# rate_limiting: cap spans per second
+- name: cap
+  type: rate_limiting
+  rate_limiting:
+    spans_per_second: 1000
+```
+
+#### Decision precedence
+
+All policies are evaluated (unless `sample_on_first_match: true`), then a single decision is chosen: a `drop` decision wins over everything; otherwise any `sample` decision keeps the trace; if no policy matches, the trace is **not** sampled.
+
+> **`invert_match` note:** as of recent contrib releases the legacy "inverted decisions" are disabled — `invert_match: true` now yields a plain sample/not-sample on the negated condition and no longer vetoes other policies. To explicitly suppress traces, use a `drop` policy instead.
+
+## Verification
+
+`tail_sampling` ships in the `contrib` and `k8s` distributions.
+
+Config (`tailsampling-verify.yaml`):
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+processors:
+  tail_sampling:
+    decision_wait: 5s
+    num_traces: 1000
+    policies:
+      - name: errors-only
+        type: status_code
+        status_code:
+          status_codes: [ERROR]
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [tail_sampling]
+      exporters: [debug]
+```
+
+Generate traces, some with error status (see the `otel-telemetrygen` skill):
+
+```bash
+# OK traces — expect these to be dropped by the errors-only policy
+telemetrygen traces --otlp-insecure --otlp-endpoint localhost:4317 --traces 20
+# Error traces — expect these to survive
+telemetrygen traces --otlp-insecure --otlp-endpoint localhost:4317 --traces 20 --status-code Error
+```
+
+The `--status-code Error` flag is confirmed in the `otel-telemetrygen` skill (accepted values: `Unset`/`0`, `Error`/`1`, `Ok`/`2`). It sets the span status to ERROR, which the `status_code` policy matches.
+
+**What proves it worked:** after `decision_wait`, the `debug` exporter shows the error traces and not the OK traces.
+
+## Advanced use-cases
+
+### `and` — require multiple conditions
+
+Sample only traces that are **both** an error **and** slow:
+
+```yaml
+- name: slow-errors
+  type: and
+  and:
+    and_sub_policy:
+      - name: has-error
+        type: status_code
+        status_code:
+          status_codes: [ERROR]
+      - name: is-slow
+        type: latency
+        latency:
+          threshold_ms: 1000
+```
+
+`and` accepts all policy types except `composite`, `and`, and `drop`.
+
+### `composite` — tiered sampling with rate allocation
+
+Allocate a total spans-per-second budget across policies in priority order:
+
+```yaml
+- name: tiered
+  type: composite
+  composite:
+    max_total_spans_per_second: 1000
+    policy_order: [errors, slow, sample-rest]
+    composite_sub_policy:
+      - name: errors
+        type: status_code
+        status_code:
+          status_codes: [ERROR]
+      - name: slow
+        type: latency
+        latency:
+          threshold_ms: 1000
+      - name: sample-rest
+        type: always_sample
+    rate_allocation:
+      - policy: errors
+        percent: 60
+      - policy: slow
+        percent: 30
+      # sample-rest uses the remaining 10%
+```
+
+Each sub-policy gets `(percent/100) * max_total_spans_per_second`; the first matching policy under budget samples the trace. Put an `always_sample` last to use leftover capacity.
+
+### Combining policies and dropping noise
+
+Order policies by intent: force-drop noise first (`drop`), then keep errors, then service-specific rules, then a probabilistic baseline. Any `sample` decision keeps the trace unless a `drop` policy fired.
+
+```yaml
+policies:
+  - name: drop-health
+    type: drop
+    drop:
+      drop_sub_policy:
+        - name: health-routes
+          type: string_attribute
+          string_attribute:
+            key: http.route
+            values: ["^/health$", "^/ready$", "^/metrics$"]
+            enabled_regex_matching: true
+  - name: errors
+    type: status_code
+    status_code:
+      status_codes: [ERROR]
+  - name: baseline
+    type: probabilistic
+    probabilistic:
+      sampling_percentage: 1
+```
+
+### Scaling horizontally with the `loadbalancing` exporter
+
+A single tail-sampling instance only works while every span of a trace lands on it. To run **more than one** tail-sampling collector you need a front layer of collectors using the `loadbalancing` exporter with `routing_key: traceID`, so all spans of a given trace are routed to the **same** downstream tail-sampling instance:
+
+```yaml
+# Layer 1 — routing collectors (any number of replicas)
+exporters:
+  loadbalancing:
+    routing_key: traceID
+    protocol:
+      otlp:
+        tls:
+          insecure: true
+    resolver:
+      dns:
+        hostname: tail-sampling-layer
+        port: 4317
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [loadbalancing]
+
+# Layer 2 — tail-sampling collectors (behind the DNS name above)
+processors:
+  tail_sampling:
+    decision_wait: 30s
+    num_traces: 100000
+    policies: [ ... ]
+```
+
+For high-volume systems also size `decision_cache` larger than `num_traces` so late-arriving spans inherit the prior decision instead of forming a new (partial) trace.
+
+## Known quirks
+
+### All spans of a trace must reach the SAME instance
+
+The decision is made per-trace inside one process. If spans of one trace are spread across multiple tail-sampling collectors, each sees only a fragment and makes its own (wrong/partial) decision. Whenever you run more than one tail-sampling collector you **must** put a `loadbalancing` exporter layer in front that routes by `traceID`. A single instance needs no load balancer.
+
+### Memory scales with `num_traces` and trace size
+
+`num_traces` is the in-flight trace buffer: every trace awaiting a decision is held in memory. Rough estimate `num_traces * avg_spans_per_trace * ~1KB/span` (e.g. 50,000 traces × 20 spans ≈ 1 GB). Longer `decision_wait` means more traces resident at once. When the buffer fills, the oldest traces are evicted **before** their decision (surfacing as the `sampling_trace_dropped_too_early` metric) unless `block_on_overflow` is set. Size it as `traces_per_sec * decision_wait_seconds * safety_factor`.
+
+### `decision_wait` adds latency and a fixed window
+
+Sampled traces are only exported after `decision_wait` expires, so this delay is added before any trace leaves the processor. Set it long enough for distributed traces to assemble; too short and late spans miss the window. Spans that arrive **after** the decision are not retroactively folded into it — they either inherit the cached decision (if `decision_cache` is configured) or risk forming a separate/dropped partial trace.
+
+### Stateful, single-process decision
+
+Tail sampling is inherently stateful: the keep/drop choice is computed once, in one process, from whatever spans were buffered at decision time. There is no cross-instance coordination and no re-evaluation of a trace once decided. Place context-enriching processors (e.g. `k8sattributes`) **before** `tail_sampling` in the pipeline, since the processor re-batches spans and downstream context can be lost.
+
+## Related components
+
+- `probabilistic_sampler` — head sampling; stateless, trace-ID based, decided up front. Cheaper but content-blind.
+- `loadbalancing` exporter — routes spans by `traceID` so all spans of a trace reach the same tail-sampling instance; required when scaling tail sampling to more than one collector.
+- `groupbytrace` — groups spans by trace ID and waits before forwarding. Not needed in front of `tail_sampling`, which already groups by trace ID internally.

--- a/skills/otel-collector/components/tail_sampling.md
+++ b/skills/otel-collector/components/tail_sampling.md
@@ -85,12 +85,15 @@ Each policy has `name` and `type`, plus a config block named after the type.
 | `status_code` | Sample if any span has a matching status code. |
 | `string_attribute` | Sample by string span/resource attribute value (exact or regex). |
 | `rate_limiting` | Sample up to a maximum spans-per-second. |
+| `bytes_limiting` | Sample up to a maximum bytes-per-second via a token bucket; `bytes_per_second` (required) + `burst_capacity` (optional, default 2× the rate). |
 | `span_count` | Sample by number of spans in the trace. |
 | `trace_state` | Sample by W3C TraceState key/value. |
+| `trace_flags` | Sample if the W3C `sampled` flag is set on any span; config `flags: ["sampled"]`. |
 | `boolean_attribute` | Sample by boolean attribute value. |
 | `ottl_condition` | Sample when OTTL conditions on spans/span-events match. |
 | `and` | Combine sub-policies with AND — all must match to sample. |
 | `composite` | Combine sub-policies with priority order and per-policy rate allocation. |
+| `not` | Invert the decision of a single wrapped sub-policy via `not_sub_policy`. |
 | `drop` | Force-drop traces where all sub-policies match; takes precedence over sampling. |
 
 Key sub-fields for the common policies:
@@ -143,7 +146,7 @@ Key sub-fields for the common policies:
 
 All policies are evaluated (unless `sample_on_first_match: true`), then a single decision is chosen: a `drop` decision wins over everything; otherwise any `sample` decision keeps the trace; if no policy matches, the trace is **not** sampled.
 
-> **`invert_match` note:** as of recent contrib releases the legacy "inverted decisions" are disabled — `invert_match: true` now yields a plain sample/not-sample on the negated condition and no longer vetoes other policies. To explicitly suppress traces, use a `drop` policy instead.
+> **`invert_match` note:** as of recent contrib releases the legacy "inverted decisions" are disabled — `invert_match: true` now yields a plain sample/not-sample on the negated condition and no longer vetoes other policies. To explicitly suppress traces, use a `drop` policy; to sample on the opposite of a wrapped policy's decision, use a `not` policy instead.
 
 ## Verification
 

--- a/skills/otel-collector/components/tail_sampling.md
+++ b/skills/otel-collector/components/tail_sampling.md
@@ -3,10 +3,10 @@
 | | |
 |-|-|
 | Kind | processor |
+| Type | `tail_sampling` |
 | Signals | traces |
 | Stability | Beta |
 | Distributions | contrib, k8s |
-| `type` | `tail_sampling` |
 | Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor` |
 | Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor> |
 


### PR DESCRIPTION
Adds four new cost/quality component pages on the canonical 8-section template, and indexes them in `SKILL.md`.

**Stacked on #46 (Phase 1)** — review/merge that first; this PR's base is the Phase 1 branch and will auto-retarget to `main` once #46 merges.

## New component pages
- **`cardinality_guardian`** (metrics, Development) — detects per-label cardinality growth, strips/tags the offending label; documents the single-writer-violation footgun in enforcement mode.
- **`tail_sampling`** (traces, Beta) — full top-level config + all 17 policy types; quirks cover the same-instance / loadbalancing requirement and `num_traces` memory.
- **`drain`** (logs, Alpha) — Drain log-template clustering; full config table + persistence/warmup quirks.
- **`redaction`** (traces Beta, logs/metrics Alpha) — allow/block-list masking, hashing, URL/DB sanitizers; documents the allowlist footgun.
- **`SKILL.md`** — four index rows, generalized stability note, new frontmatter trigger keywords.

Config sourced from current upstream contrib docs; every `telemetrygen` flag in the verification recipes was checked against the `otel-telemetrygen` skill.

Tracked in Linear **E-2199**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded OpenTelemetry Collector skill documentation with enhanced stability guidance and expanded processor index
  * Added comprehensive documentation for four new processors: cardinality_guardian (metric cardinality monitoring), drain (log clustering), redaction (attribute masking/sanitization), and tail_sampling (trace filtering)
  * Each processor includes configuration examples, verification procedures, and advanced usage scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->