### PR TITLE
otel-collector: add filter component (per-component directory)

### DIFF
--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: otel-collector
-description: OpenTelemetry Collector component configuration. Use when authoring, reviewing, or debugging Collector YAML for a specific receiver, processor, exporter, connector, or extension — config keys, defaults, validation rules, signal support, stability levels, and component-level gotchas. Triggers on questions about specific components such as `log_dedup` / `logdedup`, `interval` (metric aggregation), `tail_sampling`, `drain`, `redaction`, and other Collector components covered in `components/`.
+description: OpenTelemetry Collector component configuration. Use when authoring, reviewing, or debugging Collector YAML for a specific receiver, processor, exporter, connector, or extension — config keys, defaults, validation rules, signal support, stability levels, and component-level gotchas. Triggers on questions about specific components such as `log_dedup` / `logdedup`, `interval` (metric aggregation), `tail_sampling`, `drain`, `redaction`, `filter`, and other Collector components covered in `components/`.
 ---
 
 # OpenTelemetry Collector
@@ -28,6 +28,7 @@ Each component is a directory under `components/<type>/`. The `File` column poin
 | `tail_sampling` | `components/tail_sampling/README.md` | processor | traces | Beta | Buffers whole traces and makes a single keep/drop decision after a wait window via policies. Requires a loadbalancing layer to scale across instances. |
 | `drain` | `components/drain/README.md` | processor | logs | Alpha | Clusters log bodies with the Drain algorithm and annotates each record with a derived template string. |
 | `redaction` | `components/redaction/README.md` | processor | traces, logs, metrics | Beta (traces), Alpha (logs/metrics) | Allow/block-list masking or removal of sensitive attribute keys and values, with hashing and URL/DB sanitizers. |
+| `filter` | `components/filter/README.md` | processor | traces, metrics, logs | Alpha | Drops spans, metric data points, and log records that match OTTL conditions (or legacy metric-name / severity filters). The most direct telemetry-volume lever. |
 
 ## Collector-wide conventions
 

--- a/skills/otel-collector/components/filter/README.md
+++ b/skills/otel-collector/components/filter/README.md
@@ -1,0 +1,43 @@
+# `filter` processor
+
+| | |
+|-|-|
+| Kind | processor |
+| Type | `filter` |
+| Signals | traces (Alpha), metrics (Alpha), logs (Alpha), profiles (Development) |
+| Distributions | core, contrib, k8s |
+| Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor` |
+| Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor> |
+
+## Description
+
+Drops telemetry — spans, span events, metrics, datapoints, log records (and, in development, profiles) — from a pipeline when it matches an OTTL condition or a legacy metric-name/attribute matcher. Conditions are evaluated per item; when any condition for a given context evaluates to `true`, that item is dropped. Multiple conditions in the same context are ORed together. Filtering is hierarchical: if a higher-level item is dropped (e.g. a span), the lower-level conditions for it (e.g. its span events) are not evaluated.
+
+OTTL is the modern, recommended approach; the per-signal blocks (`traces`, `metrics`, `logs`) carry the condition lists. The top-level `error_mode` controls what happens when a condition fails to evaluate — `propagate` (default) fails the batch, `ignore` logs and continues, `silent` continues without logging. A legacy include/exclude form survives for metrics and logs but cannot be combined with OTTL conditions for the same signal.
+
+## Main use-cases
+
+Use it when:
+- You want to drop noise outright — health-check spans, debug/trace logs, internal or test-environment metrics.
+- You need to reduce backend volume by removing low-value signals at the collector.
+- You want to strip telemetry by resource attribute (environment, service, pod) before it leaves the pipeline.
+
+Avoid it when:
+- You want to **modify** rather than drop telemetry — use `transform`.
+- You need a content-aware keep/drop decision over a **whole trace** (errors, latency) — use `tail_sampling`.
+- Dropping would orphan child spans or break trace/log correlation (see [Known quirks](quirks.md)).
+
+## Related components
+
+- `transform` — rewrites telemetry via OTTL instead of dropping it; same expression language.
+- `attributes` / `resource` — add or modify the attributes that filter conditions match on (run before `filter`).
+- `tail_sampling` — trace-wide, content-aware keep/drop sampling for traces.
+- `probabilistic_sampler` — stateless head sampling by trace ID.
+- `routing` — sends telemetry to different pipelines by condition rather than dropping it.
+
+## Details
+
+- [Configuration](configuration.md) — `error_mode`, the per-signal OTTL contexts (`traces.span`, `traces.spanevent`, `metrics.metric`, `metrics.datapoint`, `logs.log_record`), and the legacy include/exclude form.
+- [Verification](verification.md) — telemetrygen recipe that drops a subset of logs by severity so the drop is observable.
+- [Advanced use-cases](advanced.md) — combining conditions, `error_mode`, metric/datapoint filtering, resource-attribute filters, OTTL functions, named instances.
+- [Known quirks](quirks.md) — orphaned telemetry, the drop-last-datapoint rule, error-mode behavior, stability caveats, anti-patterns, troubleshooting.

--- a/skills/otel-collector/components/filter/advanced.md
+++ b/skills/otel-collector/components/filter/advanced.md
@@ -1,0 +1,121 @@
+# `filter`: advanced use-cases
+
+## Combining conditions
+
+Conditions within a context are ORed — any match drops the item. Use `and`/`or`/`not()` and parentheses inside a single condition for AND logic:
+
+```yaml
+processors:
+  filter:
+    error_mode: ignore
+    traces:
+      span:
+        # OR across the list — drop either name
+        - 'name == "readiness"'
+        - 'name == "liveness"'
+        # AND within one condition — short, successful spans only
+        - '(end_time - start_time) < Duration("10ms") and status.code == STATUS_CODE_OK'
+```
+
+## error_mode
+
+```yaml
+# Development: catch broken conditions immediately
+processors:
+  filter:
+    error_mode: propagate   # a failing condition drops the whole batch
+
+# Production: a bad condition logs but does not drop unrelated data
+processors:
+  filter:
+    error_mode: ignore
+
+# Noisy environments: continue without logging the error at all
+processors:
+  filter:
+    error_mode: silent
+```
+
+## Metric and datapoint filtering
+
+Drop whole metrics by name or type (cheapest), or individual datapoints by value/attribute:
+
+```yaml
+processors:
+  filter:
+    error_mode: ignore
+    metrics:
+      metric:
+        - 'IsMatch(name, "internal\\..*")'
+        - 'type == METRIC_DATA_TYPE_HISTOGRAM'
+        # metric-only converters (must run in the metric context)
+        - 'HasAttrKeyOnDatapoint("internal")'
+        - 'HasAttrOnDatapoint("environment", "test")'
+      datapoint:
+        - 'metric.name == "k8s.pod.phase" and value_int == 4'
+```
+
+Filter at `metric` level when you want to drop the whole series — it is cheaper than evaluating every datapoint. See [Known quirks](quirks.md) for the drop-last-datapoint rule.
+
+## Filtering by resource attribute
+
+Resource attributes are visible in every context, so the same condition shape works across signals — useful for stripping an environment or service wholesale:
+
+```yaml
+processors:
+  filter:
+    error_mode: ignore
+    traces:
+      span:
+        - 'resource.attributes["deployment.environment"] == "dev"'
+    metrics:
+      metric:
+        - 'resource.attributes["deployment.environment"] == "dev"'
+    logs:
+      log_record:
+        - 'resource.attributes["deployment.environment"] == "dev"'
+```
+
+## OTTL function usage
+
+The processor exposes the standard OTTL converters (see the `otel-ottl` skill) plus the two metric-only functions above:
+
+```yaml
+processors:
+  filter:
+    error_mode: ignore
+    traces:
+      span:
+        - 'IsMatch(resource.attributes["k8s.pod.name"], "canary-.*")'
+    logs:
+      log_record:
+        - 'IsMatch(body, ".*(password|secret|api[_-]?key).*")'
+        - 'attributes["http.request.method"] == nil'
+```
+
+## Named instances
+
+```yaml
+processors:
+  filter/health:
+    error_mode: ignore
+    traces:
+      span:
+        - 'name == "health_check"'
+  filter/debug-logs:
+    error_mode: ignore
+    logs:
+      log_record:
+        - 'severity_number < SEVERITY_NUMBER_INFO'
+
+service:
+  pipelines:
+    traces:
+      processors: [memory_limiter, filter/health]
+    logs:
+      processors: [memory_limiter, filter/debug-logs]
+```
+
+## OTTL context
+
+The condition fields evaluate in their per-signal contexts (span, spanevent, metric, datapoint, log). Path and converter inventories live in the `otel-ottl` skill; the field summary per context is in [configuration.md](configuration.md).

--- a/skills/otel-collector/components/filter/configuration.md
+++ b/skills/otel-collector/components/filter/configuration.md
@@ -1,0 +1,93 @@
+# `filter`: configuration
+
+## Typical config
+
+```yaml
+processors:
+  filter:
+    error_mode: ignore
+    traces:
+      span:
+        - 'name == "health_check"'
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, filter]
+      exporters: [otlphttp]
+```
+
+## Top-level keys
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `error_mode` | string | `propagate` | How OTTL condition-evaluation errors are handled: `propagate`, `ignore`, or `silent`. See [Error mode](#error-mode). |
+| `traces` | block | — | Trace conditions (`span`, `spanevent`). |
+| `metrics` | block | — | Metric conditions (`metric`, `datapoint`) or legacy `include`/`exclude`. |
+| `logs` | block | — | Log conditions (`log_record`) or legacy `include`/`exclude`. |
+
+> A `processor.filter.defaultErrorModeIgnore` feature gate (alpha, disabled by default, v0.150.0+) flips the default `error_mode` from `propagate` to `ignore`. Until it is enabled, the default is `propagate`.
+
+## Per-signal OTTL conditions
+
+Each field below takes a list of OTTL boolean expressions. An item is **dropped** when any condition in its context evaluates to `true`. The expression language itself — operators, paths, converter functions — is covered in the `otel-ottl` skill; only the filter-specific surface is described here.
+
+| Field | OTTL context | Drops | Representative fields |
+|-------|--------------|-------|-----------------------|
+| `traces.span` | span | a span | `name`, `attributes[...]`, `status.code`, `kind`, `start_time`, `end_time`, `resource.attributes[...]`, `instrumentation_scope` |
+| `traces.spanevent` | spanevent | a span event | `name`, `attributes[...]`, `time_unix_nano`, plus the enclosing span's fields |
+| `metrics.metric` | metric | a whole metric | `name`, `description`, `unit`, `type`, `aggregation_temporality`, `resource.attributes[...]` |
+| `metrics.datapoint` | datapoint | a single datapoint | `attributes[...]`, `value_int`, `value_double`, `time_unix_nano`, `metric.name`, `metric.type` |
+| `logs.log_record` | log | a log record | `body`, `attributes[...]`, `severity_number`, `severity_text`, `resource.attributes[...]`, `instrumentation_scope` |
+
+**OTTL-context note:** each field evaluates in its own context. You cannot reference span fields from a `spanevent` condition's top level except through the span context the spanevent inherits, and metric-level fields (`name`, `type`) are reachable from `datapoint` only via `metric.name` / `metric.type`. Two metric-only converters are added by this processor and must run in the `metrics.metric` context: `HasAttrKeyOnDatapoint(key)` (true if any datapoint carries that attribute key) and `HasAttrOnDatapoint(key, value)` (true if any datapoint has that string key/value).
+
+Hierarchy: if a span is dropped, its `spanevent` conditions are not evaluated; if all datapoints of a metric are dropped, the metric is removed too. See [Known quirks](quirks.md).
+
+## Error mode
+
+| Mode | Behavior | When |
+|------|----------|------|
+| `propagate` | Returns the error up the pipeline, dropping the whole payload. | **Default.** Development/testing — surfaces config mistakes immediately. |
+| `ignore` | Logs the error and moves to the next condition. | **Recommended in production** — a bad condition won't drop unrelated data. |
+| `silent` | Continues without logging. | When error logging is too noisy. |
+
+## Legacy include/exclude (metrics and logs only)
+
+The pre-OTTL form still works but **cannot be combined with OTTL conditions for the same signal**. Prefer OTTL for new configs.
+
+Metrics — match by name and/or resource attribute:
+
+```yaml
+metrics:
+  include:
+    match_type: strict   # or regexp
+    metric_names:
+      - "system.cpu.utilization"
+    resource_attributes:
+      - key: "env"
+        value: "production"
+  exclude:
+    match_type: regexp
+    metric_names:
+      - "internal\\..*"
+```
+
+Logs — match by severity, body, or attribute:
+
+```yaml
+logs:
+  include:
+    match_type: strict   # or regexp
+    severity_number:
+      min: "INFO"
+      match_undefined: true
+    bodies:
+      - ".*error.*"
+    record_attributes:
+      - key: "user_id"
+        value: ".*"
+```
+
+Semantics: `include` alone keeps only matches; `exclude` alone drops matches; both means `include` is applied first, then `exclude`. `match_type` is `strict` (exact) or `regexp`. For metrics, a `regexp` block (`cacheenabled`, `cachemaxnumentries`) tunes the regex cache when `match_type: regexp`.

--- a/skills/otel-collector/components/filter/configuration.md
+++ b/skills/otel-collector/components/filter/configuration.md
@@ -45,6 +45,8 @@ Each field below takes a list of OTTL boolean expressions. An item is **dropped*
 
 Hierarchy: if a span is dropped, its `spanevent` conditions are not evaluated; if all datapoints of a metric are dropped, the metric is removed too. See [Known quirks](quirks.md).
 
+> Two surfaces are intentionally not detailed here: an **inferred-context** condition form (`trace_conditions` / `metric_conditions` / `log_conditions`, v0.146.0+) that lets a single list span multiple contexts, and a **`profiles.profile`** block (Development stability). Both are documented in the [upstream README](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor) if you need them.
+
 ## Error mode
 
 | Mode | Behavior | When |

--- a/skills/otel-collector/components/filter/quirks.md
+++ b/skills/otel-collector/components/filter/quirks.md
@@ -1,0 +1,78 @@
+# `filter`: known quirks
+
+## Data is permanently dropped
+
+`filter` removes data from the pipeline; there is no recovery downstream. Test conditions with `error_mode: propagate` and `debug` logging before rolling out.
+
+## Dropping a metric's only datapoint removes the metric
+
+Filtering at the `datapoint` level that empties a metric also removes the metric — if all datapoints of a metric match, the whole metric disappears. Likewise, if all telemetry for a resource is dropped, the resource is removed from the payload, and if all span events of a span are dropped the span itself survives (only the events go). Be deliberate about which level you filter at.
+
+## Orphaned telemetry / broken trace completeness
+
+- Dropping a **parent** span orphans its children — they remain in the trace but point at a span that no longer exists, which breaks waterfall views.
+- Dropping spans that logs reference (via trace/span ID) breaks log↔trace correlation.
+- Dropping arbitrary spans makes a trace incomplete. When you need a whole-trace keep/drop decision, use `tail_sampling`, not `filter`.
+
+## error_mode behavior
+
+- Default is `propagate`: a single failing condition (e.g. a type mismatch or a nil dereference) **drops the entire batch**, not just the offending item. This surprises people in production — set `error_mode: ignore` there.
+- `silent` hides evaluation errors entirely; if a filter "isn't working," confirm it isn't set to `silent`.
+- The `processor.filter.defaultErrorModeIgnore` feature gate can flip the default to `ignore`; don't assume the default without checking whether the gate is enabled.
+
+## Stability caveats
+
+All signals are **Alpha** (profiles are **Development**). Config keys can still change between releases, and profile filtering may break. Check the upstream README for the running version before treating any key as stable.
+
+## Troubleshooting
+
+**Nothing is dropped.**
+- Wrong context — span fields used in a `spanevent` block, or metric fields used directly in `datapoint` (use `metric.name`).
+- Attribute doesn't exist — add a nil check: `attributes["x"] != nil and attributes["x"] == "y"`.
+- `error_mode: silent` is swallowing evaluation errors — switch to `propagate` while debugging.
+
+**Everything is dropped.**
+- Overly broad condition (`IsMatch(name, ".*")` matches all). Tighten it and re-test with debug logging.
+
+**Validation error: `cannot use ottl conditions and include/exclude ... at the same time`.**
+- You mixed OTTL conditions and legacy include/exclude for the same signal. Pick one.
+
+**Verifying effectiveness.** The processor emits `processor_filter_spans.filtered`, `processor_filter_datapoints.filtered`, `processor_filter_logs.filtered` (and `processor_filter_profiles.filtered`, development) — watch these to confirm drops.
+
+## Anti-patterns
+
+**Datapoint-level filtering when a whole metric should go.**
+
+```yaml
+# Less efficient — evaluates every datapoint
+metrics:
+  datapoint:
+    - 'resource.attributes["env"] == "test"'
+
+# Prefer — drops the whole metric in one check
+metrics:
+  metric:
+    - 'resource.attributes["env"] == "test"'
+```
+
+**Dropping parent/correlated spans.**
+
+```yaml
+# Risky — orphans children, breaks log correlation
+traces:
+  span:
+    - 'kind == SPAN_KIND_SERVER'
+```
+
+Filter leaf/noise spans, or move whole-trace decisions to `tail_sampling`.
+
+**Complex negative-lookahead regex.**
+
+```yaml
+# Hard to maintain, error-prone
+logs:
+  log_record:
+    - 'IsMatch(body, "^(?!.*(error|warn|fail)).*$")'
+```
+
+Prefer explicit positive conditions (`severity_number < SEVERITY_NUMBER_WARN`).

--- a/skills/otel-collector/components/filter/verification.md
+++ b/skills/otel-collector/components/filter/verification.md
@@ -1,0 +1,45 @@
+# `filter`: verification
+
+See [Verification harness](../../SKILL.md#verification-harness) for how to run this end-to-end.
+
+`filter` ships in the `core`, `contrib`, and `k8s` distributions, so a stock contrib collector can run this.
+
+Config (`filter-verify.yaml`) — drop `ERROR`-and-above logs, let everything below pass:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+processors:
+  filter:
+    error_mode: ignore
+    logs:
+      log_record:
+        - 'severity_number >= SEVERITY_NUMBER_ERROR'
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [filter]
+      exporters: [debug]
+```
+
+Send two batches — one that the condition matches (dropped) and one that it doesn't (kept) — see the `otel-telemetrygen` skill:
+
+```bash
+# Info logs (severity 9) — below ERROR, expect these to survive
+telemetrygen logs --otlp-insecure --otlp-endpoint localhost:4317 \
+  --logs 10 --severity-number 9 --body "info log keep me"
+# Error logs (severity 17) — at/above ERROR, expect these to be dropped
+telemetrygen logs --otlp-insecure --otlp-endpoint localhost:4317 \
+  --logs 10 --severity-number 17 --body "error log drop me"
+```
+
+Flags confirmed against the `otel-telemetrygen` skill (`references/flags.md`): `--otlp-insecure`, `--otlp-endpoint`, `--logs`, `--severity-number` (int32, 1–24; 9=Info, 17=Error per the severity-number reference), and `--body`. No `--duration` here — telemetrygen ignores `--logs` when `--duration` is set, so the count would not be 10.
+
+**What proves it worked:** the `debug` exporter prints the 10 Info records ("info log keep me") and **none** of the 10 Error records ("error log drop me"). Fewer records reach `debug` than were sent, and only the non-matching severity survives.


### PR DESCRIPTION
Adds the `filter` processor to the otel-collector skill — **Phase 3, backlog item #1** (the most direct telemetry-volume lever).

Per-component directory: lean `README.md` + `configuration.md` / `verification.md` / `advanced.md` / `quirks.md`, following the structure from #50/#52. Sourced from the `telemetrydrops/ai-context` filterprocessor README.

## Verified end-to-end
Ran the verification recipe against contrib v0.152.0 + telemetrygen: a `severity_number >= SEVERITY_NUMBER_ERROR` log filter dropped all 10 error logs and kept all 10 info logs at the `debug` exporter. ✅ All telemetrygen flags confirmed against the `otel-telemetrygen` skill.

## SKILL.md
Index row added (`components/filter/README.md`) + `filter` frontmatter trigger keyword.

Closes ENG-2202. Part of the Phase 3 backlog (E-2201).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the filter processor, including configuration options, advanced condition writing techniques, detailed behavioral quirks and edge cases, and verification procedures to help users properly configure and troubleshoot filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->