### PR TITLE
docs(otel-go): document independently-versioned module groups

### DIFF
--- a/skills/otel-go/SKILL.md
+++ b/skills/otel-go/SKILL.md
@@ -28,7 +28,7 @@ and version churn:
 |---|---|---|
 | Stable signals (traces, metrics) | `go.opentelemetry.io/otel`, `otel/sdk`, `otel/trace`, `otel/metric`, OTLP trace/metric exporters | **v1.x** (e.g. v1.44.0) |
 | Logs | `otel/log`, `otel/sdk/log`, `otel/exporters/otlp/otlplog/otlploghttp` | **v0.x** (separate, lower line) |
-| Contrib instrumentation | `contrib/instrumentation/net/http/otelhttp`, `.../otelgrpc` | **v1.x** |
+| Contrib instrumentation | `contrib/instrumentation/net/http/otelhttp`, `.../otelgrpc` | **v0.x** (separate line, e.g. v0.69.0) |
 | Contrib log bridges | `contrib/bridges/otelslog`, `otelzap`, `otelzerolog` | **v0.x** |
 
 **The trap:** pinning every module to the core version (e.g. `go get go.opentelemetry.io/otel/log@v1.44.0`)
@@ -42,8 +42,9 @@ go get go.opentelemetry.io/otel@latest go.opentelemetry.io/otel/sdk@latest
 # logs (separate v0.x line — do NOT force the core version):
 go get go.opentelemetry.io/otel/log@latest go.opentelemetry.io/otel/sdk/log@latest \
        go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp@latest
-# contrib (bridges resolve to their own v0.x; instrumentation to v1.x):
-go get go.opentelemetry.io/contrib/bridges/otelslog@latest
+# contrib (instrumentation and bridges each resolve to their own v0.x line):
+go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@latest \
+       go.opentelemetry.io/contrib/bridges/otelslog@latest
 go mod tidy && go build ./...
 ```
 

--- a/skills/otel-go/SKILL.md
+++ b/skills/otel-go/SKILL.md
@@ -18,6 +18,38 @@ task; each reference is self-contained.
 | [`references/performance.md`](references/performance.md) | Tuning sampling, batch processor, metric reader, exporter compression/retry, attribute allocation, log `Enabled()` short-circuiting, graceful shutdown. |
 | [`references/breaking-changes.md`](references/breaking-changes.md) | Auditing existing code for deprecated calls, renamed semantic conventions, and removed APIs across recent SDK / contrib releases. |
 
+## Module versioning — read before adding dependencies
+
+opentelemetry-go is split into **independently versioned module groups**. They do NOT
+share one version number. Assuming they do is the most common cause of broken builds
+and version churn:
+
+| Module group | Example modules | Version line |
+|---|---|---|
+| Stable signals (traces, metrics) | `go.opentelemetry.io/otel`, `otel/sdk`, `otel/trace`, `otel/metric`, OTLP trace/metric exporters | **v1.x** (e.g. v1.44.0) |
+| Logs | `otel/log`, `otel/sdk/log`, `otel/exporters/otlp/otlplog/otlploghttp` | **v0.x** (separate, lower line) |
+| Contrib instrumentation | `contrib/instrumentation/net/http/otelhttp`, `.../otelgrpc` | **v1.x** |
+| Contrib log bridges | `contrib/bridges/otelslog`, `otelzap`, `otelzerolog` | **v0.x** |
+
+**The trap:** pinning every module to the core version (e.g. `go get go.opentelemetry.io/otel/log@v1.44.0`)
+fails — log and bridge modules have no v1.x tag. Hand-picking and re-guessing each `@vX`
+is the churn to avoid.
+
+**Do this instead** — add each module with `@latest` and let Go resolve a compatible set:
+
+```bash
+go get go.opentelemetry.io/otel@latest go.opentelemetry.io/otel/sdk@latest
+# logs (separate v0.x line — do NOT force the core version):
+go get go.opentelemetry.io/otel/log@latest go.opentelemetry.io/otel/sdk/log@latest \
+       go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp@latest
+# contrib (bridges resolve to their own v0.x; instrumentation to v1.x):
+go get go.opentelemetry.io/contrib/bridges/otelslog@latest
+go mod tidy && go build ./...
+```
+
+If exact versions are required, fetch each module group's tag from its own source
+(see below) — never infer one group's version from another's.
+
 ## Sources of Truth
 
 For YAML schema details, fetch the upstream sources listed in the `otel-declarative-config` skill.


### PR DESCRIPTION
## Problem

opentelemetry-go is split into **independently versioned module groups** that do NOT share one version number — stable signals (traces, metrics) on **v1.x**, logs and contrib bridges on **v0.x**. Agents assume a single version and pin every module to the core version (e.g. `go get go.opentelemetry.io/otel/log@v1.44.0`), which fails because log/bridge modules have no v1.x tag → `no required module provides package` → build fails. They then churn through many `@vX` guesses.

This is a **Go-specific footgun**: Maven/Gradle BOM, npm, pip, and NuGet all auto-resolve transitive versions, so agents in those ecosystems don't churn. The `otel-go` SKILL.md didn't warn about it.

## Change

Adds a "Module versioning — read before adding dependencies" section to `skills/otel-go/SKILL.md`:
- A table of the module groups and their version lines (v1.x vs v0.x).
- A churn-proof `@latest` install recipe that lets Go resolve a compatible set instead of hand-pinning.

Written durably (structure + `@latest`, not pinned numbers).

## Evidence

A/B eval on otel-bench `go-microservices` (opencode agent, gpt-5.2, skills force-loaded):
- **Without the section:** 5–36 distinct package versions tried per trial; nudged pass rate **40%**.
- **With the section:** **86%** (graded 98%) and **75%** on a repeat — **+35 / +38 pts** paired same-day delta. The skill's effect flipped from negative to strongly positive.

Necessity checked: NOT replicated to otel-python/js/dotnet — their eval failures are export-wiring, not versioning.

## Verification (2026-06-29)

Confirmed upstream the split still holds: core latest **v1.44.0** (v1.x), `otel/log` on **v0.x**, contrib `otelslog` bridge on **v0.x**.

Closes OTEL-245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on OpenTelemetry Go module versioning.
  * Clarified how to avoid version mismatches when adding dependencies across module groups.
  * Included recommended install commands and best practices for safely pinning exact versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->