### PR TITLE
otel-collector: add transform component (per-component directory)

### DIFF
--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: otel-collector
-description: OpenTelemetry Collector component configuration. Use when authoring, reviewing, or debugging Collector YAML for a specific receiver, processor, exporter, connector, or extension — config keys, defaults, validation rules, signal support, stability levels, and component-level gotchas. Triggers on questions about specific components such as `log_dedup` / `logdedup`, `interval` (metric aggregation), `tail_sampling`, `drain`, `redaction`, `filter`, and other Collector components covered in `components/`.
+description: OpenTelemetry Collector component configuration. Use when authoring, reviewing, or debugging Collector YAML for a specific receiver, processor, exporter, connector, or extension — config keys, defaults, validation rules, signal support, stability levels, and component-level gotchas. Triggers on questions about specific components such as `log_dedup` / `logdedup`, `interval` (metric aggregation), `tail_sampling`, `drain`, `redaction`, `filter`, `transform`, and other Collector components covered in `components/`.
 ---
 
 # OpenTelemetry Collector
@@ -29,6 +29,7 @@ Each component is a directory under `components/<type>/`. The `File` column poin
 | `drain` | `components/drain/README.md` | processor | logs | Alpha | Clusters log bodies with the Drain algorithm and annotates each record with a derived template string. |
 | `redaction` | `components/redaction/README.md` | processor | traces, logs, metrics | Beta (traces), Alpha (logs/metrics) | Allow/block-list masking or removal of sensitive attribute keys and values, with hashing and URL/DB sanitizers. |
 | `filter` | `components/filter/README.md` | processor | traces, metrics, logs | Alpha | Drops spans, metric data points, and log records that match OTTL conditions (or legacy metric-name / severity filters). The most direct telemetry-volume lever. |
+| `transform` | `components/transform/README.md` | processor | traces, metrics, logs | Beta | Applies OTTL statements to mutate spans, metric data points, and log records in place (rename/redact/convert/aggregate attributes). The OTTL language itself lives in the `otel-ottl` skill. |
 
 ## Collector-wide conventions
 

--- a/skills/otel-collector/components/transform/README.md
+++ b/skills/otel-collector/components/transform/README.md
@@ -1,0 +1,44 @@
+# `transform` processor
+
+| | |
+|-|-|
+| Kind | processor |
+| Type | `transform` |
+| Signals | traces (Beta), metrics (Beta), logs (Beta), profiles (Development) |
+| Distributions | contrib, k8s |
+| Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor` |
+| Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor> |
+
+## Description
+
+Mutates telemetry — spans, span events, metrics, datapoints, log records (and, in development, profiles) — **in place** by running OTTL statements against it. You supply a per-signal list of statements (`trace_statements`, `metric_statements`, `log_statements`); each statement executes sequentially against incoming data, optionally guarded by a `where` clause. Unlike `filter`, which drops items, `transform` rewrites them: set, delete, rename, redact, convert types, parse structured fields, and more.
+
+The top-level `error_mode` controls what happens when a statement fails to evaluate — `propagate` (default) drops the whole payload, `ignore` logs and continues to the next statement, `silent` continues without logging. Statement groups run in the order written, so later statements see the effects of earlier ones. The OTTL language itself (functions, paths, editors/converters, grammar) lives in the `otel-ottl` skill; this page documents only the processor's config surface.
+
+## Main use-cases
+
+Use it when:
+- You need to **modify** telemetry — rename or set attributes, set defaults for missing fields, normalize formats across sources.
+- You want to redact sensitive values (passwords, tokens, PII) in place rather than dropping the record.
+- You need metric reshaping — convert sum↔gauge, extract count/sum/percentile from histograms, scale or aggregate datapoints.
+- You want to parse structured data out of an unstructured log body into attributes.
+
+Avoid it when:
+- You only need to **drop** whole items — use `filter` (it complements `transform`).
+- You need a whole-trace keep/drop decision — use `tail_sampling`.
+- You need cross-batch metric aggregation over time — use `interval` or a metrics connector.
+
+## Related components
+
+- `filter` — drops telemetry via the same OTTL language; pair it with `transform` when some items should be removed and others rewritten.
+- `attributes` — simpler key/value attribute edits without OTTL, for straightforward add/update/delete.
+- `resource` — resource-attribute edits specifically.
+- `metricstransform` — name/label-oriented metric renaming and aggregation outside OTTL.
+- `routing` — sends telemetry to different pipelines by condition instead of mutating it.
+
+## Details
+
+- [Configuration](configuration.md) — `error_mode`, the statement-group structure, `context` values per signal, the inferred-context form, group-level `conditions`, and statement ordering/short-circuiting.
+- [Verification](verification.md) — telemetrygen recipe that sets an attribute on logs so the change is observable in `debug` output.
+- [Advanced use-cases](advanced.md) — multiple statement groups, scoping with conditions, context selection trade-offs, combining with `filter`, error_mode for resilience, named instances, common transforms.
+- [Known quirks](quirks.md) — statement ordering, shared-resource mutation, propagate dropping the batch, context performance, OTTL version drift, stability caveats, anti-patterns.

--- a/skills/otel-collector/components/transform/advanced.md
+++ b/skills/otel-collector/components/transform/advanced.md
@@ -1,0 +1,114 @@
+# `transform`: advanced use-cases
+
+## Multiple statement groups
+
+Split work into ordered groups when statements need different contexts, conditions, or error modes. Groups run top-to-bottom; within a group, statements run top-to-bottom too.
+
+```yaml
+processors:
+  transform:
+    error_mode: ignore
+    metric_statements:
+      # Group 1 — metric context
+      - statements:
+          - convert_sum_to_gauge() where metric.name == "process.count"
+          - set(metric.description, "process count gauge")
+      # Group 2 — datapoint context (separate group: different context)
+      - statements:
+          - limit(datapoint.attributes, 50, ["host.name", "service.name"])
+          - delete_matching_keys(datapoint.attributes, "(?i).*temp.*")
+```
+
+## Scoping statements with conditions
+
+Group-level `conditions` pre-gate a whole group; they are OR'd, and AND'd with each statement's `where`.
+
+```yaml
+processors:
+  transform:
+    error_mode: ignore
+    log_statements:
+      # Only JSON-looking logs
+      - conditions:
+          - IsMatch(log.body, "^\\{")
+        statements:
+          - merge_maps(log.cache, ParseJSON(log.body), "upsert")
+          - set(log.attributes["parsed"], true)
+      # Only one service
+      - conditions:
+          - resource.attributes["service.name"] == "payment-service"
+        statements:
+          - delete_matching_keys(log.attributes, "(?i).*(card|ssn|password).*")
+```
+
+## Context selection trade-offs
+
+Pick the **broadest** context that still reaches what you need: editing at `resource` runs once per resource, while `datapoint`/`spanevent` runs per item and is more expensive. Inference already prefers the most specific context that covers your paths — set `context:` explicitly only to override it, and prefer to express a transform at the highest level that the data allows. Path inventories per context live in the `otel-ottl` skill; the context table is in [configuration.md](configuration.md).
+
+## Combining with `filter`
+
+`transform` and `filter` share the OTTL language but do opposite jobs: `filter` drops, `transform` rewrites. A common pipeline normalizes then drops:
+
+```yaml
+service:
+  pipelines:
+    logs:
+      processors: [memory_limiter, transform, filter]
+```
+
+Run `transform` first if `filter`'s conditions depend on attributes `transform` sets (or vice-versa) — ordering in the pipeline is load-bearing.
+
+## error_mode for resilience
+
+```yaml
+# Production: a failing statement logs but doesn't drop the batch
+processors:
+  transform:
+    error_mode: ignore
+
+# Mixed: most groups tolerant, one group must fail loudly
+processors:
+  transform:
+    error_mode: ignore
+    metric_statements:
+      - error_mode: propagate          # this group only
+        statements:
+          - set(metric.unit, "By") where metric.name == "system.memory.usage"
+      - statements:                     # inherits ignore
+          - set(metric.description, metric.cache["description"])
+```
+
+## Named instances
+
+```yaml
+processors:
+  transform/redact:
+    error_mode: ignore
+    log_statements:
+      - replace_pattern(log.body, "\\b\\d{16}\\b", "****")
+  transform/enrich:
+    error_mode: ignore
+    log_statements:
+      - set(log.attributes["env"], "prod")
+
+service:
+  pipelines:
+    logs/redact:
+      processors: [memory_limiter, transform/redact]
+    logs/enrich:
+      processors: [memory_limiter, transform/enrich]
+```
+
+## Common transforms
+
+| Goal | Shape (OTTL — see `otel-ottl` skill for function details) |
+|------|------------------------------------------------------------|
+| Rename an attribute | `set(resource.attributes["new"], resource.attributes["old"])` then `delete_key(resource.attributes, "old")` — set before delete. |
+| Redact a value | `replace_pattern(...)` / `delete_key(...)` / `delete_matching_keys(...)`. |
+| Set a default | `set(log.severity_text, "INFO") where log.severity_text == nil or log.severity_text == ""`. |
+| Limit / truncate attributes | `keep_keys(...)`, `limit(...)`, `truncate_all(...)`. |
+| Convert metric types | `convert_sum_to_gauge()`, `convert_gauge_to_sum(...)` (metric context, with a `where` clause). |
+| Reshape histograms | `extract_count_metric(...)`, `extract_sum_metric(...)`, `extract_percentile_metric(...)`. |
+| Aggregate datapoints | `aggregate_on_attributes(...)`, `aggregate_on_attribute_value(...)`. |
+
+These are processor-specific OTTL functions; their full signatures and the general OTTL converter set live in the `otel-ottl` skill.

--- a/skills/otel-collector/components/transform/configuration.md
+++ b/skills/otel-collector/components/transform/configuration.md
@@ -1,0 +1,116 @@
+# `transform`: configuration
+
+## Typical config
+
+```yaml
+processors:
+  transform:
+    error_mode: ignore
+    log_statements:
+      - set(log.attributes["env"], "prod")
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, transform]
+      exporters: [otlphttp]
+```
+
+## Top-level keys
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `error_mode` | string | `propagate` | How OTTL statement-evaluation errors are handled: `propagate`, `ignore`, or `silent`. See [Error mode](#error-mode). |
+| `trace_statements` | list | `[]` | Statements run against trace data. |
+| `metric_statements` | list | `[]` | Statements run against metric data. |
+| `log_statements` | list | `[]` | Statements run against log data. |
+| `profile_statements` | list | `[]` | Statements run against profile data (Development stability). |
+
+> A `processor.transform.defaultErrorModeIgnore` feature gate (alpha, disabled by default, v0.150.0+) flips the default `error_mode` from `propagate` to `ignore`. Until it is enabled, the default is `propagate`.
+
+> A `flatten_data` boolean (default `false`, behind the `transform.flatten.logs` alpha feature gate) gives each log record a distinct copy of its resource and scope before transformation, then regroups afterwards — useful when log-level data drives resource/scope edits. It copies and hashes every record, so enable only when needed.
+
+## Error mode
+
+| Mode | Behavior | When |
+|------|----------|------|
+| `propagate` | Returns the error up the pipeline, dropping the whole payload. | **Default.** Development/testing — surfaces config mistakes immediately. |
+| `ignore` | Logs the error and moves to the next statement. | **Recommended in production** — one bad statement won't drop unrelated data. |
+| `silent` | Continues without logging. | When error logging is too noisy. |
+
+The top-level `error_mode` can be overridden per statement group (see below).
+
+## Statement groups
+
+Each `*_statements` field accepts entries in two styles. **Do not mix the two styles within one signal's list.**
+
+### Flat (inferred-context) form
+
+The recommended form for most cases: a plain list of OTTL statements. The processor **infers the context** from the path prefixes in each statement (e.g. `log.body` → `log` context; `resource.attributes` alone → `resource` context). You write statements without declaring a context.
+
+```yaml
+transform:
+  error_mode: ignore
+  trace_statements:
+    - keep_keys(span.attributes, ["service.name", "http.request.method", "http.route"])
+    - set(resource.attributes["deployment.environment.name"], "production")
+  log_statements:
+    - set(log.severity_text, "FAIL") where log.body == "request failed"
+```
+
+### Explicit-group form
+
+For complex cases, group related statements and attach options. Each group is an object with an optional `context`, an optional group-level `error_mode`, optional `conditions`, and a required `statements` list.
+
+```yaml
+transform:
+  error_mode: propagate           # default for all groups
+  metric_statements:
+    - context: metric             # optional; inferred if omitted
+      error_mode: ignore          # optional; overrides top-level for this group
+      conditions:                 # optional; OR'd together
+        - metric.type == METRIC_DATA_TYPE_SUM
+      statements:                 # required
+        - set(metric.description, "Sum metric")
+        - convert_sum_to_gauge() where metric.name == "system.processes.count"
+```
+
+| Group key | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `context` | string | No | Explicit OTTL context (see [Context values](#context-values)). Usually inferred — only set it to override inference. |
+| `error_mode` | string | No | Overrides the top-level `error_mode` for this group only. |
+| `conditions` | list | No | Group-level OTTL booleans, OR'd together. If any is true (or the list is empty), the group's statements run. |
+| `statements` | list | Yes | The OTTL statements to execute, in order. |
+
+## Context values
+
+Context determines which paths the statements can reach. Contexts are hierarchical — a more specific context can also read the broader ones above it. The processor picks the **most specific context** that covers all paths in a group; set `context:` explicitly only when inference can't reconcile the paths.
+
+| Signal | Contexts (broad → specific) | Reaches |
+|--------|------------------------------|---------|
+| traces | `resource`, `scope`, `span`, `spanevent` | `spanevent` can read `resource`, `scope`, `span`, `spanevent` |
+| metrics | `resource`, `scope`, `metric`, `datapoint` | `datapoint` can read `resource`, `scope`, `metric`, `datapoint` |
+| logs | `resource`, `scope`, `log` | `log` can read `resource`, `scope`, `log` |
+| profiles | `resource`, `scope`, `profile` | `profile` can read `resource`, `scope`, `profile` (Development) |
+
+Some path/function combinations can't share a context (e.g. a metric-context-only function alongside a `datapoint` path). When inference fails, split the conflicting statements into separate groups. See [Known quirks](quirks.md).
+
+## `conditions` vs `where`
+
+- `conditions` (group-level) gate the **whole group**; the entries are OR'd. If none match, no statement in the group runs.
+- `where` (per statement) gates a **single statement**; it is AND'd with the group's conditions.
+
+```yaml
+metric_statements:
+  - conditions:
+      - metric.type == METRIC_DATA_TYPE_SUM        # group runs only for Sum metrics
+    statements:
+      - set(metric.description, "count") where metric.name == "http.requests"  # AND name matches
+```
+
+## Statement ordering and short-circuiting
+
+Statements run top-to-bottom; later statements observe the effects of earlier ones (so set-then-delete order matters). With `error_mode: propagate`, the first failing statement **short-circuits the rest of the payload** — remaining statements never run and the batch is dropped. With `ignore`/`silent`, a failing statement is skipped and the next one still runs.
+
+The OTTL expression surface — functions, paths, editors, converters, grammar, enums — is covered in the `otel-ottl` skill and is not reproduced here.

--- a/skills/otel-collector/components/transform/quirks.md
+++ b/skills/otel-collector/components/transform/quirks.md
@@ -1,0 +1,85 @@
+# `transform`: known quirks
+
+## Statement order matters
+
+Statements run top-to-bottom and later ones see earlier effects. A classic bug is deleting an attribute before reading it:
+
+```yaml
+# BAD — delete runs first, set reads nil
+- delete_key(resource.attributes, "k8s.namespace.name")
+- set(resource.attributes["namespace"], resource.attributes["k8s.namespace.name"])
+
+# GOOD — set first, then delete
+- set(resource.attributes["namespace"], resource.attributes["k8s.namespace.name"])
+- delete_key(resource.attributes, "k8s.namespace.name")
+```
+
+## Mutating shared resource/scope affects everything under it
+
+A `resource`-context statement runs once per resource and changes are seen by **all** spans/metrics/logs sharing that resource. Setting a resource attribute from per-item data (e.g. a single log's attribute) leaks that value across the whole group. When per-item resource edits are genuinely needed for logs, enable `flatten_data` (behind the `transform.flatten.logs` feature gate) so each record gets its own resource copy — at the cost of copying and hashing every record.
+
+## `error_mode: propagate` drops the whole batch on error
+
+The default is `propagate`: the first statement that errors (a type mismatch, a nil dereference like `log.cache["x"]["y"]` when `x` is nil) **drops the entire payload**, not just the offending item, and the remaining statements never run. In production set `error_mode: ignore` (or `silent`), and nil-check before accessing nested fields:
+
+```yaml
+- set(log.attributes["uid"], log.cache["user"]["id"]) where log.cache["user"] != nil
+```
+
+`silent` hides evaluation errors entirely — if a transform "isn't working," confirm it isn't set to `silent`. The `processor.transform.defaultErrorModeIgnore` feature gate (alpha, v0.150.0+) can flip the default to `ignore`; don't assume the default without checking whether the gate is on.
+
+## Context performance
+
+Statements evaluate per item at their inferred context. A `datapoint`- or `spanevent`-context group runs for every datapoint/event, which is far more work than a `resource`- or `metric`-context group. Express each transform at the broadest context that reaches the data. Mixing incompatible paths/functions in one group makes context inference fail — split them:
+
+```yaml
+# FAILS — convert_sum_to_gauge is metric-context-only; limit needs datapoint context
+metric_statements:
+  - convert_sum_to_gauge() where metric.name == "process.count"
+  - limit(datapoint.attributes, 100, ["host.name"])
+
+# WORKS — one group per context
+metric_statements:
+  - statements:
+      - convert_sum_to_gauge() where metric.name == "process.count"
+  - statements:
+      - limit(datapoint.attributes, 100, ["host.name"])
+```
+
+## OTTL version drift
+
+`transform` is a thin shell around OTTL, which evolves quickly: function names, signatures, path syntax, and enums change between collector releases (e.g. the path-prefix style `log.body` vs older bare `body`; `set_semconv_span_name` semconv versions; `extract_percentile_metric` added in v0.151.0). Validate statements against the running version — see the `otel-ottl` skill — rather than assuming a snippet from another release still parses.
+
+## Don't change identity carelessly
+
+- Setting `span.trace_id`/`span.span_id` orphans spans and breaks trace/log correlation.
+- Renaming a metric or stripping all its datapoint attributes (`set(metric.name, ...)`, `delete_matching_keys(datapoint.attributes, ".*")`) collapses distinct series into one — an identity conflict.
+- `copy_metric` without a `where` clause that excludes the copy creates an infinite loop. Always gate it.
+
+## Stability caveats
+
+Traces, metrics, and logs are **Beta**; profiles are **Development**. Beta means breaking changes are rare but config keys can still move; profile support may break. Check the upstream README for the running version before treating any key as stable.
+
+## Troubleshooting
+
+**Statement does nothing.**
+- A `where` clause or group `conditions` didn't match.
+- Wrong context inferred — set `context:` explicitly, or split the group.
+- The field is nil; guard with a nil check.
+- Enable `service.telemetry.logs.level: debug` to see the `TransformContext` before/after each statement and whether conditions matched.
+
+**Errors logged but telemetry still flows.** Expected under `error_mode: ignore`; use `silent` to quiet the logs once you've accepted the errors.
+
+**Whole payloads disappear.** `error_mode: propagate` plus an erroring statement. Switch to `ignore` or fix the statement.
+
+**"unexpected token" / "unknown context" on startup.** Incompatible paths/functions in one group (split them), a syntax error, an unknown/renamed function, or mixing the flat and explicit-group styles in one signal's list.
+
+## Anti-patterns
+
+**Using `transform` to filter.** Setting a flag so a later `filter` drops the item is a smell — drop directly with `filter`.
+
+**Hardcoding values that should come from detection.** `set(resource.attributes["deployment.environment.name"], "production")` belongs in resource detection or the SDK, not a static transform, unless you genuinely have no better source.
+
+**`propagate` in production.** Any single error drops the batch; use `ignore`/`silent` and nil-guard nested access.
+
+**Over-transformation.** Long chains of rewrites per item add latency and CPU; do at the source what you can, and transform only what must change downstream.

--- a/skills/otel-collector/components/transform/verification.md
+++ b/skills/otel-collector/components/transform/verification.md
@@ -1,0 +1,42 @@
+# `transform`: verification
+
+See [Verification harness](../../SKILL.md#verification-harness) for how to run this end-to-end.
+
+`transform` ships in the `contrib` and `k8s` distributions, so a stock contrib collector can run this.
+
+Config (`transform-verify.yaml`) — add an `env` attribute to every log record that telemetrygen does **not** itself produce:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+processors:
+  transform:
+    error_mode: ignore
+    log_statements:
+      - set(log.attributes["env"], "prod")
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [transform]
+      exporters: [debug]
+```
+
+Send a batch of logs — see the `otel-telemetrygen` skill:
+
+```bash
+telemetrygen logs --otlp-insecure --otlp-endpoint localhost:4317 \
+  --logs 5 --body "transform me"
+```
+
+Flags confirmed against the `otel-telemetrygen` skill (`references/flags.md`): `--otlp-insecure` (bool), `--otlp-endpoint` (string), `--logs` (int, per-worker count; ignored if `--duration` is set, so no `--duration` here), and `--body` (string). No flag here invents a value.
+
+**What proves it worked:** the `debug` exporter prints all 5 log records, and each carries an `env: Str(prod)` attribute in its `Attributes` block. telemetrygen never emits an `env` log attribute, so its presence in the output is unambiguous proof the statement ran. The log body ("transform me") is unchanged — only the attribute was added.
+
+> The exact `debug` rendering of attributes (`-> env: Str(prod)`) can shift between collector versions; what matters is that the `env`/`prod` pair appears on records that didn't have it on input.


### PR DESCRIPTION
Adds the `transform` processor — **Phase 3, backlog item #2**.

Per-component directory (lean `README.md` + `configuration.md` / `verification.md` / `advanced.md` / `quirks.md`), sourced from the ai-context transformprocessor README. Scoped to the **processor config surface** (`error_mode`, statement groups, contexts, inferred-context form, conditions); the OTTL language itself is deferred to the `otel-ottl` skill.

## Verified end-to-end
Ran the recipe against contrib v0.152.0 + telemetrygen: `set(log.attributes["env"], "prod")` added `env: Str(prod)` to all 5 log records (body unchanged). Config valid, flat-context path syntax confirmed. ✅ All telemetrygen flags checked against the `otel-telemetrygen` skill.

## SKILL.md
Index row (`components/transform/README.md`, Beta) + `transform` frontmatter keyword.

Closes ENG-2203. Phase 3 backlog (E-2201).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the `transform` processor component, including configuration guides, advanced usage patterns, known limitations, and verification examples.
  * Updated component reference to include the `transform` processor with its supported signals and stability status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->