### PR TITLE
otel-collector: add memory_limiter component (per-component directory)

### DIFF
--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: otel-collector
-description: OpenTelemetry Collector component configuration. Use when authoring, reviewing, or debugging Collector YAML for a specific receiver, processor, exporter, connector, or extension — config keys, defaults, validation rules, signal support, stability levels, and component-level gotchas. Triggers on questions about specific components such as `log_dedup` / `logdedup`, `interval` (metric aggregation), `tail_sampling`, `drain`, `redaction`, `filter`, `transform`, `probabilistic_sampler`, `attributes`, `resource`, `k8s_attributes` / `k8sattributes` (Kubernetes metadata enrichment), `routing` (connector — route telemetry to pipelines by OTTL condition), and other Collector components covered in `components/`.
+description: OpenTelemetry Collector component configuration. Use when authoring, reviewing, or debugging Collector YAML for a specific receiver, processor, exporter, connector, or extension — config keys, defaults, validation rules, signal support, stability levels, and component-level gotchas. Triggers on questions about specific components such as `log_dedup` / `logdedup`, `interval` (metric aggregation), `tail_sampling`, `drain`, `redaction`, `filter`, `transform`, `probabilistic_sampler`, `attributes`, `resource`, `k8s_attributes` / `k8sattributes` (Kubernetes metadata enrichment), `routing` (connector — route telemetry to pipelines by OTTL condition), `memory_limiter` (OOM safety valve / backpressure), and other Collector components covered in `components/`.
 ---
 
 # OpenTelemetry Collector
@@ -35,6 +35,7 @@ Each component is a directory under `components/<type>/`. The `File` column poin
 | `resource` | `components/resource/README.md` | processor | traces, metrics, logs, profiles | Beta (traces/metrics/logs), Development (profiles) | Modifies the **resource** attributes of telemetry via the same action grammar as `attributes` (e.g. set `service.name`, drop noisy resource keys). No include/exclude matching. |
 | `k8s_attributes` | `components/k8s_attributes/README.md` | processor | traces, metrics, logs, profiles | Beta (traces/metrics/logs), Development (profiles) | Enriches telemetry with Kubernetes pod/namespace/node/workload metadata, associating each record to a pod by IP or resource attribute. Renamed from `k8sattributes` in v0.146.0; alias preserved. |
 | `routing` | `components/routing/README.md` | connector | traces, metrics, logs | Alpha | Routes same-signal telemetry to different pipelines by OTTL `condition`/`statement` per context; ordered table, first match wins, `default_pipelines` fallback. Replaces the deprecated `routingprocessor`. |
+| `memory_limiter` | `components/memory_limiter/README.md` | processor | traces, metrics, logs, profiles | Beta (traces/metrics/logs), Alpha (profiles) | Safety valve against OOM: refuses data with backpressure when Go heap exceeds a soft/hard limit, forcing GC above the hard limit. Belongs first in every pipeline; pairs with `GOMEMLIMIT`. |
 
 ## Collector-wide conventions
 

--- a/skills/otel-collector/components/memory_limiter/README.md
+++ b/skills/otel-collector/components/memory_limiter/README.md
@@ -1,0 +1,40 @@
+# `memory_limiter` processor
+
+| | |
+|-|-|
+| Kind | processor |
+| Type | `memory_limiter` |
+| Signals | traces (Beta), metrics (Beta), logs (Beta), profiles (Alpha) |
+| Distributions | core, contrib, k8s |
+| Go module | `go.opentelemetry.io/collector/processor/memorylimiterprocessor` |
+| Upstream README | <https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor> |
+
+## Description
+
+A safety valve that keeps the Collector from being OOM-killed. A background goroutine reads Go heap allocation (`runtime.MemStats.Alloc`) every `check_interval` and compares it against two thresholds derived from the configured limit: a **soft limit** (`limit_mib - spike_limit_mib`) and a **hard limit** (`limit_mib`). Above the soft limit the processor sets a `mustRefuse` flag and every data path returns a **non-permanent** `ErrDataRefused` to the preceding component — backpressure that well-behaved receivers retry with backoff. Above the hard limit it additionally forces a `runtime.GC()`. When heap drops back below the soft limit it resumes normally; no manual intervention.
+
+It measures **heap**, not process RSS — total process memory runs 50–100 MiB higher, so container limits should sit above `limit_mib`. The processor does not mutate data (`MutatesData: false`); it only accepts or refuses. It is a safety net, not a sizing or performance tool — a chronically undersized collector will simply refuse data constantly. Use it together with the `GOMEMLIMIT` environment variable so Go's GC paces toward the same target.
+
+## Main use-cases
+
+Use it when:
+- **Always** — on every production Collector, as the **first** processor in every pipeline.
+- You run in a memory-capped environment (Kubernetes pod, Docker container) and must avoid OOM kills under traffic spikes.
+- You want early backpressure to receivers so clients rate-limit at the source before buffers fill downstream.
+
+Avoid it when:
+- You are reaching for it to fix throughput on an undersized collector — size the collector first, then add this as a safety net (see [Known quirks](quirks.md)).
+- A minimal verification/repro pipeline where you are isolating another component on purpose (the skill's verification configs omit it deliberately).
+
+## Related components
+
+- `batch` / exporter `sending_queue.batch` — batching allocates buffers; `memory_limiter` must sit **before** it so refusal happens before data is buffered.
+- `tail_sampling`, `transform`, `log_dedup` — stateful/allocating processors; place them after `memory_limiter` so memory pressure refuses data before it reaches them.
+- The **`memory_limiter` extension** — same checker exposed as gRPC/HTTP middleware (experimental); see [Known quirks](quirks.md).
+
+## Details
+
+- [Configuration](configuration.md) — full config table (`check_interval`, `limit_mib` vs `limit_percentage`, spike limits, GC intervals), validation rules, and the soft/hard-limit mechanism.
+- [Verification](verification.md) — telemetrygen recipe that forces refusal with a deliberately tiny limit and shows `ErrDataRefused` in the logs.
+- [Advanced use-cases](advanced.md) — `GOMEMLIMIT` pairing, percentage mode for Kubernetes, spike sizing for bursty traffic, multi-pipeline singleton behavior.
+- [Known quirks](quirks.md) — heap-vs-RSS, required fields, `limit_percentage` cgroup detection, GC-interval ordering, the singleton checker, the experimental extension variant, stability caveats.

--- a/skills/otel-collector/components/memory_limiter/advanced.md
+++ b/skills/otel-collector/components/memory_limiter/advanced.md
@@ -1,0 +1,81 @@
+# `memory_limiter`: advanced use-cases
+
+## Pair with `GOMEMLIMIT`
+
+Set the `GOMEMLIMIT` environment variable to roughly **80% of the hard limit**. It tunes Go's garbage collector to target that heap level, so the runtime reclaims memory *before* the limiter has to start refusing — the two work together rather than the limiter being the only brake:
+
+```yaml
+# Container env
+env:
+  - name: GOMEMLIMIT
+    value: "3200MiB"   # ~80% of limit_mib
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 800
+```
+
+`GOMEMLIMIT` is a soft target for the GC pacer; `memory_limiter` is the hard backstop that refuses data. Use both. See <https://pkg.go.dev/runtime#hdr-Environment_Variables>.
+
+## Percentage mode for Kubernetes
+
+When the pod's memory limit varies across environments, use `limit_percentage` so the collector adapts without a config change. It reads the cgroup memory limit (v1/v2) or falls back to `/proc/meminfo`:
+
+```yaml
+# Pod spec: resources.limits.memory: 2Gi
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
+# Hard limit = 1.5 GiB (75% of 2 GiB), soft limit = 1.2 GiB (60%)
+```
+
+`limit_mib` takes precedence if both are set. Percentage mode is most reliable on Linux with cgroups; on macOS/Windows it reads total *system* memory, which is rarely what you want (see [Known quirks](quirks.md)).
+
+## Size `spike_limit_mib` for the traffic shape
+
+`spike_limit_mib` must cover the largest heap increase that can occur in a single `check_interval`. The buffer between soft and hard limit is the recovery headroom:
+
+| Traffic | Config |
+|---------|--------|
+| Steady | `check_interval: 1s`, `spike_limit_mib: 800` (20% of 4000) |
+| Bursty (2× spikes) | `check_interval: 500ms`, `spike_limit_mib: 1200` (30%) — check more often *and* widen the buffer |
+| Low-latency, predictable | `check_interval: 1s`, `spike_limit_mib: 400` (10%) — tight control |
+
+If the collector still OOMs, the spike outran the buffer between two checks: lower `check_interval` and/or raise `spike_limit_mib`.
+
+## Multi-pipeline: one config, one checker
+
+A single `memory_limiter` definition referenced from every pipeline shares one background checker (the [singleton](quirks.md), keyed on identical config), so there is no redundant GC:
+
+```yaml
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 800
+
+service:
+  pipelines:
+    traces:  { processors: [memory_limiter, batch] }
+    metrics: { processors: [memory_limiter, batch] }
+    logs:    { processors: [memory_limiter, batch] }
+```
+
+## Tuning the GC intervals
+
+The two `min_gc_interval_*` keys throttle forced GC so it does not pin the CPU when memory hovers near the limit. Keep the soft-limited interval `>=` the hard-limited one (the hard limit is more urgent, so it should GC at least as eagerly):
+
+```yaml
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    min_gc_interval_when_soft_limited: 10s   # default — opportunistic
+    min_gc_interval_when_hard_limited: 0s    # default — GC every over-hard-limit check
+```
+
+Reach for these only if debug logs show `Forcing a GC` firing so often that CPU suffers; the defaults are right for most deployments.

--- a/skills/otel-collector/components/memory_limiter/configuration.md
+++ b/skills/otel-collector/components/memory_limiter/configuration.md
@@ -26,7 +26,7 @@ Hard limit 4000 MiB, soft limit 3200 MiB, checked every second. `memory_limiter`
 | `check_interval` | duration | `0s` (**required**, must be `> 0`) | Time between memory measurements. `1s` is recommended; `500ms` for spiky traffic. |
 | `limit_mib` | uint32 | `0` | Hard limit, in MiB of **heap**. Required unless `limit_percentage` is set; **takes precedence** over `limit_percentage` if both are set. |
 | `spike_limit_mib` | uint32 | 20% of `limit_mib` | Expected max heap increase between checks. Must be `< limit_mib`. Soft limit = `limit_mib - spike_limit_mib`. |
-| `limit_percentage` | uint32 | `0` | Hard limit as a percentage of total memory (`> 0`, `<= 100`). Used **only when `limit_mib` is unset/0**. Needs Linux cgroups, else falls back to `/proc/meminfo`. |
+| `limit_percentage` | uint32 | `0` | Hard limit as a percentage of total memory (`> 0`, `<= 100`). Used **only when `limit_mib` is unset/0**. On Linux reads the cgroup limit, falling back to `/proc/meminfo`; on non-Linux it reads total *system* memory (rarely a container limit). See [Known quirks](quirks.md). |
 | `spike_limit_percentage` | uint32 | 20% of `limit_percentage` | Spike as a percentage of total memory. Must be `< limit_percentage` and `<= 100`. Only used with `limit_percentage`. |
 | `min_gc_interval_when_soft_limited` | duration | `10s` | Minimum time between forced GCs while above the soft limit. Must be `>= min_gc_interval_when_hard_limited`. |
 | `min_gc_interval_when_hard_limited` | duration | `0s` | Minimum time between forced GCs while above the hard limit (`0s` = GC on every over-limit check). Should be `<=` the soft-limited interval. |

--- a/skills/otel-collector/components/memory_limiter/configuration.md
+++ b/skills/otel-collector/components/memory_limiter/configuration.md
@@ -1,0 +1,69 @@
+# `memory_limiter`: configuration
+
+## Typical config
+
+```yaml
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 800
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp]
+```
+
+Hard limit 4000 MiB, soft limit 3200 MiB, checked every second. `memory_limiter` is first in the processor list (see [Pipeline placement](#pipeline-placement)).
+
+## Configuration reference
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `check_interval` | duration | `0s` (**required**, must be `> 0`) | Time between memory measurements. `1s` is recommended; `500ms` for spiky traffic. |
+| `limit_mib` | uint32 | `0` | Hard limit, in MiB of **heap**. Required unless `limit_percentage` is set; **takes precedence** over `limit_percentage` if both are set. |
+| `spike_limit_mib` | uint32 | 20% of `limit_mib` | Expected max heap increase between checks. Must be `< limit_mib`. Soft limit = `limit_mib - spike_limit_mib`. |
+| `limit_percentage` | uint32 | `0` | Hard limit as a percentage of total memory (`> 0`, `<= 100`). Used **only when `limit_mib` is unset/0**. Needs Linux cgroups, else falls back to `/proc/meminfo`. |
+| `spike_limit_percentage` | uint32 | 20% of `limit_percentage` | Spike as a percentage of total memory. Must be `< limit_percentage` and `<= 100`. Only used with `limit_percentage`. |
+| `min_gc_interval_when_soft_limited` | duration | `10s` | Minimum time between forced GCs while above the soft limit. Must be `>= min_gc_interval_when_hard_limited`. |
+| `min_gc_interval_when_hard_limited` | duration | `0s` | Minimum time between forced GCs while above the hard limit (`0s` = GC on every over-limit check). Should be `<=` the soft-limited interval. |
+
+One of `limit_mib` or `limit_percentage` is mandatory; `check_interval` is always mandatory.
+
+## Soft limit vs hard limit
+
+The processor derives two thresholds and acts on the current heap allocation:
+
+| State | Threshold | Action |
+|-------|-----------|--------|
+| Below soft limit | heap `< limit - spike` | Normal operation; data accepted. |
+| Above soft limit | heap `>= limit - spike` | Refuse data (`ErrDataRefused`); opportunistic GC, throttled by `min_gc_interval_when_soft_limited`. Logs *"Memory usage is above soft limit. Refusing data."* |
+| Above hard limit | heap `>= limit` | Refuse data; aggressive GC, throttled by `min_gc_interval_when_hard_limited`. Logs *"Memory usage is above hard limit. Forcing a GC."* |
+
+Refusal is a **non-permanent** error, so receivers retry with backoff and clients can rate-limit. Recovery is automatic: once heap falls below the soft limit it logs *"Memory usage back within limits. Resuming normal operation."*
+
+## Validation rules
+
+Startup fails (config error) when:
+
+| Rule | Error message |
+|------|---------------|
+| `check_interval` not `> 0` | `'check_interval' must be greater than zero` |
+| Neither limit set | `'limit_mib' or 'limit_percentage' must be greater than zero` |
+| `spike_limit_mib >= limit_mib` | `'spike_limit_mib' must be smaller than 'limit_mib'` |
+| `min_gc_interval_when_soft_limited < min_gc_interval_when_hard_limited` | `'min_gc_interval_when_soft_limited' should be larger than 'min_gc_interval_when_hard_limited'` |
+
+## Pipeline placement
+
+`memory_limiter` must be the **first** processor in every pipeline so it refuses data before it enters allocating processors (`batch`, `transform`, `tail_sampling`) and so backpressure reaches receivers early:
+
+```yaml
+# Good — refuse before anything buffers
+processors: [memory_limiter, batch, tail_sampling]
+
+# Bad — data is already batched and processed before refusal
+processors: [batch, tail_sampling, memory_limiter]
+```

--- a/skills/otel-collector/components/memory_limiter/quirks.md
+++ b/skills/otel-collector/components/memory_limiter/quirks.md
@@ -1,0 +1,66 @@
+# `memory_limiter`: known quirks
+
+## It measures heap, not RSS
+
+The limit is compared against Go **heap allocation** (`runtime.MemStats.Alloc`), not process RSS. Total process memory typically runs **50–100 MiB higher** (Go runtime, stacks, CGO, OS page caches, mmap'd files). So `limit_mib: 4000` means a process that sits around ~4050 MiB. Set the container memory limit **10–15% above** `limit_mib`, or the kernel OOM-kills the process before the limiter ever refuses. Seeing RSS exceed `limit_mib` is expected, not a bug.
+
+## `check_interval` and one of the limits are required
+
+There are no usable defaults for the two load-bearing keys. `check_interval` defaults to `0s`, which is a validation error, and you must set `limit_mib` **or** `limit_percentage` (`> 0`). A config with only one of these fails at startup:
+
+```
+'check_interval' must be greater than zero
+'limit_mib' or 'limit_percentage' must be greater than zero
+```
+
+## `limit_mib` wins over `limit_percentage`
+
+If both are set, `limit_mib` is used and `limit_percentage` is ignored — silently. Set only the one you mean.
+
+## `spike_limit` must be smaller than the limit
+
+`spike_limit_mib < limit_mib` (and `spike_limit_percentage < limit_percentage`) is validated. If the spike limit equals or exceeds the limit, the soft limit would be `<= 0` and startup fails with `'spike_limit_mib' must be smaller than 'limit_mib'`.
+
+## GC-interval ordering is enforced
+
+`min_gc_interval_when_soft_limited` must be `>=` `min_gc_interval_when_hard_limited` (the hard limit is more urgent, so it cannot GC *less* often). Inverting them fails startup with `'min_gc_interval_when_soft_limited' should be larger than 'min_gc_interval_when_hard_limited'`.
+
+## `limit_percentage` needs cgroups to be useful
+
+Percentage mode reads the container's memory limit from cgroups v2 (`/sys/fs/cgroup/memory.max`) or v1 (`/sys/fs/cgroup/memory/memory.limit_in_bytes`), and treats an "unlimited" cgroup value (`9223372036854771712`) as absent, falling back to `/proc/meminfo`. On macOS/Windows it reads **total system memory**, not a container limit, so the percentage is rarely meaningful there. Prefer `limit_mib` on non-Linux hosts. If total-memory detection fails entirely the collector refuses to start — switch to `limit_mib`.
+
+## It is a safety net, not a sizing tool
+
+The limiter does not make a small collector handle more load — below capacity it simply **refuses data constantly** (high `processor_refused_*`, persistent *"Refusing data"* logs, receivers seeing backpressure). The fix is to size the collector for the workload or scale out, then keep `memory_limiter` as the backstop. Treat sustained refusal as an under-provisioning signal, not a tuning problem.
+
+## Refusal is non-permanent — receivers must retry
+
+When refusing, the processor returns a **non-permanent** error (gRPC `Unavailable`, *"data refused due to high memory usage"*). Well-behaved receivers (otlp, prometheus, …) retry with backoff and clients rate-limit. A receiver or client that does **not** retry will lose that data. This is by design: the limiter applies backpressure rather than buffering.
+
+## Singleton checker across identical configs
+
+Pipelines referencing the same `memory_limiter` config share one background goroutine and timer (keyed on the config), so GC isn't triggered redundantly per pipeline. Two *differently named* instances with different limits run independent checkers — intentional, but watch that their limits don't sum past the container budget.
+
+## The experimental extension variant
+
+Since v0.142.0 the memory limiter is also available as an **extension** that acts as gRPC/HTTP middleware on a receiver (v0.147.0 added streaming support and fixed a multi-interceptor startup panic):
+
+```yaml
+extensions:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        middlewares: [memory_limiter]
+service:
+  extensions: [memory_limiter]
+```
+
+It is **experimental** — use the processor form for production.
+
+## Stability caveats
+
+Traces/metrics/logs are Beta; profiles are Alpha. The profiles path can still change between releases — confirm against the upstream README for the exact collector version before relying on it.

--- a/skills/otel-collector/components/memory_limiter/verification.md
+++ b/skills/otel-collector/components/memory_limiter/verification.md
@@ -1,0 +1,58 @@
+# `memory_limiter`: verification
+
+See [Verification harness](../../SKILL.md#verification-harness) for how to run this end-to-end.
+
+`memory_limiter` ships in the `core`, `contrib`, and `k8s` distributions, so a stock contrib collector can run this.
+
+Because the processor reacts to **real heap pressure**, the trick to verifying it deterministically is to set the limit *below the collector's own idle heap* so it refuses from the first check — no need to actually exhaust memory.
+
+Config (`memlimit-verify.yaml`) — limit far below the idle heap so the soft limit is breached immediately:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 20
+    spike_limit_mib: 5
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  telemetry:
+    logs:
+      level: debug
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter]
+      exporters: [debug]
+```
+
+Wait ~5s for the first memory check, then send a few traces (see the `otel-telemetrygen` skill):
+
+```bash
+telemetrygen traces --otlp-insecure --otlp-endpoint localhost:4317 --traces 10 --workers 1
+```
+
+Flags confirmed against the `otel-telemetrygen` skill (`references/flags.md`): `--otlp-insecure`, `--otlp-endpoint`, `--traces` (int, traces **per worker**; ignored if `--duration` is set, so no `--duration` here), and `--workers` (default 1). The exact count does not matter here — every export is refused regardless.
+
+**What proves it worked** (verified run, contrib 0.152.0, idle heap ~17–20 MiB > the 15 MiB soft limit):
+
+1. The collector logs the limit being breached:
+   ```
+   warn  Memory usage is above hard limit. Forcing a GC.   {"cur_mem_mib": 20}
+   info  Memory usage after GC.                            {"cur_mem_mib": 17}
+   warn  Memory usage is above soft limit. Refusing data.  {"cur_mem_mib": 17}
+   ```
+2. telemetrygen's export fails with the non-permanent gRPC error (it retries with backoff, which is exactly the intended backpressure):
+   ```
+   traces export: ... rpc error: code = Unavailable desc = data refused due to high memory usage
+   ```
+3. **Zero** spans reach the `debug` exporter (`grep -c '^Span #'` in the collector logs returns `0`) — the data was refused before the pipeline, not dropped silently downstream.
+
+To watch normal operation instead, raise `limit_mib` well above the idle heap (e.g. `limit_mib: 4000`) and the same send passes through with spans printed by `debug`.


### PR DESCRIPTION
## What

Adds the **`memory_limiter`** processor page to the `otel-collector` skill, following the established per-component directory structure:

- `components/memory_limiter/README.md` — lean: metadata table, description, Use when / Avoid when, related components, Details index.
- `configuration.md` — full key table (`check_interval`, `limit_mib` vs `limit_percentage`, spike limits, GC intervals), soft/hard-limit mechanism, validation rules, pipeline-placement rule.
- `verification.md` — telemetrygen recipe that forces refusal deterministically.
- `advanced.md` — `GOMEMLIMIT` pairing, percentage mode for Kubernetes, spike sizing, multi-pipeline singleton, GC-interval tuning.
- `quirks.md` — heap-vs-RSS, required fields, `limit_mib` precedence, cgroup detection, GC-interval ordering, singleton checker, experimental extension variant, stability caveats.

Source of truth: the core `memorylimiterprocessor` README from the `telemetrydrops/ai-context` mirror. Every key/default/validation rule traces to source — no invention.

## Verified end-to-end (contrib 0.152.0)

Since the processor reacts to real heap pressure, the recipe sets the limit *below* the collector's idle heap so it refuses from the first check (no need to actually exhaust memory):

- Config: `limit_mib: 20`, `spike_limit_mib: 5` → soft limit 15 MiB; idle heap ~17–20 MiB.
- Collector logs: `Memory usage is above hard limit. Forcing a GC.` → `Memory usage after GC. {cur_mem_mib: 17}` → `Memory usage is above soft limit. Refusing data.`
- `telemetrygen traces --otlp-insecure --otlp-endpoint localhost:4317 --traces 10 --workers 1` → `rpc error: code = Unavailable desc = data refused due to high memory usage` (non-permanent; telemetrygen retries — the intended backpressure).
- **0** spans reached the `debug` exporter (`grep -c '^Span #'` → 0).

telemetrygen flags confirmed against the `otel-telemetrygen` skill.

## SKILL.md

- Added the component-index row (per-signal stability: Beta traces/metrics/logs, Alpha profiles).
- Added `memory_limiter` to the frontmatter trigger keywords.

Closes ENG-2208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Introduced comprehensive documentation for the memory limiter processor component, providing configuration reference with parameter descriptions and validation rules, advanced configuration patterns and tuning guidance for production environments, end-to-end operational verification procedures, and documented behavior constraints and known operational limitations.
* Updated skill metadata to include memory limiter in the component index and trigger guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->