### PR TITLE
otel-collector: add routing connector (per-component directory)

### DIFF
--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: otel-collector
-description: OpenTelemetry Collector component configuration. Use when authoring, reviewing, or debugging Collector YAML for a specific receiver, processor, exporter, connector, or extension — config keys, defaults, validation rules, signal support, stability levels, and component-level gotchas. Triggers on questions about specific components such as `log_dedup` / `logdedup`, `interval` (metric aggregation), `tail_sampling`, `drain`, `redaction`, `filter`, `transform`, `probabilistic_sampler`, `attributes`, `resource`, `k8s_attributes` / `k8sattributes` (Kubernetes metadata enrichment), and other Collector components covered in `components/`.
+description: OpenTelemetry Collector component configuration. Use when authoring, reviewing, or debugging Collector YAML for a specific receiver, processor, exporter, connector, or extension — config keys, defaults, validation rules, signal support, stability levels, and component-level gotchas. Triggers on questions about specific components such as `log_dedup` / `logdedup`, `interval` (metric aggregation), `tail_sampling`, `drain`, `redaction`, `filter`, `transform`, `probabilistic_sampler`, `attributes`, `resource`, `k8s_attributes` / `k8sattributes` (Kubernetes metadata enrichment), `routing` (connector — route telemetry to pipelines by OTTL condition), and other Collector components covered in `components/`.
 ---
 
 # OpenTelemetry Collector
@@ -34,6 +34,7 @@ Each component is a directory under `components/<type>/`. The `File` column poin
 | `attributes` | `components/attributes/README.md` | processor | traces, metrics, logs | Beta | Modifies span/log/datapoint **attributes** via an ordered action list (insert/update/upsert/delete/hash/extract/convert), scoped by include/exclude matching. |
 | `resource` | `components/resource/README.md` | processor | traces, metrics, logs, profiles | Beta (traces/metrics/logs), Development (profiles) | Modifies the **resource** attributes of telemetry via the same action grammar as `attributes` (e.g. set `service.name`, drop noisy resource keys). No include/exclude matching. |
 | `k8s_attributes` | `components/k8s_attributes/README.md` | processor | traces, metrics, logs, profiles | Beta (traces/metrics/logs), Development (profiles) | Enriches telemetry with Kubernetes pod/namespace/node/workload metadata, associating each record to a pod by IP or resource attribute. Renamed from `k8sattributes` in v0.146.0; alias preserved. |
+| `routing` | `components/routing/README.md` | connector | traces, metrics, logs | Alpha | Routes same-signal telemetry to different pipelines by OTTL `condition`/`statement` per context; ordered table, first match wins, `default_pipelines` fallback. Replaces the deprecated `routingprocessor`. |
 
 ## Collector-wide conventions
 

--- a/skills/otel-collector/components/routing/README.md
+++ b/skills/otel-collector/components/routing/README.md
@@ -1,0 +1,43 @@
+# `routing` connector
+
+| | |
+|-|-|
+| Kind | connector |
+| Type | `routing` |
+| Signals | traces→traces (Alpha), metrics→metrics (Alpha), logs→logs (Alpha) — same-signal routing, no transformation |
+| Distributions | contrib, k8s |
+| Go module | `github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector` |
+| Upstream README | <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector> |
+
+## Description
+
+Routes telemetry to different pipelines based on OTTL conditions, keeping the **same signal type** (traces→traces, metrics→metrics, logs→logs) — it forwards data unchanged, it does not transform it. As a connector it is wired as the **exporter** of an input pipeline and the **receiver** of one or more output pipelines; the input pipeline hands its data to `routing`, which then dispatches it to the matching output pipelines.
+
+The decision is driven by an ordered `table` of routes, each an OTTL `condition` (or a `route() where …` `statement`) evaluated in a chosen `context` (resource/span/metric/datapoint/log/request). Routes are evaluated **in order** and each piece of telemetry matches **at most one route** — to fan out to several pipelines, list them all under that route's `pipelines`. Telemetry that matches no route goes to `default_pipelines`, or is **dropped** if none is set. This replaces the deprecated `routingprocessor`. The OTTL expression language itself lives in the `otel-ottl` skill; this page documents the connector's config surface.
+
+## Main use-cases
+
+Use when:
+- You need to send telemetry to different backends/pipelines by attribute (tenant, region, environment, severity, service).
+- You want a fan-out: the same data to multiple pipelines based on one condition.
+- You need request-level routing from HTTP headers / gRPC metadata (multi-tenant isolation before parsing telemetry).
+- You want to split high-priority from low-priority data (e.g. errors to expensive storage, the rest to cheap storage).
+
+Avoid when:
+- You only need to **drop** telemetry — use `filter`.
+- You need to **modify** telemetry — use `transform`.
+- You need to change signal type (e.g. spans→metrics) — that is what transforming connectors like `spanmetrics` are for.
+
+## Related components
+
+- `filter` — drops telemetry via OTTL; use it when the goal is to remove data, not redirect it.
+- `transform` — mutates telemetry via OTTL; use it to rewrite data rather than route it.
+- `otel-ottl` skill — the `condition`/`statement` expression language, contexts, and functions used in the routing `table`.
+- `routingprocessor` — the deprecated processor this connector replaces (see [Known quirks](quirks.md) for migration).
+
+## Details
+
+- [Configuration](configuration.md) — full config tables for top-level keys and `table` items, supported contexts per signal, statement-vs-condition rules, `error_mode` semantics, and the connector pipeline wiring.
+- [Verification](verification.md) — telemetrygen recipe that splits telemetry across two pipelines, each writing to its own `file` exporter, proving routing and the default fallback.
+- [Advanced use-cases](advanced.md) — named instances, fan-out, multi-tenant request routing, severity/environment routing, `action: move` vs `copy`, and migrating from `routingprocessor` / the removed `match_once`.
+- [Known quirks](quirks.md) — dropped unmatched data, `error_mode` data loss, mutual exclusivity, request-context grammar limits, split Resource bundles, a validation-error→fix table, and stability caveats.

--- a/skills/otel-collector/components/routing/advanced.md
+++ b/skills/otel-collector/components/routing/advanced.md
@@ -1,0 +1,140 @@
+# `routing`: advanced use-cases
+
+## Named instances for independent dimensions
+
+Each piece of telemetry matches at most one route, so a single `routing` instance can't route on two independent dimensions at once. Use one named instance per dimension and list both as exporters of the input pipeline — each gets an independent copy of the data:
+
+```yaml
+connectors:
+  routing/tenant:
+    table:
+      - condition: attributes["tenant"] == "acme"
+        pipelines: [logs/acme]
+      - condition: attributes["tenant"] == "ecorp"
+        pipelines: [logs/ecorp]
+  routing/region:
+    table:
+      - condition: attributes["region"] == "us-east"
+        pipelines: [logs/east]
+      - condition: attributes["region"] == "us-west"
+        pipelines: [logs/west]
+
+service:
+  pipelines:
+    logs/in:
+      receivers: [otlp]
+      exporters: [routing/tenant, routing/region]   # both evaluate independently
+```
+
+## Fan-out to multiple pipelines in one route
+
+To send the same matched telemetry to several pipelines, list them all under one route — telemetry is copied to each:
+
+```yaml
+table:
+  - context: span
+    condition: duration > 5000000000          # > 5s
+    pipelines: [traces/slow, traces/all]       # slow traces go to BOTH
+```
+
+## Multi-tenant routing on request metadata
+
+`request` context routes once per incoming request, before telemetry is parsed — ideal for tenant isolation from an HTTP header or gRPC metadata. It requires `condition` and supports only `==`/`!=`:
+
+```yaml
+connectors:
+  routing:
+    default_pipelines: [logs/default]
+    table:
+      - context: request
+        condition: request["X-Tenant"] == "acme"
+        pipelines: [logs/acme]
+      - context: request
+        condition: request["X-Tenant"] == "ecorp"
+        pipelines: [logs/ecorp]
+```
+
+HTTP headers match case-insensitively; for gRPC metadata use lowercase keys (`request["x-tenant"]`).
+
+## Severity and environment routing
+
+```yaml
+# logs: cheap storage for low severity, expensive for errors
+table:
+  - context: log
+    condition: severity_number < SEVERITY_NUMBER_ERROR
+    pipelines: [logs/cheap]
+  - context: log
+    condition: severity_number >= SEVERITY_NUMBER_ERROR
+    pipelines: [logs/important]
+```
+
+```yaml
+# traces: production to one backend, everything else to the default
+connectors:
+  routing:
+    default_pipelines: [traces/dev]
+    table:
+      - context: resource
+        condition: attributes["deployment.environment"] == "production"
+        pipelines: [traces/prod]
+```
+
+Order routes from specific to general — the first match wins, so a broad route placed first will shadow a narrower one below it.
+
+## `action: move` vs `copy`
+
+`copy` (default) leaves matched data available to later routes and `default_pipelines`; `move` removes it from any further evaluation. Use `move` when a match is terminal and the data must not also reach the default:
+
+```yaml
+table:
+  - context: log
+    condition: severity_number >= SEVERITY_NUMBER_ERROR
+    action: move                       # errors leave here, never hit default_pipelines
+    pipelines: [logs/errors]
+```
+
+## Migrating from `routingprocessor`
+
+The connector replaces the deprecated `routingprocessor`. The processor sat inside one pipeline and routed to **exporters** via a `from_attribute` + `value` table; the connector bridges pipelines and routes to **pipelines** via OTTL.
+
+```yaml
+# OLD (routingprocessor)
+processors:
+  routing:
+    from_attribute: X-Tenant
+    table:
+      - value: acme
+        exporters: [otlp/acme]
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [routing]
+      exporters: [otlp/acme]
+```
+
+```yaml
+# NEW (routing connector)
+connectors:
+  routing:
+    default_pipelines: [logs/default]
+    table:
+      - context: resource
+        condition: attributes["X-Tenant"] == "acme"
+        pipelines: [logs/acme]
+service:
+  pipelines:
+    logs/in:   {receivers: [otlp], exporters: [routing]}
+    logs/acme: {receivers: [routing], exporters: [otlp/acme]}
+    logs/default: {receivers: [routing], exporters: [otlp/default]}
+```
+
+## Migrating from `match_once`
+
+`match_once` was removed in v0.120.0; each item now matches at most one route. To reproduce the old `match_once: false` (multi-match) behavior:
+
+- **Parallel routers** — split independent dimensions into separate named instances (see above). Each gets its own copy, so an item can match in both. Simplest when no `default_pipelines` is needed.
+- **Enumerate combinations** — for a small fixed set, write one route per combination and list all target pipelines in it (e.g. `condition: env=="prod" and region=="east"` → `pipelines: [logs/prod, logs/east]`). Practical only for a handful of dimensions.
+
+Prefer parallel routers; enumeration grows combinatorially.

--- a/skills/otel-collector/components/routing/configuration.md
+++ b/skills/otel-collector/components/routing/configuration.md
@@ -1,0 +1,125 @@
+# `routing`: configuration
+
+## Typical config
+
+```yaml
+connectors:
+  routing:
+    error_mode: ignore
+    default_pipelines: [logs/default]
+    table:
+      - context: resource
+        condition: attributes["tenant"] == "acme"
+        pipelines: [logs/acme]
+      - context: log
+        condition: severity_number >= SEVERITY_NUMBER_ERROR
+        pipelines: [logs/errors]
+
+service:
+  pipelines:
+    logs/in:
+      receivers: [otlp]
+      exporters: [routing]            # connector as exporter of the input pipeline
+    logs/acme:
+      receivers: [routing]            # connector as receiver of an output pipeline
+      exporters: [otlphttp/acme]
+    logs/errors:
+      receivers: [routing]
+      exporters: [otlphttp/errors]
+    logs/default:
+      receivers: [routing]
+      exporters: [otlphttp/default]
+```
+
+## Top-level configuration reference
+
+| Key | Type | Default | Required | Meaning |
+|-----|------|---------|----------|---------|
+| `table` | array of RoutingTableItem | — | **yes** (≥1 route) | The routing table. Routes are evaluated in order; each piece of telemetry matches at most one route. |
+| `default_pipelines` | array of pipeline IDs | none | no | Pipelines for telemetry that matches no route. **If unset, unmatched telemetry is dropped.** |
+| `error_mode` | string | `propagate` | no | How OTTL evaluation errors are handled: `propagate`, `ignore`, or `silent` (see below). |
+
+## RoutingTableItem reference
+
+| Key | Type | Default | Required | Meaning |
+|-----|------|---------|----------|---------|
+| `context` | string | `resource` | no | OTTL context the expression runs in: `resource`, `span`, `metric`, `datapoint`, `log`, or `request`. Must be valid for the pipeline's signal (see table below). |
+| `statement` | string | — | one of `statement`/`condition` | OTTL statement in `route() where <expr>` form. **Mutually exclusive with `condition`.** Not allowed for `request` context. |
+| `condition` | string | — | one of `statement`/`condition` | OTTL boolean expression (no `route() where`). **Mutually exclusive with `statement`.** Required for `request` context. |
+| `action` | string | `copy` | no | `copy` leaves matched data available to later routes and `default_pipelines`; `move` removes it from further evaluation. |
+| `pipelines` | array of pipeline IDs | — | **yes** (≥1) | Output pipelines this route forwards matching telemetry to. Listing several fans the data out to all of them. |
+
+Exactly one of `statement` / `condition` must be set per route — setting both, or neither, fails validation.
+
+## Supported contexts by signal
+
+A route's `context` must be supported by the signal of the pipeline it routes:
+
+| Signal | Supported contexts |
+|--------|--------------------|
+| Traces | `resource`, `span`, `request` |
+| Metrics | `resource`, `metric`, `datapoint`, `request` |
+| Logs | `resource`, `log`, `request` |
+
+Coarser contexts are cheaper: `resource` evaluates once per resource bundle, while `span`/`metric`/`log` evaluate per item and `datapoint` per data point. Use the coarsest context that expresses your condition. `request` evaluates once per incoming request, before telemetry is parsed.
+
+## `statement` vs `condition`
+
+Both express the same boolean test in OTTL; they differ only in syntax and which OTTL functions you can call:
+
+```yaml
+# condition: a bare boolean expression
+- condition: attributes["env"] == "prod"
+  pipelines: [logs/prod]
+
+# statement: route() where <expr> — lets you also run editors (e.g. delete_key)
+#            against the data in the same step, before it is routed
+- statement: route() where attributes["env"] == "prod" and delete_key(attributes, "internal.debug")
+  pipelines: [logs/prod]
+```
+
+Use `condition` for a plain match (recommended for clarity); reach for `statement` only when you want to mutate the data in the same pass. For the full expression language — paths, converters, editors — see the `otel-ottl` skill.
+
+### `request` context (limited grammar)
+
+`request` reads HTTP headers / gRPC metadata and requires `condition` (a `statement` is rejected). It supports only a single simple comparison — `==` or `!=` — with no `and`/`or`:
+
+```yaml
+- context: request
+  condition: request["X-Tenant"] == "acme"
+  pipelines: [logs/acme]
+```
+
+HTTP headers are matched case-insensitively; gRPC metadata keys are lowercased, so use lowercase keys when routing gRPC traffic (`request["x-tenant"]`). The receiver must propagate request metadata (the `otlp` receiver does).
+
+## `error_mode`
+
+Controls what happens when an OTTL expression fails to evaluate (missing attribute, type mismatch, etc.):
+
+| Value | Behavior |
+|-------|----------|
+| `propagate` (default) | The connector returns an error and the **payload is dropped** from the collector. |
+| `ignore` | The error is logged and the payload is sent to `default_pipelines`. |
+| `silent` | Same as `ignore`, but the error is not logged. |
+
+Prefer `ignore` in production so a transient OTTL error doesn't drop data.
+
+## Pipeline wiring
+
+`routing` is a connector: it bridges pipelines rather than living inside one. Wire it as the **exporter** of the input pipeline and the **receiver** of each output pipeline (including the default). Pipeline definition order does not matter — only that the connector name appears in both roles:
+
+```yaml
+service:
+  pipelines:
+    logs/in:                # input
+      receivers: [otlp]
+      exporters: [routing]
+    logs/acme:              # output
+      receivers: [routing]
+      exporters: [otlphttp/acme]
+    logs/default:           # default fallback output
+      receivers: [routing]
+      exporters: [otlphttp/default]
+```
+
+Every pipeline ID referenced in `table[].pipelines` and in `default_pipelines` must exist as a pipeline that lists `routing` as a receiver, otherwise the collector fails to start.

--- a/skills/otel-collector/components/routing/quirks.md
+++ b/skills/otel-collector/components/routing/quirks.md
@@ -1,0 +1,40 @@
+# `routing`: known quirks
+
+## Unmatched telemetry is dropped without `default_pipelines`
+
+If a piece of telemetry matches no route and `default_pipelines` is not set, it is **silently dropped** — no error, no log. This is the most common cause of "where did my data go?" with this connector. Always configure `default_pipelines` (even just a catch-all archive or a `debug` pipeline) unless dropping unmatched data is genuinely what you want.
+
+## `error_mode: propagate` drops the payload on OTTL errors
+
+With the default `error_mode: propagate`, any OTTL evaluation error — a missing attribute, a type mismatch — makes the connector return an error and the **whole payload is dropped** from the collector. In production use `error_mode: ignore`, which logs the error and sends the payload to `default_pipelines` instead — so `ignore` only actually rescues data when `default_pipelines` is set; without it the errored payload still has nowhere to go. Guard fragile conditions with nil checks (`attributes["k"] != nil and attributes["k"] == "v"`) so a missing key doesn't error in the first place.
+
+## `statement` and `condition` are mutually exclusive
+
+Each route needs **exactly one** of `statement` or `condition`. Setting both, or neither, fails config validation. `statement` is the `route() where <expr>` form (and can also run editors like `delete_key` in the same pass); `condition` is a bare boolean expression. Pick one per route.
+
+## `request` context has a limited grammar
+
+`request` routing supports only a single `==` or `!=` comparison — no `and`/`or`, and a `statement` is rejected (it must be `condition`). For compound request logic, use multiple `request` routes or move the decision to `resource` context. HTTP headers match case-insensitively, but gRPC metadata keys are lowercased — use lowercase keys (`request["x-tenant"]`) for gRPC traffic. The receiver must actually propagate request metadata (the `otlp` receiver does; file-based receivers don't).
+
+## Item-level contexts can split a Resource bundle across pipelines
+
+`span`, `metric`, `datapoint`, and `log` contexts evaluate per item, so a single incoming ResourceSpans/ResourceMetrics/ResourceLogs bundle can be torn apart — some items to one pipeline, others to another (or to the default). This is usually intended, but it means downstream pipelines may receive partial resource bundles. Use `resource` context when you want whole bundles kept together.
+
+## Validation errors → fixes
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `the routing table is empty` | `table` missing or empty | Add at least one route. |
+| `no condition or statement provided` | route has neither | Add one of `statement`/`condition`. |
+| `both condition and statement provided` | route has both | Remove one. |
+| `no pipelines defined` | route missing `pipelines` | Add at least one pipeline ID. |
+| `'request' context requires a 'condition'` | `request` route used a `statement` | Use `condition` for `request` context. |
+| `invalid context: <name>` | unsupported/typo context | Use `resource`, `span`, `metric`, `datapoint`, `log`, or `request` (and one valid for the signal). |
+
+## `match_once` was removed in v0.120.0
+
+`match_once` (deprecated v0.116.0, removed v0.120.0) is gone — each item now matches **at most one route**. Configs using `match_once: false` no longer load. To fan out, list multiple pipelines in one route; to route on independent dimensions, use parallel named instances (see [advanced](advanced.md#migrating-from-match_once)).
+
+## Stability caveats
+
+All three signal pairs (traces, metrics, logs) are **Alpha**. Config surface and behavior can shift between releases — confirm against the upstream README for your exact collector version. The connector replaces the deprecated `routingprocessor`; new configs should use the connector form.

--- a/skills/otel-collector/components/routing/verification.md
+++ b/skills/otel-collector/components/routing/verification.md
@@ -1,0 +1,67 @@
+# `routing`: verification
+
+See [Verification harness](../../SKILL.md#verification-harness) for how to run this end-to-end.
+
+`routing` ships in the `contrib` and `k8s` distributions, so a stock contrib collector can run this.
+
+The idea: send logs carrying a resource attribute `tenant`, route the ones where `tenant == "acme"` to one pipeline and let everything else fall through to `default_pipelines`. Each output pipeline writes to its **own** `file` exporter, so the split is visible as two distinct files. Run telemetrygen twice — once with the matching attribute, once without — and check which file each batch lands in.
+
+Config (`routing-verify.yaml`):
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+connectors:
+  routing:
+    error_mode: ignore
+    default_pipelines: [logs/default]
+    table:
+      - context: resource
+        condition: attributes["tenant"] == "acme"
+        pipelines: [logs/match]
+exporters:
+  file/match:
+    path: /tmp/routed-match.json
+  file/default:
+    path: /tmp/routed-default.json
+service:
+  pipelines:
+    logs/in:
+      receivers: [otlp]
+      exporters: [routing]
+    logs/match:
+      receivers: [routing]
+      exporters: [file/match]
+    logs/default:
+      receivers: [routing]
+      exporters: [file/default]
+```
+
+Send a matching batch and a non-matching batch — see the `otel-telemetrygen` skill:
+
+```bash
+# matches the route -> /tmp/routed-match.json
+telemetrygen logs --otlp-insecure --otlp-endpoint localhost:4317 \
+  --logs 3 --workers 1 --otlp-attributes 'tenant="acme"'
+
+# no matching attribute -> falls through to /tmp/routed-default.json
+telemetrygen logs --otlp-insecure --otlp-endpoint localhost:4317 \
+  --logs 2 --workers 1 --otlp-attributes 'tenant="other"'
+```
+
+Flags confirmed against the `otel-telemetrygen` skill (`references/flags.md`): `--otlp-insecure` (bool), `--otlp-endpoint` (string), `--logs` (int, **per worker**; ignored if `--duration` is set, so no `--duration` here, and `--workers 1` makes the count exact), and `--otlp-attributes` (`key="value"`, **resource-level** — the right scope, since the route uses `context: resource` and reads `attributes["tenant"]` off the resource). No flag here invents a value.
+
+**What proves it worked:** `/tmp/routed-match.json` holds the 3 records sent with `tenant="acme"` and `/tmp/routed-default.json` holds the 2 records sent with `tenant="other"`. telemetrygen sends nothing on a `tenant` attribute by default, so the split is unambiguous — records only reach `file/match` when the route condition matched, and only reach `file/default` via the unmatched fallback. The `file` exporter writes one newline-delimited JSON object per export, so count the log records inside each file (the resource-level `tenant` attribute appears once per batch, not once per record):
+
+```bash
+# each batch is one JSON line carrying its logRecords; count records, not the resource attr
+for f in /tmp/routed-match.json /tmp/routed-default.json; do
+  echo "$f: $(grep -o '"timeUnixNano"' "$f" | wc -l | tr -d ' ') records"
+done
+# => routed-match.json: 3 records, routed-default.json: 2 records
+```
+
+> Verified end-to-end on `otel/opentelemetry-collector-contrib:0.152.0`: the `tenant="acme"` batch landed only in `routed-match.json` (3 records) and the `tenant="other"` batch only in `routed-default.json` (2 records). Exact JSON field rendering can shift between collector versions; what matters is the matching records land in `routed-match.json` and the rest in `routed-default.json` — and that removing `default_pipelines` would make the non-matching batch vanish entirely (dropped), the behavior [quirks](quirks.md) warns about.


### PR DESCRIPTION
## What

Adds a component page for the OpenTelemetry Collector **`routing` connector** — the **first connector** documented in the `otel-collector` skill (all prior pages were processors).

`routing` forwards same-signal telemetry (traces→traces, metrics→metrics, logs→logs) to different pipelines based on an ordered table of OTTL `condition`/`statement` routes evaluated per context (resource/span/metric/datapoint/log/request). First match wins, each item matches at most one route, unmatched data goes to `default_pipelines` (or is dropped). Replaces the deprecated `routingprocessor`.

Follows the established per-component structure:
- `README.md` — lean contract (metadata table, description, use-cases, related, Details index)
- `configuration.md` — top-level + RoutingTableItem reference, contexts-by-signal, statement-vs-condition, `error_mode`, pipeline wiring
- `verification.md` — telemetrygen recipe splitting telemetry across two `file` exporters
- `advanced.md` — named instances, fan-out, request-metadata routing, `move` vs `copy`, `routingprocessor`/`match_once` migration
- `quirks.md` — dropped data, `error_mode` data loss, mutual exclusivity, request grammar, split bundles, validation-error→fix table, stability

All config keys/defaults/validation trace to the upstream-mirrored source; no invention.

## Verified end-to-end

Ran the verification recipe for real on `otel/opentelemetry-collector-contrib:0.152.0`:
- `telemetrygen logs --logs 3 --workers 1 --otlp-attributes 'tenant="acme"'` → routed to the match pipeline → `routed-match.json` (**3 records**)
- `telemetrygen logs --logs 2 --workers 1 --otlp-attributes 'tenant="other"'` → fell through to `default_pipelines` → `routed-default.json` (**2 records**)

The split was clean and unambiguous (telemetrygen emits no `tenant` attribute by default). telemetrygen flags confirmed against the `otel-telemetrygen` skill; `--otlp-attributes` is resource-level, matching the `context: resource` route.

## SKILL.md changes

- Added the component-index row: `routing` · connector · traces/metrics/logs · Alpha.
- Added the `routing` trigger keyword to the frontmatter `description`.

## Stability

Alpha for all three signal pairs (confirmed against upstream `metadata.yaml`).

Closes ENG-2207

🤖 Generated with [Claude Code](https://claude.com/claude-code)