### PR TITLE
otel-collector: add attributes + resource components (per-component directories)

### DIFF
--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -32,7 +32,7 @@ Each component is a directory under `components/<type>/`. The `File` column poin
 | `transform` | `components/transform/README.md` | processor | traces, metrics, logs | Beta | Applies OTTL statements to mutate spans, metric data points, and log records in place (rename/redact/convert/aggregate attributes). The OTTL language itself lives in the `otel-ottl` skill. |
 | `probabilistic_sampler` | `components/probabilistic_sampler/README.md` | processor | traces, logs | Beta (traces), Alpha (logs) | Head sampling — deterministically keeps a configured percentage of traces/logs by hashing the trace ID (or an attribute). The cheaper, stateless counterpart to `tail_sampling`. |
 | `attributes` | `components/attributes/README.md` | processor | traces, metrics, logs | Beta | Modifies span/log/datapoint **attributes** via an ordered action list (insert/update/upsert/delete/hash/extract/convert), scoped by include/exclude matching. |
-| `resource` | `components/resource/README.md` | processor | traces, metrics, logs | Beta | Modifies the **resource** attributes of telemetry via the same action grammar as `attributes` (e.g. set `service.name`, drop noisy resource keys). No include/exclude matching. |
+| `resource` | `components/resource/README.md` | processor | traces, metrics, logs, profiles | Beta (traces/metrics/logs), Development (profiles) | Modifies the **resource** attributes of telemetry via the same action grammar as `attributes` (e.g. set `service.name`, drop noisy resource keys). No include/exclude matching. |
 
 ## Collector-wide conventions
 

--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: otel-collector
-description: OpenTelemetry Collector component configuration. Use when authoring, reviewing, or debugging Collector YAML for a specific receiver, processor, exporter, connector, or extension — config keys, defaults, validation rules, signal support, stability levels, and component-level gotchas. Triggers on questions about specific components such as `log_dedup` / `logdedup`, `interval` (metric aggregation), `tail_sampling`, `drain`, `redaction`, `filter`, `transform`, `probabilistic_sampler`, and other Collector components covered in `components/`.
+description: OpenTelemetry Collector component configuration. Use when authoring, reviewing, or debugging Collector YAML for a specific receiver, processor, exporter, connector, or extension — config keys, defaults, validation rules, signal support, stability levels, and component-level gotchas. Triggers on questions about specific components such as `log_dedup` / `logdedup`, `interval` (metric aggregation), `tail_sampling`, `drain`, `redaction`, `filter`, `transform`, `probabilistic_sampler`, `attributes`, `resource`, and other Collector components covered in `components/`.
 ---
 
 # OpenTelemetry Collector
@@ -31,6 +31,8 @@ Each component is a directory under `components/<type>/`. The `File` column poin
 | `filter` | `components/filter/README.md` | processor | traces, metrics, logs | Alpha | Drops spans, metric data points, and log records that match OTTL conditions (or legacy metric-name / severity filters). The most direct telemetry-volume lever. |
 | `transform` | `components/transform/README.md` | processor | traces, metrics, logs | Beta | Applies OTTL statements to mutate spans, metric data points, and log records in place (rename/redact/convert/aggregate attributes). The OTTL language itself lives in the `otel-ottl` skill. |
 | `probabilistic_sampler` | `components/probabilistic_sampler/README.md` | processor | traces, logs | Beta (traces), Alpha (logs) | Head sampling — deterministically keeps a configured percentage of traces/logs by hashing the trace ID (or an attribute). The cheaper, stateless counterpart to `tail_sampling`. |
+| `attributes` | `components/attributes/README.md` | processor | traces, metrics, logs | Beta | Modifies span/log/datapoint **attributes** via an ordered action list (insert/update/upsert/delete/hash/extract/convert), scoped by include/exclude matching. |
+| `resource` | `components/resource/README.md` | processor | traces, metrics, logs | Beta | Modifies the **resource** attributes of telemetry via the same action grammar as `attributes` (e.g. set `service.name`, drop noisy resource keys). No include/exclude matching. |
 
 ## Collector-wide conventions
 

--- a/skills/otel-collector/components/attributes/README.md
+++ b/skills/otel-collector/components/attributes/README.md
@@ -1,0 +1,44 @@
+# `attributes` processor
+
+| | |
+|-|-|
+| Kind | processor |
+| Type | `attributes` |
+| Signals | traces (Beta), logs (Beta), metrics (Beta) |
+| Distributions | core, contrib, k8s |
+| Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor` |
+| Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor> |
+
+## Description
+
+Modifies the **attributes** of spans, log records, and metric data points through an ordered list of `actions`. Each action names an attribute `key` and one of `insert`, `update`, `upsert`, `delete`, `hash`, `extract`, or `convert`; actions run in the order listed, so later actions see the effect of earlier ones. Values can be literal (`value`), copied from another attribute (`from_attribute`), or pulled from request context (`from_context` — client IP, transport metadata, or authenticator data).
+
+An optional `include`/`exclude` matching block scopes the processor to a subset of telemetry (by service, span name, attribute, resource attribute, instrumentation library, log body, log severity, metric name, …) so only matching records are touched. This processor operates on **span/log/metric-datapoint attributes only** — it does **not** touch resource attributes; use the `resource` processor for those.
+
+## Main use-cases
+
+Use it when:
+- You want to standardize, backfill, or rename attribute keys across services (`insert` defaults, `upsert` to copy with `from_attribute`).
+- You need to redact or hash sensitive attribute values (`hash` PII, `delete` credentials) by key or regex `pattern`.
+- You want to extract structured fields from a string attribute (`extract` with named capture groups) or coerce types (`convert`).
+- You want to inject request context — client IP, headers, authenticated subject — onto telemetry (`from_context`).
+
+Avoid it when:
+- You need to edit **resource** attributes — use `resource` (same action set, resource scope).
+- You need arbitrary conditional logic, math, or cross-field transforms — use `transform` (OTTL is a superset).
+- You only need to drop records — use `filter`.
+- You need a fail-closed allow list for egress governance — use `redaction`.
+
+## Related components
+
+- `resource` — same `actions` model but applied to **resource** attributes instead of span/log/datapoint attributes.
+- `transform` — OTTL-based mutation; a superset of what `attributes` can do, at the cost of more verbosity.
+- `redaction` — allow/block-list masking with a fail-closed allow list and URL/DB sanitizers.
+- `filter` — drops whole records that match a condition (run `attributes` before it to shape the matchable attributes).
+
+## Details
+
+- [Configuration](configuration.md) — the `actions` list (every action type and its `key`/`value`/`pattern`/`from_attribute`/`from_context`/`converted_type` fields), the `include`/`exclude` matching block, and context-value sources.
+- [Verification](verification.md) — telemetrygen recipe that adds/overwrites an attribute and confirms it in `debug` output.
+- [Advanced use-cases](advanced.md) — include/exclude scoping, hashing PII, regex `extract`, type conversion, ordered-action pipelines, named instances, and combining with `resource`/`filter`.
+- [Known quirks](quirks.md) — action order, the resource-attribute confusion, `insert`/`update`/`upsert` semantics, `extract` overwrites, regexp performance, metric identity-conflict caveats, and stability.

--- a/skills/otel-collector/components/attributes/advanced.md
+++ b/skills/otel-collector/components/attributes/advanced.md
@@ -1,0 +1,139 @@
+# `attributes`: advanced use-cases
+
+## Scope with include / exclude
+
+Limit the actions to a subset so you don't touch unrelated telemetry. `include` is evaluated first; `exclude` then trims that set.
+
+```yaml
+processors:
+  attributes/scoped:
+    include:
+      match_type: strict
+      services: ["auth-service"]
+    exclude:
+      match_type: strict
+      attributes:
+        - key: test_request
+          value: true
+    actions:
+      - key: sensitive_data
+        action: delete
+      - key: user.email
+        action: hash
+```
+
+Only spans from `auth-service` are considered, and test requests within that set are skipped. For metrics, only `metric_names` and `resources` are valid match fields — see [Configuration](configuration.md#valid-fields-per-signal).
+
+## Hash PII instead of deleting
+
+Hashing keeps a stable, joinable token without exposing the raw value. Hash by key or by regex `pattern`:
+
+```yaml
+actions:
+  - key: user.email
+    action: hash
+  - pattern: "^pii_.*"
+    action: hash
+```
+
+## Extract structured fields from a string
+
+`extract` runs a regex with **named** capture groups against a string attribute and creates one attribute per group. The source value is left in place.
+
+```yaml
+actions:
+  - key: http.url
+    pattern: '^(?P<http_scheme>https?):\/\/(?P<http_host>[^\/]+)(?P<http_path>.*)'
+    action: extract
+  # http.url = "https://api.example.com/v1/users"
+  # -> http_scheme="https", http_host="api.example.com", http_path="/v1/users"
+```
+
+## Convert types
+
+Coerce an attribute to `int`, `double`, or `string` for downstream compatibility:
+
+```yaml
+actions:
+  - key: http.status_code
+    action: convert
+    converted_type: int
+  - key: response_time_ms
+    action: convert
+    converted_type: double
+```
+
+## Ordered-action pipelines
+
+Actions run top to bottom, so you can stage a transform: copy through a temporary key, then clean up.
+
+```yaml
+actions:
+  - key: operation        # 1. backfill a default
+    value: default
+    action: insert
+  - key: svc.operation    # 2. copy to the standardized key
+    from_attribute: operation
+    action: upsert
+  - key: operation        # 3. drop the old key
+    action: delete
+```
+
+## Inject request context
+
+Pull values from transport metadata or an authenticator (requires `include_metadata: true` on the receiver, or an authenticator extension — see [Configuration](configuration.md#context-values)).
+
+```yaml
+actions:
+  - key: client.ip
+    from_context: client.address
+    action: insert
+  - key: enduser.id
+    from_context: auth.subject
+    action: insert
+```
+
+## Named instances
+
+Configure the same type more than once with `type/name` and reference each in the pipeline that needs it:
+
+```yaml
+processors:
+  attributes/redact:
+    actions:
+      - key: user.email
+        action: hash
+  attributes/enrich:
+    actions:
+      - key: region
+        value: us-east-1
+        action: upsert
+
+service:
+  pipelines:
+    traces:
+      processors: [attributes/redact, attributes/enrich]
+```
+
+## Combining with `resource` and `filter`
+
+- Pair with **`resource`** when you also need to edit resource-level attributes (`attributes` cannot — it only sees span/log/datapoint attributes).
+- Run **before `filter`** so the attribute you want to filter on exists, or has been normalized, by the time `filter`'s condition is evaluated.
+
+```yaml
+processors:
+  attributes:
+    actions:
+      - key: env
+        from_attribute: deployment.env
+        action: upsert
+  filter:
+    traces:
+      span:
+        - 'attributes["env"] == "test"'   # drop test spans normalized above
+
+service:
+  pipelines:
+    traces:
+      processors: [attributes, filter]
+```

--- a/skills/otel-collector/components/attributes/configuration.md
+++ b/skills/otel-collector/components/attributes/configuration.md
@@ -1,0 +1,135 @@
+# `attributes`: configuration
+
+The processor operates on **span / log-record / metric-datapoint attributes** — not resource attributes (use the `resource` processor for those). It has two parts: a required ordered list of `actions`, and an optional `include`/`exclude` matching block that scopes which records the actions apply to.
+
+## Root configuration
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `actions` | list | none | Yes | Ordered list of attribute actions. At least one is required; applied in the order specified. |
+| `include` | object | none | No | Match criteria; only matching records are processed. |
+| `exclude` | object | none | No | Match criteria; matching records are skipped. When both are set, `include` is evaluated first, then `exclude` filters the included set. |
+
+## Action fields
+
+Each entry in `actions` is one operation:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `key` | string | Conditional | Attribute key to act on. Required for all actions except `delete`/`hash` when only a `pattern` is given. |
+| `action` | string | Yes | One of `insert`, `update`, `upsert`, `delete`, `hash`, `extract`, `convert` (case-insensitive). |
+| `value` | any | Conditional | Literal value to set (string/int/double/bool). Required for `insert`/`update`/`upsert` unless `from_attribute` or `from_context` is used. Mutually exclusive with `from_attribute`/`from_context`. |
+| `from_attribute` | string | Conditional | Copy the value from another attribute on the same record. Mutually exclusive with `value` and `from_context`. |
+| `from_context` | string | Conditional | Pull the value from request context. Mutually exclusive with `value` and `from_attribute`. See [Context values](#context-values). |
+| `default_value` | any | No | Fallback value when the `from_attribute`/`from_context` source is missing (v0.152.0). Prevents the action from being skipped. |
+| `pattern` | string | Conditional | Regex (Go syntax). For `delete`/`hash`, matches attribute **keys** to act on. For `extract`, the regex applied to the value (must use named capture groups). |
+| `converted_type` | string | Conditional | Target type for `convert`: `int`, `double`, or `string`. Required for `convert`. |
+
+### Action types
+
+| Action | Requires | Behavior |
+|--------|----------|----------|
+| `insert` | `key` + one of `value`/`from_attribute`/`from_context` | Adds the attribute only if the key does **not** already exist. No-op if the key exists or the source is missing. |
+| `update` | `key` + one of `value`/`from_attribute`/`from_context` | Replaces the value only if the key **already** exists. No-op if the key is absent or the source is missing. |
+| `upsert` | `key` + one of `value`/`from_attribute`/`from_context` | Insert if absent, update if present (insert + update). No-op only if the source value is missing. |
+| `delete` | `key` and/or `pattern` | Removes the named key and/or every key matching `pattern`. |
+| `hash` | `key` and/or `pattern` | Replaces the value(s) of the named key and/or keys matching `pattern` with their SHA-256 hash (hex string). |
+| `extract` | `key` + `pattern` (named groups) | Applies the regex to the **string** value of `key` and creates one attribute per named capture group. Source value is left unchanged. Only acts on string values; overwrites existing attributes when group names collide. |
+| `convert` | `key` + `converted_type` | Converts the existing value of `key` to `int`/`double`/`string`. No-op if the key is absent; on a failed conversion the original value is kept (logged at debug). |
+
+Example covering several actions:
+
+```yaml
+processors:
+  attributes:
+    actions:
+      - key: environment        # default value if absent
+        value: production
+        action: insert
+      - key: db.statement       # redact in place
+        value: "[REDACTED]"
+        action: update
+      - key: user.email         # hash PII
+        action: hash
+      - pattern: "^temp_.*"     # bulk delete by key regex
+        action: delete
+      - key: http.status_code   # coerce type
+        action: convert
+        converted_type: int
+```
+
+## Include / exclude matching
+
+`include` and `exclude` share the same structure. Both are optional; if neither is set, every record is processed.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `match_type` | string | `strict` (exact, case-sensitive) or `regexp` (Go regexp). Required when `include`/`exclude` is present. |
+| `regexp` | object | Regex tuning, only valid with `match_type: regexp`. See [Regexp options](#regexp-options). |
+| `services` | list[string] | Match by service name (traces and logs only). |
+| `span_names` | list[string] | Match by span name (traces only). |
+| `span_kinds` | list[string] | Match by span kind, e.g. `SPAN_KIND_INTERNAL` (traces only). |
+| `log_bodies` | list[string] | Match by log body, **string bodies only** (logs only). |
+| `log_severity_texts` | list[string] | Match by log severity text (logs only). |
+| `log_severity_number` | object | Match by numeric severity (logs only). See below. |
+| `metric_names` | list[string] | Match by metric name (metrics only). |
+| `attributes` | list[object] | Match by attribute: each entry has `key` and optional `value`. Key-only matches any value. |
+| `resources` | list[object] | Match by resource attribute: `key` and optional `value`. |
+| `libraries` | list[object] | Match by instrumentation library: `name` and optional `version`. |
+
+`log_severity_number` takes `min` (inclusive minimum severity number — TRACE 1-4, DEBUG 5-8, INFO 9-12, WARN 13-16, ERROR 17-20, FATAL 21-24) and `match_undefined` (when `true`, records with no severity number also match; default `false`).
+
+### Valid fields per signal
+
+- **Traces:** `services`, `span_names`, `span_kinds`, `attributes`, `resources`, `libraries`.
+- **Logs:** `log_bodies` (string bodies), `log_severity_texts`, `log_severity_number`, `attributes`, `resources`, `libraries`.
+- **Metrics:** `metric_names`, `resources`. (No `services`, `attributes`, `span_*`, or `log_*` fields.)
+
+### Regexp options
+
+When `match_type: regexp`, a nested `regexp` block can tune an LRU cache of match results for high-throughput pipelines:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cacheenabled` | bool | `false` | Cache compiled-regex match results. |
+| `cachemaxnumentries` | int | unlimited | Cap on cache entries when caching is enabled. |
+
+```yaml
+include:
+  match_type: regexp
+  regexp:
+    cacheenabled: true
+    cachemaxnumentries: 1000
+  services: ["^auth-.*", "^payment-.*"]
+```
+
+## Context values
+
+`from_context` pulls a value from request context. Three source kinds:
+
+- **`client.address`** — the client IP (plain key, no prefix).
+- **`metadata.*`** — gRPC metadata / HTTP headers, e.g. `metadata.x-request-id`. Requires the receiver to set `include_metadata: true`.
+- **`auth.*`** — data from a server authenticator extension, e.g. `auth.subject`. Requires an authenticator on the receiver; available keys depend on the authenticator.
+
+If a context key has multiple values, they are joined with `;`.
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        include_metadata: true   # required for metadata.* keys
+
+processors:
+  attributes/context:
+    actions:
+      - key: client.ip
+        from_context: client.address
+        action: insert
+      - key: request_id
+        from_context: metadata.x-request-id
+        action: insert
+      - key: enduser.id
+        from_context: auth.subject
+        action: insert
+```

--- a/skills/otel-collector/components/attributes/quirks.md
+++ b/skills/otel-collector/components/attributes/quirks.md
@@ -25,7 +25,7 @@ A frequent bug: using `insert` and seeing nothing change because the key already
 
 ## Regexp performance
 
-`match_type: regexp` filters and `pattern`-based `delete`/`hash` compile and run Go regexes per record. On high-throughput pipelines enable the LRU cache (`regexp.cacheenabled: true`, bound with `cachemaxnumentries`) and keep patterns simple — anchored prefixes (`^foo_.*`) are far cheaper than unanchored, backtracking-heavy expressions. Remember `.` matches any character; use `\.` for a literal dot.
+`match_type: regexp` filters and `pattern`-based `delete`/`hash` compile and run Go regexes per record. On high-throughput pipelines enable the LRU cache (`regexp.cacheenabled: true`, bound with `cachemaxnumentries`) and keep patterns simple — anchored prefixes (`^foo_.*`) let the engine reject non-matches early, while unanchored patterns scan the whole value. (Go's `regexp` is RE2-based and linear-time, so there's no catastrophic backtracking; the cost is per-record CPU and cache pressure, not exponential blow-up.) Remember `.` matches any character; use `\.` for a literal dot.
 
 ## Metric support caveats (identity conflict)
 

--- a/skills/otel-collector/components/attributes/quirks.md
+++ b/skills/otel-collector/components/attributes/quirks.md
@@ -1,0 +1,47 @@
+# `attributes`: known quirks
+
+## Action order matters
+
+`actions` run strictly in the order listed, and each sees the result of the previous ones. A `delete` before a `from_attribute` copy removes the source first; an `insert` of a default before an `upsert` copy changes what gets copied. Order cheap actions (`delete`, `insert`) before expensive ones (`extract`, `convert`) when possible. Do **not** split related actions across two processor instances and rely on order between them — a temporary key created in `attributes/first` may not exist yet when `attributes/second` runs.
+
+## It does NOT touch resource attributes
+
+This is the most common confusion. `attributes` operates on **span / log-record / metric-datapoint** attributes only. To add, rename, hash, or delete **resource** attributes (e.g. `service.name`, `host.name`, `deployment.environment`), use the **`resource`** processor — it has the same `actions` model but resource scope. Note that include/exclude *matching* can read resource attributes (the `resources` match field), but the actions still only write to non-resource attributes.
+
+## insert vs update vs upsert
+
+- `insert` — writes only if the key is **absent**. Silently no-ops on an existing key. Use for defaults/backfill.
+- `update` — writes only if the key is **present**. Silently no-ops on a missing key. Use to rewrite/redact known fields.
+- `upsert` — always writes (insert if absent, update if present). The safe choice when you don't care about prior state; also the right tool for debugging "why didn't my action apply" (swap to `upsert` to rule out existence checks).
+
+A frequent bug: using `insert` and seeing nothing change because the key already existed, or `update` and seeing nothing because the key was absent.
+
+## `extract` quirks
+
+- Requires **named** capture groups (`(?P<name>...)`); a pattern with unnamed groups is a config error.
+- Only acts on **string** values. A non-string source (or a missing key) is a no-op.
+- **Overwrites** existing attributes when a capture-group name collides with an existing key — there is no insert-only mode for `extract`.
+- The source `key`'s own value is left unchanged; `extract` only adds the captured fields.
+
+## Regexp performance
+
+`match_type: regexp` filters and `pattern`-based `delete`/`hash` compile and run Go regexes per record. On high-throughput pipelines enable the LRU cache (`regexp.cacheenabled: true`, bound with `cachemaxnumentries`) and keep patterns simple — anchored prefixes (`^foo_.*`) are far cheaper than unanchored, backtracking-heavy expressions. Remember `.` matches any character; use `\.` for a literal dot.
+
+## Metric support caveats (identity conflict)
+
+For metrics, **adding new** data-point attributes is safe, but **modifying or deleting existing** data-point attributes can create an **identity conflict**: a metric's identity includes its data-point attributes, and this processor does **not** re-aggregate. Changing them can split or duplicate time series and corrupt cardinality. If you must change existing metric attributes, re-aggregate downstream (a connector, or the `metricstransform` processor), or fix it at the source. This warning does **not** apply to traces or logs — attributes there can be freely modified. Also note `attributes` does not rename metrics or change metric names — that's `metricstransform`.
+
+## Common config errors
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Action silently does nothing | `insert` on an existing key, or `update` on a missing key | Use `upsert`, or check the include/exclude filter isn't blocking the record. |
+| Config validation error | More than one of `value` / `from_attribute` / `from_context` set on one action | Use exactly one value source per action. |
+| Config validation error | `extract` pattern has unnamed groups | Use `(?P<name>...)` named groups. |
+| Convert no-op | Value can't be parsed to the target type (e.g. `"abc"` → int), or key absent | Pre-validate; conversion failures keep the original value (logged at debug). |
+| `from_context` empty | Receiver missing `include_metadata: true`, or no authenticator for `auth.*` | Configure the receiver/authenticator (see configuration.md). |
+| Wrong-signal field rejected | e.g. `span_names` under a metrics pipeline | Use only the match fields valid for the signal. |
+
+## Stability
+
+All three signals (traces, logs, metrics) are **Beta** — production viable, breaking changes rare. Hashing uses SHA-256 on modern versions; very old collectors used SHA-1, so hashes are not comparable across a version boundary. `default_value` on an action is newer (v0.152.0) — confirm your collector version before relying on it.

--- a/skills/otel-collector/components/attributes/verification.md
+++ b/skills/otel-collector/components/attributes/verification.md
@@ -1,0 +1,49 @@
+# `attributes`: verification
+
+See [Verification harness](../../SKILL.md#verification-harness) for how to run this end-to-end.
+
+`attributes` ships in the `core`, `contrib`, and `k8s` distributions.
+
+Config (`attributes-verify.yaml`) — an `upsert` action that sets (or overwrites) an `env` attribute on every span:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+processors:
+  attributes:
+    actions:
+      - key: env
+        value: prod
+        action: upsert
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [attributes]
+      exporters: [debug]
+```
+
+Send a known number of traces, each carrying an `env` attribute with a *different* value so the `upsert` overwrite is observable. Use `--workers 1` so the `--traces` count (which is **per worker**) is exact:
+
+```bash
+telemetrygen traces --otlp-insecure --otlp-endpoint localhost:4317 \
+  --workers 1 --traces 5 --telemetry-attributes 'env="staging"'
+```
+
+Flags used, all confirmed against the `otel-telemetrygen` skill (`references/flags.md`):
+
+- `--otlp-insecure` — disable transport security (common flag).
+- `--otlp-endpoint` — destination, defaults to `localhost:4317` for gRPC (common flag).
+- `--workers` — concurrent workers; `1` keeps the count exact (common flag).
+- `--traces` — traces **per worker** (trace-specific flag).
+- `--telemetry-attributes` — span-level attribute as `key="value"` (must be quoted). Resource-level `--otlp-attributes` would attach to the Resource, which the `attributes` processor does **not** touch.
+
+**What proves it worked:** in the `debug` exporter output, every span shows `env: Str(prod)` in its span attributes — the value sent (`staging`) has been overwritten by the `upsert` action. To prove the **insert** half of `upsert`, drop `--telemetry-attributes` and send plain traces; `env: Str(prod)` still appears because the key was absent and got inserted. (Use `insert` instead of `upsert` to confirm it leaves a pre-existing `env` untouched, or `update` to confirm it only writes when the key already exists.)
+
+You can run the same recipe with `telemetrygen logs ... --logs 5` and a `logs` pipeline to confirm log-record attributes; `--logs` is likewise per-worker, so keep `--workers 1`.

--- a/skills/otel-collector/components/resource/README.md
+++ b/skills/otel-collector/components/resource/README.md
@@ -1,0 +1,45 @@
+# `resource` processor
+
+| | |
+|-|-|
+| Kind | processor |
+| Type | `resource` |
+| Signals | traces (Beta), metrics (Beta), logs (Beta), profiles (Development) |
+| Distributions | core, contrib, k8s |
+| Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor` |
+| Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor> |
+
+## Description
+
+Modifies the **resource** attributes of telemetry through an ordered list of `attributes` actions. The resource describes the entity producing the telemetry (a service instance, host, container, …), and its attributes are shared across every span, log record, and metric data point from that resource. Each action names an attribute `key` and one of `insert`, `update`, `upsert`, `delete`, `hash`, `extract`, or `convert`; actions run in the order listed, so later actions see the effect of earlier ones. Values can be literal (`value`), copied from another resource attribute (`from_attribute`), or pulled from request context (`from_context` — client IP, transport metadata, or authenticator data).
+
+It uses the **same action grammar as the [`attributes`](../attributes/README.md) processor**, but scoped to the resource: set `service.name`, add `deployment.environment.name`, rename legacy keys to semantic conventions, or drop noisy resource keys. Unlike `attributes`, it has **no `include`/`exclude` matching** — every resource that flows through the pipeline is processed.
+
+## Main use-cases
+
+Use it when:
+- You want to set or standardize resource identity — `service.name`, `service.namespace`, `service.instance.id` — across services (`upsert` static values, `insert` defaults).
+- You need to add environment / infrastructure context to all telemetry from a collector (`deployment.environment.name`, `cloud.region`, static tags).
+- You want to rename or migrate legacy resource keys to semantic conventions (`insert` from `from_attribute`, then `delete` the old key).
+- You need to drop high-cardinality or sensitive resource keys, or `hash` identifying resource attributes (`host.id`, container IDs).
+
+Avoid it when:
+- You need to edit **span / log / datapoint** attributes — use [`attributes`](../attributes/README.md) (same action set, telemetry scope).
+- You need `include`/`exclude` scoping — `resource` has none; use [`attributes`](../attributes/README.md) (which supports resource-attribute matching) or `transform`.
+- You want to auto-discover resource attributes from the environment — use `resourcedetection`.
+- You want Kubernetes pod/namespace/node metadata — use `k8sattributes`.
+- You need conditional logic, math, or cross-field transforms — use `transform` (OTTL).
+
+## Related components
+
+- [`attributes`](../attributes/README.md) — the **same `insert`/`update`/`upsert`/`delete`/`hash`/`extract`/`convert` actions**, but applied to span/log/datapoint attributes instead of the resource.
+- `resourcedetection` — auto-detects resource attributes (cloud, host, container, k8s) from the environment; commonly run **before** `resource`, which then normalizes/renames the detected keys.
+- `k8sattributes` — enriches resources with Kubernetes pod/namespace/node metadata from the k8s API; use it for dynamic pod-level enrichment rather than static `resource` values.
+- `transform` — OTTL-based mutation that can also edit resource attributes (`context: resource`); a superset of `resource`, at the cost of more verbosity.
+
+## Details
+
+- [Configuration](configuration.md) — the `attributes` action list (every action type and its `key`/`value`/`from_attribute`/`from_context`/`pattern`/`converted_type` fields), scoped to **resource** attributes, and why there is no include/exclude matching.
+- [Verification](verification.md) — telemetrygen recipe that sets a resource attribute and confirms it in the **Resource attributes** block of `debug` output.
+- [Advanced use-cases](advanced.md) — normalizing `service.name`, setting `deployment.environment.name`, dropping high-cardinality keys, hashing identifiers, ordered actions, named instances, and combining with `resourcedetection`/`k8sattributes`.
+- [Known quirks](quirks.md) — operates only on resource attributes (the common `attributes` confusion), no include/exclude, action order, batch-wide effect, `delete`/`hash` semantics, and stability.

--- a/skills/otel-collector/components/resource/advanced.md
+++ b/skills/otel-collector/components/resource/advanced.md
@@ -165,4 +165,4 @@ service:
 - **Scope** — `resource` edits resource attributes; `attributes` edits span/log/datapoint attributes.
 - **Matching** — `attributes` has `include`/`exclude` (which can even match on resource attributes); `resource` has none.
 
-If you need to edit resource attributes *only for matching telemetry*, reach for `attributes` (with a `resources:` matcher) or `transform`, not `resource`.
+If you need to edit resource attributes *only for matching telemetry*, reach for `transform` (with a `where`/OTTL condition), not `resource`. `attributes` can *match* on resource attributes via its `resources:` matcher, but it only edits span/log/datapoint attributes — never the resource — so it can't do conditional resource edits either.

--- a/skills/otel-collector/components/resource/advanced.md
+++ b/skills/otel-collector/components/resource/advanced.md
@@ -1,0 +1,168 @@
+# `resource`: advanced use-cases
+
+All actions here operate on **resource** attributes and use the same grammar as the [`attributes`](../attributes/README.md) processor. Actions run top-to-bottom; order matters (see [quirks](quirks.md)).
+
+## Normalize `service.name`
+
+Force a canonical service name regardless of what the SDK set, or backfill one when it's missing:
+
+```yaml
+processors:
+  resource/canonical-name:
+    attributes:
+      - key: service.name        # always overwrite
+        value: checkout
+        action: upsert
+  resource/default-name:
+    attributes:
+      - key: service.name        # only if the SDK left it unset
+        value: unknown-service
+        action: insert
+```
+
+## Set `deployment.environment.name`
+
+Tag all telemetry from a collector instance with its environment (semantic conventions renamed `deployment.environment` → `deployment.environment.name`):
+
+```yaml
+processors:
+  resource:
+    attributes:
+      - key: deployment.environment.name
+        value: production
+        action: upsert
+      - key: cloud.region
+        value: us-east-1
+        action: upsert
+```
+
+## Drop high-cardinality / sensitive resource keys
+
+Remove resource attributes that inflate cardinality or leak internal data — by exact key or regex:
+
+```yaml
+processors:
+  resource:
+    attributes:
+      - key: process.command_line     # noisy, often unbounded
+        action: delete
+      - pattern: ^internal\..*        # bulk delete by key regex
+        action: delete
+```
+
+## Hash identifying resource attributes
+
+Anonymize identifiers while keeping them usable as a stable join key (SHA-256, deterministic):
+
+```yaml
+processors:
+  resource:
+    attributes:
+      - key: host.id
+        action: hash
+      - pattern: ^container\.id$
+        action: hash
+```
+
+## Rename legacy keys with ordered actions
+
+`extract`/`from_attribute` read; `insert`/`upsert` write; `delete`/`hash` clean up. Read before you delete:
+
+```yaml
+processors:
+  resource:
+    attributes:
+      # copy legacy key to the semantic-convention key
+      - key: k8s.cluster.name
+        from_attribute: k8s-cluster
+        action: insert
+      # parse a region out of the AZ before anything removes it
+      - key: cloud.availability_zone
+        pattern: ^(?P<cloud_region>[a-z]+-[a-z]+-\d+)[a-z]$
+        action: extract
+      # only now drop the legacy key
+      - key: k8s-cluster
+        action: delete
+```
+
+## Named instances
+
+Like every component, `resource` supports the `type/name` form so the same type can be configured more than once and selected per pipeline:
+
+```yaml
+processors:
+  resource/prod-tags:
+    attributes:
+      - key: deployment.environment.name
+        value: production
+        action: upsert
+  resource/strip-internal:
+    attributes:
+      - pattern: ^internal\..*
+        action: delete
+
+service:
+  pipelines:
+    traces/prod:
+      processors: [resource/prod-tags]
+    traces/egress:
+      processors: [resource/strip-internal]
+```
+
+## Combine with `resourcedetection`
+
+The canonical pattern: `resourcedetection` discovers infrastructure attributes from the environment, then `resource` normalizes, renames, and adds static values. Place `resourcedetection` **first**:
+
+```yaml
+processors:
+  resourcedetection:
+    detectors: [env, system, docker, ec2]
+    override: false
+  resource:
+    attributes:
+      - key: deployment.environment.name
+        value: production
+        action: upsert
+      - key: k8s.cluster.name
+        from_attribute: k8s-cluster
+        action: insert
+      - key: k8s-cluster
+        action: delete
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resourcedetection, resource]
+      exporters: [otlp]
+```
+
+## Combine with `k8sattributes`
+
+Let `k8sattributes` provide dynamic pod/namespace/node metadata from the k8s API, and use `resource` only for static cluster-level values that the API can't supply. Don't hard-code pod-level attributes in `resource` — they're per-pod and dynamic:
+
+```yaml
+processors:
+  k8sattributes:
+    extract:
+      metadata: [k8s.pod.name, k8s.namespace.name, k8s.node.name]
+  resource:
+    attributes:
+      - key: k8s.cluster.name        # static, not pod-specific
+        value: prod-us-east
+        action: upsert
+
+service:
+  pipelines:
+    traces:
+      processors: [k8sattributes, resource]
+```
+
+## Relationship to `attributes`
+
+`resource` and [`attributes`](../attributes/README.md) share an identical action set (`insert`/`update`/`upsert`/`delete`/`hash`/`extract`/`convert`) and the same `value`/`from_attribute`/`from_context`/`pattern`/`converted_type` fields. The only differences:
+
+- **Scope** — `resource` edits resource attributes; `attributes` edits span/log/datapoint attributes.
+- **Matching** — `attributes` has `include`/`exclude` (which can even match on resource attributes); `resource` has none.
+
+If you need to edit resource attributes *only for matching telemetry*, reach for `attributes` (with a `resources:` matcher) or `transform`, not `resource`.

--- a/skills/otel-collector/components/resource/configuration.md
+++ b/skills/otel-collector/components/resource/configuration.md
@@ -1,0 +1,102 @@
+# `resource`: configuration
+
+The processor operates on **resource attributes only** — the attributes attached to the `Resource` that describes the entity producing the telemetry. It does **not** touch span, log-record, or metric-datapoint attributes (use the [`attributes`](../attributes/README.md) processor for those). Its only field is a required ordered list of `attributes` actions; there is **no `include`/`exclude` matching block** (unlike `attributes`), so every resource flowing through the pipeline is processed.
+
+## Root configuration
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `attributes` | list | none | Yes | Ordered list of actions to perform on the resource's attributes. At least one is required (an empty list is invalid); applied in the order specified. |
+
+There is no default configuration — the processor must be explicitly configured with at least one action.
+
+```yaml
+processors:
+  resource:
+    attributes:
+      - key: service.name
+        value: my-service
+        action: upsert
+```
+
+## Action fields
+
+Each entry in `attributes` is one operation. The fields are identical to the `attributes` processor's action fields, but `key`/`from_attribute` refer to **resource** attributes.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `key` | string | Conditional | Resource attribute key to act on. Required for all actions except `delete`/`hash` when only a `pattern` is given. |
+| `action` | string | Yes | One of `insert`, `update`, `upsert`, `delete`, `hash`, `extract`, `convert` (case-insensitive). |
+| `value` | any | Conditional | Literal value to set (string/int/double/bool). Required for `insert`/`update`/`upsert` unless `from_attribute` or `from_context` is used. Mutually exclusive with `from_attribute`/`from_context`. |
+| `from_attribute` | string | Conditional | Copy the value from another **resource** attribute. Mutually exclusive with `value` and `from_context`. |
+| `from_context` | string | Conditional | Pull the value from request context. Mutually exclusive with `value` and `from_attribute`. See [Context values](#context-values). |
+| `default_value` | any | No | Fallback value when the `from_attribute`/`from_context` source is missing (v0.152.0). Prevents the action from being skipped. |
+| `pattern` | string | Conditional | Regex (Go syntax). For `delete`/`hash`, matches attribute **keys** to act on. For `extract`, the regex applied to the value (must use named capture groups). |
+| `converted_type` | string | Conditional | Target type for `convert`: `int`, `double`, or `string`. Required for `convert`. |
+
+Only **one** of `value`, `from_attribute`, or `from_context` may be set per action; setting more than one fails validation.
+
+### Action types
+
+| Action | Requires | Behavior |
+|--------|----------|----------|
+| `insert` | `key` + one of `value`/`from_attribute`/`from_context` | Adds the resource attribute only if the key does **not** already exist. No-op if the key exists or the source is missing. |
+| `update` | `key` + one of `value`/`from_attribute`/`from_context` | Replaces the value only if the key **already** exists. No-op if the key is absent or the source is missing. |
+| `upsert` | `key` + one of `value`/`from_attribute`/`from_context` | Insert if absent, update if present (insert + update). No-op only if the source value is missing. The most common action for static configuration. |
+| `delete` | `key` and/or `pattern` | Removes the named key and/or every resource key matching `pattern`. |
+| `hash` | `key` and/or `pattern` | Replaces the value(s) of the named key and/or keys matching `pattern` with their SHA-256 hash (lowercase hex string). |
+| `extract` | `key` + `pattern` (named groups) | Applies the regex to the **string** value of `key` and creates one resource attribute per named capture group. Source value is left unchanged. Only acts on string values; overwrites existing attributes when group names collide. All groups must be named (`(?P<name>…)`). |
+| `convert` | `key` + `converted_type` | Converts the existing value of `key` to `int`/`double`/`string`. No-op if the key is absent; on a failed conversion the original value is kept. |
+
+Example covering several actions, all scoped to the resource:
+
+```yaml
+processors:
+  resource:
+    attributes:
+      - key: deployment.environment.name   # always set
+        value: production
+        action: upsert
+      - key: k8s.cluster.name              # rename legacy key
+        from_attribute: k8s-cluster
+        action: insert
+      - key: k8s-cluster                    # drop the old key
+        action: delete
+      - key: host.id                        # anonymize identifier
+        action: hash
+      - pattern: ^internal\..*              # bulk delete by key regex
+        action: delete
+      - key: service.port                   # coerce type
+        action: convert
+        converted_type: int
+```
+
+## No include / exclude matching
+
+Unlike the [`attributes`](../attributes/README.md) processor, `resource` has **no `include`/`exclude` block**. There is no way to scope its actions to a subset of resources by service, attribute, or any other matcher — every resource that passes through the pipeline is processed. To apply resource-attribute edits only to matching telemetry, use the `attributes` processor (its match block supports `resources:` matchers) or `transform` (OTTL conditions).
+
+## Context values
+
+`from_context` pulls a value from request context into a resource attribute. Three source kinds:
+
+- **`client.address`** — the client IP (plain key, no prefix). Only available for network receivers (OTLP, Jaeger, …), not file/push ingestion.
+- **`metadata.*`** — gRPC metadata / HTTP headers, e.g. `metadata.x-trace-id`. Requires the receiver to set `include_metadata: true`. Multiple values are joined with `;`.
+- **`auth.*`** — data from a server authenticator extension, e.g. `auth.username`, `auth.tenant_id`. Requires an authenticator on the receiver; available keys depend on the authenticator. If the `auth.` key doesn't match an auth attribute, the processor falls back to checking metadata with the full key.
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        include_metadata: true   # required for metadata.* keys
+
+processors:
+  resource/context:
+    attributes:
+      - key: client.ip
+        from_context: client.address
+        action: insert
+      - key: tenant.id
+        from_context: auth.tenant_id
+        action: insert
+```

--- a/skills/otel-collector/components/resource/configuration.md
+++ b/skills/otel-collector/components/resource/configuration.md
@@ -81,7 +81,7 @@ Unlike the [`attributes`](../attributes/README.md) processor, `resource` has **n
 
 - **`client.address`** — the client IP (plain key, no prefix). Only available for network receivers (OTLP, Jaeger, …), not file/push ingestion.
 - **`metadata.*`** — gRPC metadata / HTTP headers, e.g. `metadata.x-trace-id`. Requires the receiver to set `include_metadata: true`. Multiple values are joined with `;`.
-- **`auth.*`** — data from a server authenticator extension, e.g. `auth.username`, `auth.tenant_id`. Requires an authenticator on the receiver; available keys depend on the authenticator. If the `auth.` key doesn't match an auth attribute, the processor falls back to checking metadata with the full key.
+- **`auth.*`** — data from a server authenticator extension, e.g. `auth.username`, `auth.tenant_id`. Requires an authenticator on the receiver; available keys depend on the authenticator. `auth.` and `metadata.` are separate namespaces — there is no fallback between them.
 
 ```yaml
 receivers:

--- a/skills/otel-collector/components/resource/quirks.md
+++ b/skills/otel-collector/components/resource/quirks.md
@@ -1,0 +1,79 @@
+# `resource`: known quirks
+
+## Operates only on resource attributes
+
+The single most common confusion: `resource` touches **only resource attributes** — the attributes on the `Resource` that describes the producing entity. It does **not** see span, log-record, or metric-datapoint attributes. A config like this silently does nothing useful, because `http.status_code` is a span attribute, not a resource attribute:
+
+```yaml
+# WRONG: http.status_code lives on the span, not the resource
+resource:
+  attributes:
+    - key: http.status_code
+      action: delete
+```
+
+For span/log/datapoint attributes use the [`attributes`](../attributes/README.md) processor — it has the exact same action grammar. `resource` is the resource-scoped twin of `attributes`.
+
+## No include / exclude matching
+
+`resource` has **no `include`/`exclude` block**. Every resource flowing through the pipeline is processed — there's no way to scope its actions to a subset of resources. If you need conditional application (e.g. only rename a key for one service), use the `attributes` processor (its match block supports `resources:` matchers) or `transform` with an OTTL condition. Attempting to add an `include:` key to a `resource` config is a configuration error.
+
+## Changes are wholesale across the batch
+
+A `Resource` is shared by every span / log record / metric data point grouped under it in a batch. An action on a resource attribute therefore affects **all** of those records at once — there's no per-record granularity. In the `debug` exporter the attribute appears once, in the **Resource attributes** block, not repeated per span. This is what makes `resource` cheap (one edit per resource, not per record) but also means you can't vary the value by record.
+
+## Action order matters
+
+Actions run top-to-bottom and later actions see the effect of earlier ones. The classic mistake is deleting a key before reading it:
+
+```yaml
+# WRONG: source is gone before extract runs
+- key: cloud.availability_zone
+  action: delete
+- key: cloud.availability_zone
+  pattern: ^(?P<cloud_region>.+)[a-z]$
+  action: extract   # no-op, key already deleted
+
+# RIGHT: read first, clean up last
+- key: cloud.availability_zone
+  pattern: ^(?P<cloud_region>.+)[a-z]$
+  action: extract
+- key: cloud.availability_zone
+  action: delete
+```
+
+Rule of thumb: order as `extract`/read → `insert`/`update`/`upsert`/write → `delete`/`hash`/cleanup.
+
+## `delete` and `hash` semantics
+
+- `delete` and `hash` accept `key` and/or `pattern` (Go regex against attribute **keys**). With both set, the named key plus all pattern matches are affected.
+- `hash` replaces the value with its **SHA-256** lowercase-hex digest. It's deterministic (same input → same output) and irreversible; add salt at instrumentation time if you need stronger anonymization. Hashing has a higher per-attribute CPU cost than the simple write actions.
+- A `pattern` that matches nothing is a silent no-op — not an error.
+
+## `insert` vs `update` vs `upsert`
+
+- `insert` only writes if the key is **absent** — using it to "change" an existing value silently does nothing.
+- `update` only writes if the key **already exists** — using it to "set" a missing value silently does nothing.
+- `upsert` always writes (the usual choice for guaranteeing a value).
+
+If an attribute "won't change," check you're not using `insert` on an existing key or `update` on a missing one.
+
+## `extract` only works on string values
+
+`extract` applies its regex to the **string** value of `key`; non-string values are skipped. All capture groups must be **named** (`(?P<name>…)`) — anonymous `()` groups are a config error. Group names become new resource attribute keys, overwriting any existing attribute of the same name.
+
+## `convert` failures are silent
+
+`convert` coerces a value to `int`/`double`/`string`. A failed conversion (e.g. `"abc"` → `int`) keeps the **original** value rather than erroring; the failure is only visible at debug log level. Make sure source values are actually convertible.
+
+## One value source per action
+
+Exactly one of `value`, `from_attribute`, or `from_context` may be set per action. Setting more than one fails validation at startup (`error creating AttrProc due to multiple value sources being set`).
+
+## `from_context` depends on transport
+
+`from_context: metadata.*` requires the receiver to set `include_metadata: true`; `client.address` is only populated for network receivers (OTLP, Jaeger), not file/push ingestion; `auth.*` requires a server authenticator extension. Missing context is a silent no-op — the attribute simply isn't created (unless `default_value` is set).
+
+## Stability
+
+Beta for traces, metrics, and logs; **Development** for profiles. The Beta signals are production-viable; treat profiles support as experimental and subject to breaking changes. Confirm the current stability in the upstream README before relying on it for a given signal.

--- a/skills/otel-collector/components/resource/verification.md
+++ b/skills/otel-collector/components/resource/verification.md
@@ -46,6 +46,6 @@ Flags used, all confirmed against the `otel-telemetrygen` skill (`references/fla
 
 **What proves it worked:** in the `debug` exporter output, the **Resource attributes** block (not the span attributes) shows `deployment.environment.name: Str(prod)` — the value sent (`staging`) has been overwritten by the `upsert` action. The attribute appears once per resource, shared across all spans in the batch.
 
-To prove the **insert** half of `upsert`, drop `--otlp-attributes` and send plain traces; `deployment.environment.name: Str(prod)` still appears in the Resource attributes because the key was absent and got inserted. (Use `insert` instead of `upsert` to confirm it leaves a pre-existing resource value untouched, or `update` to confirm it only writes when the key already exists.)
+Dropping `--otlp-attributes` and sending plain traces exercises the **absent-key path** of `upsert`: `deployment.environment.name: Str(prod)` still appears in the Resource attributes because the key wasn't present and got inserted. To test the `insert` **action** itself, swap `action: upsert` → `action: insert` in the config — `insert` writes only when the key is absent and leaves a pre-existing value untouched; `update` writes only when the key already exists.
 
 You can run the same recipe with `telemetrygen logs ... --logs 5` (or `metrics ... --metrics 5`) and a matching pipeline; `--logs`/`--metrics` are likewise per-worker, so keep `--workers 1`. `--otlp-attributes` sets the resource for every signal type.

--- a/skills/otel-collector/components/resource/verification.md
+++ b/skills/otel-collector/components/resource/verification.md
@@ -1,0 +1,51 @@
+# `resource`: verification
+
+See [Verification harness](../../SKILL.md#verification-harness) for how to run this end-to-end.
+
+`resource` ships in the `core`, `contrib`, and `k8s` distributions.
+
+Config (`resource-verify.yaml`) — an `upsert` action that sets (or overwrites) the `deployment.environment` **resource** attribute:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+processors:
+  resource:
+    attributes:
+      - key: deployment.environment
+        value: prod
+        action: upsert
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resource]
+      exporters: [debug]
+```
+
+Send a known number of traces whose **resource** carries `deployment.environment` with a *different* value, so the `upsert` overwrite is observable. telemetrygen sets resource attributes with `--otlp-attributes` (telemetry-level attributes use the separate `--telemetry-attributes` flag). Use `--workers 1` so the `--traces` count (which is **per worker**) is exact:
+
+```bash
+telemetrygen traces --otlp-insecure --otlp-endpoint localhost:4317 \
+  --workers 1 --traces 5 --otlp-attributes 'deployment.environment="staging"'
+```
+
+Flags used, all confirmed against the `otel-telemetrygen` skill (`references/flags.md`):
+
+- `--otlp-insecure` — disable transport security (common flag).
+- `--otlp-endpoint` — destination, defaults to `localhost:4317` for gRPC (common flag).
+- `--workers` — concurrent workers; `1` keeps the count exact (common flag).
+- `--traces` — traces **per worker** (trace-specific flag).
+- `--otlp-attributes` — **resource**-level attribute as `key="value"` (string values must be quoted; repeatable). This is the resource counterpart of `--telemetry-attributes`, which sets span/log/datapoint attributes that the `resource` processor does **not** touch.
+
+**What proves it worked:** in the `debug` exporter output, the **Resource attributes** block (not the span attributes) shows `deployment.environment: Str(prod)` — the value sent (`staging`) has been overwritten by the `upsert` action. The attribute appears once per resource, shared across all spans in the batch.
+
+To prove the **insert** half of `upsert`, drop `--otlp-attributes` and send plain traces; `deployment.environment: Str(prod)` still appears in the Resource attributes because the key was absent and got inserted. (Use `insert` instead of `upsert` to confirm it leaves a pre-existing resource value untouched, or `update` to confirm it only writes when the key already exists.)
+
+You can run the same recipe with `telemetrygen logs ... --logs 5` (or `metrics ... --metrics 5`) and a matching pipeline; `--logs`/`--metrics` are likewise per-worker, so keep `--workers 1`. `--otlp-attributes` sets the resource for every signal type.

--- a/skills/otel-collector/components/resource/verification.md
+++ b/skills/otel-collector/components/resource/verification.md
@@ -4,7 +4,7 @@ See [Verification harness](../../SKILL.md#verification-harness) for how to run t
 
 `resource` ships in the `core`, `contrib`, and `k8s` distributions.
 
-Config (`resource-verify.yaml`) — an `upsert` action that sets (or overwrites) the `deployment.environment` **resource** attribute:
+Config (`resource-verify.yaml`) — an `upsert` action that sets (or overwrites) the `deployment.environment.name` **resource** attribute:
 
 ```yaml
 receivers:
@@ -15,7 +15,7 @@ receivers:
 processors:
   resource:
     attributes:
-      - key: deployment.environment
+      - key: deployment.environment.name
         value: prod
         action: upsert
 exporters:
@@ -29,11 +29,11 @@ service:
       exporters: [debug]
 ```
 
-Send a known number of traces whose **resource** carries `deployment.environment` with a *different* value, so the `upsert` overwrite is observable. telemetrygen sets resource attributes with `--otlp-attributes` (telemetry-level attributes use the separate `--telemetry-attributes` flag). Use `--workers 1` so the `--traces` count (which is **per worker**) is exact:
+Send a known number of traces whose **resource** carries `deployment.environment.name` with a *different* value, so the `upsert` overwrite is observable. telemetrygen sets resource attributes with `--otlp-attributes` (telemetry-level attributes use the separate `--telemetry-attributes` flag). Use `--workers 1` so the `--traces` count (which is **per worker**) is exact:
 
 ```bash
 telemetrygen traces --otlp-insecure --otlp-endpoint localhost:4317 \
-  --workers 1 --traces 5 --otlp-attributes 'deployment.environment="staging"'
+  --workers 1 --traces 5 --otlp-attributes 'deployment.environment.name="staging"'
 ```
 
 Flags used, all confirmed against the `otel-telemetrygen` skill (`references/flags.md`):
@@ -44,8 +44,8 @@ Flags used, all confirmed against the `otel-telemetrygen` skill (`references/fla
 - `--traces` — traces **per worker** (trace-specific flag).
 - `--otlp-attributes` — **resource**-level attribute as `key="value"` (string values must be quoted; repeatable). This is the resource counterpart of `--telemetry-attributes`, which sets span/log/datapoint attributes that the `resource` processor does **not** touch.
 
-**What proves it worked:** in the `debug` exporter output, the **Resource attributes** block (not the span attributes) shows `deployment.environment: Str(prod)` — the value sent (`staging`) has been overwritten by the `upsert` action. The attribute appears once per resource, shared across all spans in the batch.
+**What proves it worked:** in the `debug` exporter output, the **Resource attributes** block (not the span attributes) shows `deployment.environment.name: Str(prod)` — the value sent (`staging`) has been overwritten by the `upsert` action. The attribute appears once per resource, shared across all spans in the batch.
 
-To prove the **insert** half of `upsert`, drop `--otlp-attributes` and send plain traces; `deployment.environment: Str(prod)` still appears in the Resource attributes because the key was absent and got inserted. (Use `insert` instead of `upsert` to confirm it leaves a pre-existing resource value untouched, or `update` to confirm it only writes when the key already exists.)
+To prove the **insert** half of `upsert`, drop `--otlp-attributes` and send plain traces; `deployment.environment.name: Str(prod)` still appears in the Resource attributes because the key was absent and got inserted. (Use `insert` instead of `upsert` to confirm it leaves a pre-existing resource value untouched, or `update` to confirm it only writes when the key already exists.)
 
 You can run the same recipe with `telemetrygen logs ... --logs 5` (or `metrics ... --metrics 5`) and a matching pipeline; `--logs`/`--metrics` are likewise per-worker, so keep `--workers 1`. `--otlp-attributes` sets the resource for every signal type.


### PR DESCRIPTION
Adds the `attributes` and `resource` processors — **Phase 3, backlog item #4** (two closely related components, documented as adjacent cross-linked pages).

Per-component directories (lean `README.md` + `configuration.md` / `verification.md` / `advanced.md` / `quirks.md`), sourced from the ai-context READMEs. `resource` is the same action grammar scoped to resource attributes; the pages cross-link and call out the key differences (attributes doesn't touch resource attrs; resource has no include/exclude matching).

## Verified end-to-end (contrib v0.152.0 + telemetrygen)
- **attributes**: an `upsert env=prod` action overwrote the sent `env=staging` on all 10 spans. ✅
- **resource**: an `upsert deployment.environment.name=prod` action overwrote the sent `staging` in the Resource attributes (5/5 resources). ✅

Flags verified against the `otel-telemetrygen` skill, including the `--telemetry-attributes` (span-level) vs `--otlp-attributes` (resource-level) distinction, and `--workers 1` for exact per-worker counts.

## SKILL.md
Two index rows + `attributes`/`resource` frontmatter keywords.

Closes ENG-2205. Phase 3 backlog (E-2201).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs for the attributes processor: configuration, advanced patterns, quirks, and verification recipes.
  * Added comprehensive docs for the resource processor: configuration, advanced usage, quirks, and verification recipes.
  * Updated the skill index/overview to include the attributes and resource processors and broadened trigger/coverage descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->