### PR TITLE
feat(otel-browser): add OpenTelemetry browser / RUM skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -72,6 +72,11 @@
       "name": "otel-dotnet",
       "source": "./skills/otel-dotnet",
       "description": "OpenTelemetry in .NET: DI/builder SDK setup (OpenTelemetry.Extensions.Hosting), native BCL instrumentation (ActivitySource, Meter, ILogger), zero-code CLR-profiler agent and contrib instrumentation catalog, performance tuning, breaking-change audits. Note: .NET has no declarative YAML config yet."
+    },
+    {
+      "name": "otel-browser",
+      "source": "./skills/otel-browser",
+      "description": "OpenTelemetry in the browser (Real User Monitoring / RUM): web tracing SDK (sdk-trace-web, context-zone) and experimental browser-sdk, event- and span-based browser instrumentations (web vitals, navigation, errors, fetch/XHR), sessions, frontend-to-backend trace propagation, bundle size / cost / PII trade-offs."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ skills/
   otel-dotnet/
     SKILL.md
     references/
+  otel-browser/
+    SKILL.md
+    references/        # setup-sdk, instrumentation, performance
   otel-collector/
     SKILL.md
     components/        # one file per Collector component (log_dedup, interval, …)
@@ -101,6 +104,7 @@ Language-specific skills:
 | `otel-js` | `skills/otel-js/` | OpenTelemetry in Node.js / JavaScript / TypeScript: NodeSDK setup, declarative YAML configuration via `@opentelemetry/configuration`, auto-instrumentations, and ESM vs CJS import patterns. |
 | `otel-python` | `skills/otel-python/` | OpenTelemetry in Python: declarative SDK setup via file config, API surface and logging bridge, zero-code instrumentation (opentelemetry-distro / opentelemetry-instrument) and contrib catalog, performance tuning, breaking-change audits. |
 | `otel-dotnet` | `skills/otel-dotnet/` | OpenTelemetry in .NET: DI/builder SDK setup (`OpenTelemetry.Extensions.Hosting`), native BCL instrumentation (`ActivitySource`, `Meter`, `ILogger`), zero-code CLR-profiler agent and contrib instrumentation catalog, performance tuning, breaking-change audits. |
+| `otel-browser` | `skills/otel-browser/` | OpenTelemetry in the browser (Real User Monitoring / RUM): web tracing SDK (`sdk-trace-web`, `context-zone`) and experimental `browser-sdk`, event- and span-based browser instrumentations (web vitals, navigation, errors, fetch/XHR), sessions, frontend→backend trace propagation, and bundle-size/cost/PII trade-offs. |
 
 ## Contributing
 

--- a/skills/otel-browser/SKILL.md
+++ b/skills/otel-browser/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: otel-browser
+description: OpenTelemetry in the browser (Real User Monitoring / RUM) — capturing page loads, Core Web Vitals, route changes, clicks, console output, and JavaScript errors, and connecting frontend telemetry to backend traces. Covers the web tracing SDK (sdk-trace-web, context-zone), the experimental browser-sdk, and event- and span-based browser instrumentations. Use when adding, reviewing, or configuring OpenTelemetry in a web app (SPA/MPA). Triggers on "browser otel", "RUM", "real user monitoring", "frontend observability", "web vitals", "core web vitals", "sdk-trace-web", "WebTracerProvider", "browser-sdk", "browser-instrumentation", "instrument the frontend", "page load tracing", "session", or any browser/web OTel question.
+---
+
+# OpenTelemetry in the Browser (RUM)
+
+Entry point for OpenTelemetry mechanics in web apps. Load a reference below based on the task;
+each reference is self-contained.
+
+> **Stability**: Browser/RUM is one of the **newest and most experimental** areas of OpenTelemetry.
+> Only the web *tracing* primitives (`@opentelemetry/sdk-trace-web`, `@opentelemetry/context-zone`)
+> and the JS API are **stable** today. The Browser SDK (`@opentelemetry/browser-sdk`) and the
+> event-based instrumentations are experimental and may break between minor versions — pin exact
+> versions. Verify current status via the Sources of Truth below.
+
+## References
+
+| File | Use when |
+|---|---|
+| [`references/setup-sdk.md`](references/setup-sdk.md) | Wiring up the SDK: stable primitives (`WebTracerProvider` + `ZoneContextManager` + `LoggerProvider`) vs the experimental `browser-sdk`, sessions, frontend→backend `traceparent`/CORS propagation, and why a Collector sits in front. |
+| [`references/instrumentation.md`](references/instrumentation.md) | Choosing and configuring instrumentations: the event-based catalog (navigation, web vitals, console, errors, …), the span-based catalog (fetch, XHR, document-load, long-task, …), per-instrumentation options, and what each captures. |
+| [`references/performance.md`](references/performance.md) | Keeping it cheap, fast, and private: bundle size, off-main-thread processing, page-lifecycle flushing, telemetry volume/cost, and PII vectors. |
+
+## Two telemetry models — read first
+
+Browser telemetry is modeled as **spans** and **events**; there is **no browser metrics story
+yet** (metrics are out of scope for the Browser SDK). Picking the right model per signal is the
+first decision:
+
+| Model | Signal | For | Examples |
+|---|---|---|---|
+| **Events** | Logs API → `LogRecord` | point-in-time facts (no duration/children) | web vitals, navigation, console, errors, user action |
+| **Spans** | Trace API | operations with a duration and parent/child | `fetch`, XHR, document load, long task |
+
+## The browser package ecosystem — three repositories
+
+Browser packages are spread across three upstream repos. The
+[`opentelemetry-browser` README "Browser Packages" tables](https://github.com/open-telemetry/opentelemetry-browser#browser-packages)
+are the authoritative, current map. Summary:
+
+| Package | Repo | Model | Stability |
+|---|---|---|---|
+| `@opentelemetry/sdk-trace-web` | opentelemetry-js | SDK (spans) | **stable** |
+| `@opentelemetry/context-zone` | opentelemetry-js | context | **stable** |
+| `@opentelemetry/instrumentation-fetch` | opentelemetry-js | spans | experimental |
+| `@opentelemetry/instrumentation-xml-http-request` | opentelemetry-js | spans | experimental |
+| `@opentelemetry/browser-detector` | opentelemetry-js | resource | experimental |
+| `@opentelemetry/browser-instrumentation` | opentelemetry-browser | events | experimental |
+| `@opentelemetry/browser-sdk` | opentelemetry-browser | SDK | experimental (unreleased) |
+| `@opentelemetry/auto-instrumentations-web` | opentelemetry-js-contrib | bundle | experimental |
+| `instrumentation-document-load` / `-long-task` / `-user-interaction` | opentelemetry-js-contrib | spans | experimental |
+| `instrumentation-browser-navigation` / `-web-exception` | opentelemetry-js-contrib | events | experimental |
+| `plugin-react-load` | opentelemetry-js-contrib | spans | experimental |
+
+`opentelemetry-browser` is the home of the event-based instrumentations and the future home of the
+Browser SDK; the span-based packages still live in `opentelemetry-js` / `opentelemetry-js-contrib`.
+
+## Why browser RUM is different
+
+These constraints drive most design decisions (detailed in the references):
+
+- **The process disappears** — no graceful shutdown. Flush on `visibilitychange`/`pagehide` with
+  `keepalive`, not `unload`.
+- **No gRPC** — export is **OTLP/HTTP** only (protobuf or JSON).
+- **Cross-origin propagation is opt-in** — `traceparent` is not sent to other origins unless you set
+  `propagateTraceHeaderCorsUrls` **and** the server allows the header via `Access-Control-Allow-Headers`.
+- **The client is untrusted and chatty** — put a **Collector (or vendor edge)** between browsers and
+  your backend for CORS termination, sampling, redaction, and rate limiting.
+- **PII is everywhere** — URLs, console output, form fields, and click targets routinely carry it.
+
+## Sources of Truth
+
+Browser packages move fast while experimental — fetch current versions and status rather than
+relying on these notes.
+
+| Fact | Fetch |
+|---|---|
+| `opentelemetry-browser` package versions / status | `gh api repos/open-telemetry/opentelemetry-browser/releases -q '.[].tag_name'` |
+| Latest `@opentelemetry/browser-instrumentation` | `npm view @opentelemetry/browser-instrumentation version` |
+| Latest `@opentelemetry/browser-sdk` (may be unpublished) | `npm view @opentelemetry/browser-sdk version` |
+| Latest `@opentelemetry/sdk-trace-web` | `npm view @opentelemetry/sdk-trace-web version` |
+| Latest `@opentelemetry/auto-instrumentations-web` | `npm view @opentelemetry/auto-instrumentations-web version` |
+| Authoritative browser package map | `WebFetch https://github.com/open-telemetry/opentelemetry-browser#browser-packages` |
+| `browser-instrumentation` README / config | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-browser/main/packages/instrumentation/README.md` |
+| `browser.*` event semantic-convention status | `WebFetch https://opentelemetry.io/docs/specs/semconv/browser/` |
+
+## Cross-References
+
+- Shared JS API and Node.js SDK (the browser builds on the same API): `otel-js` skill.
+- Schema-level facts for declarative YAML config: `otel-declarative-config` skill.
+- Semantic conventions lookup (`browser.*`, `session.*`, `exception`): `otel-semantic-conventions` skill.
+- Edge sampling / redaction / rate limiting in front of browsers: `otel-collector` skill.
+- SDK version selection across languages: `otel-sdk-versions` skill.

--- a/skills/otel-browser/SKILL.md
+++ b/skills/otel-browser/SKILL.md
@@ -18,7 +18,7 @@ each reference is self-contained.
 
 | File | Use when |
 |---|---|
-| [`references/setup-sdk.md`](references/setup-sdk.md) | Wiring up the SDK: stable primitives (`WebTracerProvider` + `ZoneContextManager` + `LoggerProvider`) vs the experimental `browser-sdk`, sessions, frontend→backend `traceparent`/CORS propagation, and why a Collector sits in front. |
+| [`references/setup-sdk.md`](references/setup-sdk.md) | Wiring up the SDK: the direct providers (`WebTracerProvider` + `ZoneContextManager` for spans; `LoggerProvider` for events) vs the experimental `browser-sdk`, sessions, frontend→backend `traceparent`/CORS propagation, and why a Collector sits in front. |
 | [`references/instrumentation.md`](references/instrumentation.md) | Choosing and configuring instrumentations: the event-based catalog (navigation, web vitals, console, errors, …), the span-based catalog (fetch, XHR, document-load, long-task, …), per-instrumentation options, and what each captures. |
 | [`references/performance.md`](references/performance.md) | Keeping it cheap, fast, and private: bundle size, off-main-thread processing, page-lifecycle flushing, telemetry volume/cost, and PII vectors. |
 

--- a/skills/otel-browser/references/instrumentation.md
+++ b/skills/otel-browser/references/instrumentation.md
@@ -1,0 +1,192 @@
+# Browser instrumentation catalog
+
+Choosing and configuring browser/RUM instrumentations. Browser telemetry uses **two signal shapes**;
+knowing which is which tells you where each instrumentation lives and how to consume the data.
+
+| Model | Signal | Lives in | Examples |
+|---|---|---|---|
+| **Event-based** | Logs API → `LogRecord` | `@opentelemetry/browser-instrumentation` + js-contrib | navigation, navigation timing, resource timing, web vitals, console, errors, user action |
+| **Span-based** | Trace API → spans | `opentelemetry-js` + `opentelemetry-js-contrib` | fetch, XHR, document-load, long-task, user-interaction, react-load |
+
+Many browser signals are *point-in-time facts* ("LCP was 2.1s", "a navigation happened", "an error
+was thrown") rather than operations with a duration and children — modeling them as events is
+cheaper than forcing a span around them. Spans remain the right model for network requests and work
+with a real begin/end and parent/child relationship.
+
+> Exact config options and captured attributes change while these packages are experimental. Confirm
+> against the upstream READMEs and `package.json` `exports` (see
+> [SKILL.md Sources of Truth](../SKILL.md#sources-of-truth)).
+
+## Event-based instrumentations (`@opentelemetry/browser-instrumentation`)
+
+Entry points are subpath exports under `./experimental/*`; they emit through the global
+`LoggerProvider` (see [setup-sdk.md](setup-sdk.md#logger-provider-events)).
+
+```typescript
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { WebVitalsInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/web-vitals';
+import { NavigationInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/navigation';
+import { ErrorsInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/errors';
+// …also: navigation-timing, resource-timing, user-action, console
+
+registerInstrumentations({
+  instrumentations: [
+    new WebVitalsInstrumentation(),
+    new NavigationInstrumentation(),
+    new ErrorsInstrumentation(),
+  ],
+});
+```
+
+### Navigation (`browser.navigation`)
+
+An event for the initial page load (hard navigation) and SPA route changes (soft navigations:
+`history.pushState`/`replaceState`, `popstate`, hash changes). This is the reliable
+**analytics / user-journey** signal — emitted early, unlike navigation *timing* which finalizes late.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `useNavigationApiIfAvailable` | `boolean` | `false` | Use the [Navigation API](https://developer.mozilla.org/docs/Web/API/Navigation_API) instead of patching `history.*` (falls back when unavailable). |
+| `sanitizeUrl` | `(url: string) => string` | — | Rewrite the URL before it is written to `url.full` — strip tokens, IDs, query params. |
+| `applyCustomLogRecordData` | `(logRecord) => void` | — | Mutate the record before emit. Thrown errors are caught + diag-logged. |
+
+Captured attributes include `url.full`, `browser.navigation.same_document` (false = full-page load,
+true = SPA route change), `browser.navigation.hash_change`, and `browser.navigation.type`
+(`push`/`replace`/`reload`/`traverse`). A `defaultSanitizeUrl` helper strips `user:password@`
+credentials and common sensitive query params (`api_key`, `token`, `password`, …); compose your own
+on top.
+
+### Navigation Timing (`browser.navigation_timing`)
+
+Detailed page-load milestones (DNS, TCP, TLS, request, response, DOM processing) from
+[PerformanceNavigationTiming](https://developer.mozilla.org/docs/Web/API/PerformanceNavigationTiming).
+Use for **performance** analysis; pair with the navigation *event* for reliable counts (timing can be
+lost if `load` never fires).
+
+### Resource Timing (`browser.resource_timing`)
+
+One event per resource the page loads (scripts, CSS, images, fonts, XHR/fetch) from
+[PerformanceResourceTiming](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming).
+Stays off the main thread (`requestIdleCallback`, Safari `setTimeout` fallback), processes in
+batches, captures resources loaded before it was enabled (buffered), and flushes on visibility change.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `batchSize` | `number` | `50` | Resources processed per batch. |
+| `forceProcessingAfter` | `number` | `1000` | Max ms to wait for an idle callback before forcing. |
+| `maxProcessingTime` | `number` | `50` | Max ms spent per idle callback. |
+| `maxQueueSize` | `number` | `1000` | Queue size before forcing an immediate flush. |
+| `initiatorTypes` | `string[]` | (all) | Restrict to specific initiator types, e.g. `['xmlhttprequest', 'fetch']`. |
+
+Captured data: URL, initiator type, total duration, timing phases, transfer/encoded/decoded sizes,
+HTTP protocol (h1/h2/h3), redirect timing, service-worker start, render-blocking status (Chromium).
+This is one of the **highest-volume** RUM signals — a content-heavy page can load hundreds of
+resources. Restrict `initiatorTypes` or sample aggressively (see
+[performance.md](performance.md#telemetry-volume-and-cost)).
+
+### Web Vitals (`browser.web_vital`)
+
+[Core Web Vitals](https://web.dev/vitals/) via the Google
+[`web-vitals`](https://github.com/GoogleChrome/web-vitals) library: **LCP** (loading), **INP**
+(responsiveness; replaced FID), **CLS** (visual stability), plus TTFB and FCP. This event's semantic
+conventions are **merged** (see the
+[WebVital event](https://opentelemetry.io/docs/specs/semconv/browser/browser-events/#webvital-event)).
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `includeRawAttribution` | `boolean` | `false` | Set the record body to the `web-vitals` attribution object (which element/event caused the metric). |
+| `applyCustomLogRecordData` | `(logRecord) => void` | — | Mutate the record before emit. |
+
+INP and CLS finalize near the end of the page lifecycle — they depend on the SDK flushing on
+`pagehide`/`visibilitychange`.
+
+### Console (`browser.console`)
+
+Captures console API calls (by default `log`, `warn`, `error`, `info`, `debug`); records carry
+`browser.console.method`. Capturing `log`/`info`/`debug` in production is typically noise and a PII
+risk — restrict it:
+
+```typescript
+new ConsoleInstrumentation({ logMethods: ['error', 'warn'] });
+```
+
+### Errors (`exception`)
+
+An `exception` event for every uncaught error (`window` `error`) and unhandled promise rejection
+(`unhandledrejection`), reusing the existing `exception` event. Records carry `exception.type`,
+`exception.message`, `exception.stacktrace` (type/stacktrace omitted for non-`Error` throws).
+`applyCustomAttributes` can add fields (e.g. an app-level severity).
+
+### User Action (`browser.user_action`)
+
+Captures user input events (by default `click`). Any `data-otel-*` attribute on the clicked element
+is copied onto the record — a deliberate channel for **non-PII** business context.
+
+```typescript
+new UserActionInstrumentation({ autoCapturedActions: ['click'] }); // default
+```
+
+```html
+<button data-otel-feature="signup">Sign Up</button>
+```
+
+> `data-otel-*` values are exported verbatim — do not put PII (emails, names) in them.
+
+## Span-based instrumentations (`opentelemetry-js` / `js-contrib`)
+
+These produce **spans** and live outside `opentelemetry-browser`. The easiest on-ramp is the auto
+bundle:
+
+```typescript
+import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
+registerInstrumentations({ instrumentations: [getWebAutoInstrumentations()] });
+```
+
+| Package | Repo | What it does |
+|---|---|---|
+| `instrumentation-fetch` | js | Spans for `fetch()`; injects `traceparent` (configure `propagateTraceHeaderCorsUrls`). |
+| `instrumentation-xml-http-request` | js | Spans for `XMLHttpRequest`; same propagation knobs. |
+| `instrumentation-document-load` | js-contrib | Spans for document load + navigation/resource timing (span flavor). |
+| `instrumentation-user-interaction` | js-contrib | Spans for user interactions (clicks) with their async causal tree. |
+| `instrumentation-long-task` | js-contrib | Spans for [Long Tasks](https://developer.mozilla.org/docs/Web/API/Long_Tasks_API) (>50 ms main-thread blocks). |
+| `instrumentation-browser-navigation` | js-contrib | Event-based SPA navigation (alternative to the one above). |
+| `instrumentation-web-exception` | js-contrib | Event-based unhandled exception capture. |
+| `plugin-react-load` | js-contrib | React component mount/load performance. |
+
+### fetch / XHR cross-origin propagation
+
+```typescript
+import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+
+new FetchInstrumentation({
+  // Required for traceparent to be sent to OTHER origins.
+  propagateTraceHeaderCorsUrls: [/api\.example\.com/],
+  // Avoid tracing telemetry export calls themselves (prevents feedback loops).
+  ignoreUrls: [/\/v1\/(traces|logs)/],
+});
+```
+
+The server must list `traceparent` (and `tracestate`/`baggage` if used) in
+`Access-Control-Allow-Headers`, or the preflight fails. See
+[setup-sdk.md](setup-sdk.md#connecting-frontend-to-backend-traces).
+
+## Choosing what to enable
+
+| Goal | Enable |
+|---|---|
+| Page performance | Web Vitals, Navigation Timing, Resource Timing (span: document-load, long-task) |
+| User journeys / analytics | Navigation, User Action |
+| Error tracking | Errors, Console (`error`/`warn` only) |
+| Frontend↔backend tracing | fetch + XHR span instrumentation with CORS propagation |
+| Minimal footprint | Web Vitals + Errors + Navigation (low volume, high value); add the rest deliberately |
+
+## Anti-patterns
+
+| Anti-pattern | Why it's wrong | Fix |
+|---|---|---|
+| Enabling every instrumentation by default | Resource-timing + console `log` create huge, low-value volume | Start minimal; add deliberately once you understand the volume |
+| Capturing `console.log`/`debug` in production | Noise + PII leakage | `logMethods: ['error', 'warn']` |
+| Putting PII in `data-otel-*` or URLs | Exported verbatim to your backend | Use `sanitizeUrl`; keep `data-otel-*` to non-PII business keys |
+| Tracing your own OTLP export calls | Infinite telemetry-about-telemetry loop | `ignoreUrls` the `/v1/traces` and `/v1/logs` endpoints |
+| Forcing spans around point-in-time facts | Wrong model; bloats traces | Use the event-based instrumentations for vitals/navigation/errors |
+| Relying on navigation *timing* for page-view counts | Lost when `load` never fires / user leaves early | Use the navigation *event* for counts, timing for performance |

--- a/skills/otel-browser/references/instrumentation.md
+++ b/skills/otel-browser/references/instrumentation.md
@@ -20,7 +20,10 @@ with a real begin/end and parent/child relationship.
 ## Event-based instrumentations (`@opentelemetry/browser-instrumentation`)
 
 Entry points are subpath exports under `./experimental/*`; they emit through the global
-`LoggerProvider` (see [setup-sdk.md](setup-sdk.md#logger-provider-events)).
+`LoggerProvider` (see [setup-sdk.md](setup-sdk.md#logger-provider-events)), so call
+`logs.setGlobalLoggerProvider(...)` **before** `registerInstrumentations`. (Span-based
+instrumentations instead need `tracerProvider` passed to `registerInstrumentations` — see
+[setup-sdk.md](setup-sdk.md#register-the-instrumentations).)
 
 ```typescript
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
@@ -139,7 +142,12 @@ bundle:
 
 ```typescript
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
-registerInstrumentations({ instrumentations: [getWebAutoInstrumentations()] });
+// Pass tracerProvider when you use a non-global WebTracerProvider, or these span-based
+// instrumentations bind to the global no-op tracer and emit nothing.
+registerInstrumentations({
+  tracerProvider: provider,
+  instrumentations: [getWebAutoInstrumentations()],
+});
 ```
 
 | Package | Repo | What it does |
@@ -190,3 +198,4 @@ The server must list `traceparent` (and `tracestate`/`baggage` if used) in
 | Tracing your own OTLP export calls | Infinite telemetry-about-telemetry loop | `ignoreUrls` the `/v1/traces` and `/v1/logs` endpoints |
 | Forcing spans around point-in-time facts | Wrong model; bloats traces | Use the event-based instrumentations for vitals/navigation/errors |
 | Relying on navigation *timing* for page-view counts | Lost when `load` never fires / user leaves early | Use the navigation *event* for counts, timing for performance |
+| Assuming an instrumentation works because registration threw no error | These packages are experimental; a misconfigured or no-op instrumentation emits neither errors nor telemetry | Verify each one reaches the Collector (diag logging + `debug` exporter) — see [setup-sdk.md](setup-sdk.md#verify-it-actually-emits) |

--- a/skills/otel-browser/references/instrumentation.md
+++ b/skills/otel-browser/references/instrumentation.md
@@ -22,8 +22,8 @@ with a real begin/end and parent/child relationship.
 Entry points are subpath exports under `./experimental/*`; they emit through the global
 `LoggerProvider` (see [setup-sdk.md](setup-sdk.md#logger-provider-events)), so call
 `logs.setGlobalLoggerProvider(...)` **before** `registerInstrumentations`. (Span-based
-instrumentations instead need `tracerProvider` passed to `registerInstrumentations` — see
-[setup-sdk.md](setup-sdk.md#register-the-instrumentations).)
+instrumentations resolve their tracer at registration time too — pass `tracerProvider` or register
+the provider globally first; see [setup-sdk.md](setup-sdk.md#register-the-instrumentations).)
 
 ```typescript
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
@@ -142,8 +142,8 @@ bundle:
 
 ```typescript
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
-// Pass tracerProvider when you use a non-global WebTracerProvider, or these span-based
-// instrumentations bind to the global no-op tracer and emit nothing.
+// Pass tracerProvider (or register the provider globally BEFORE this call); otherwise these
+// span-based instrumentations resolve the no-op tracer at registration time and emit nothing.
 registerInstrumentations({
   tracerProvider: provider,
   instrumentations: [getWebAutoInstrumentations()],

--- a/skills/otel-browser/references/performance.md
+++ b/skills/otel-browser/references/performance.md
@@ -1,0 +1,145 @@
+# Browser performance, cost & privacy
+
+In the browser the SDK is shipped to the user and runs on their device. Every byte of SDK and every
+exported record competes with page-load speed and observability spend. Three budgets dominate —
+**bundle size**, **runtime cost**, and **telemetry volume/cost** — with **PII** as a hard constraint
+across all three.
+
+| Budget | Main levers |
+|---|---|
+| Bundle size | Tree-shaking, per-signal SDK imports, prefer events over spans, skip `zone.js` when you can |
+| Runtime cost | Off-main-thread processing, batch processors, idle callbacks |
+| Telemetry volume/cost | Fewer instrumentations, restrict resource-timing, sampling, Collector-side trimming |
+| Privacy (PII) | URL sanitization, restrict console capture, redact in the Collector |
+
+## Bundle size
+
+The SDK affects page-load performance, so bundle size is a first-class constraint for browser OTel —
+more so than for backend SDKs.
+
+- **Import per-signal SDK entry points** so the bundler drops unused signals. If nothing produces
+  spans, import only `@opentelemetry/browser-sdk/logs` and skip the tracing SDK (and vice versa). See
+  [setup-sdk.md](setup-sdk.md#per-signal-sdks-tree-shaking).
+- **Prefer event-based over span-based** instrumentations where both exist — they pull in less SDK
+  surface.
+- **Use subpath imports** for instrumentations
+  (`@opentelemetry/browser-instrumentation/experimental/web-vitals`) rather than a barrel import, so
+  unused instrumentations tree-shake away.
+- **`zone.js` is ~1 MB.** `ZoneContextManager` is the only reliable way to propagate trace context
+  across async boundaries, but it is heavy. A common trade-off is to relax in-browser async tracing
+  and rely on **session correlation** instead, adding `zone.js` only when stitched async spans are
+  genuinely needed.
+- Pin exact versions and watch the bundle in CI — experimental packages change size between minors.
+
+## Runtime cost (don't block the main thread)
+
+The main thread renders the page; telemetry must stay off it.
+
+- **Resource timing** already uses `requestIdleCallback` (Safari `setTimeout` fallback), processes in
+  batches, and bounds time per idle callback. Tune `batchSize`, `maxProcessingTime`, and
+  `maxQueueSize` if you load many resources. See
+  [instrumentation.md](instrumentation.md#resource-timing-browserresource_timing).
+- **Always use the Batch processors** (`BatchSpanProcessor`, `BatchLogRecordProcessor`), never the
+  `Simple*` variants (one network request per record). Bound the queue and batch:
+
+```typescript
+new BatchLogRecordProcessor(exporter, {
+  maxQueueSize: 100,        // illustrative — drop records past this rather than grow unbounded
+  maxExportBatchSize: 50,
+  scheduledDelayMillis: 5000,
+});
+```
+
+(Numbers are illustrative, not a standard — tune to your traffic.)
+
+## Page lifecycle: flush before the page vanishes
+
+A browser page can be closed, backgrounded, or frozen (bfcache) at any time with no graceful
+shutdown. Telemetry buffered in a batch processor is lost if you don't flush in time.
+
+- **Flush on `visibilitychange`/`pagehide`, not `unload`/`beforeunload`** — the latter are unreliable
+  (especially on mobile) and break bfcache.
+- The OTLP/HTTP browser exporter uses **`fetch` with `keepalive`** (the modern replacement for
+  `navigator.sendBeacon`) so in-flight exports survive the page going away.
+- Late-finalizing signals (INP, CLS, Web Vitals generally) are only known near the end of the page
+  lifecycle — they depend on this flush actually happening.
+
+```typescript
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'hidden') {
+    void loggerProvider.forceFlush();
+    void tracerProvider.forceFlush();
+  }
+});
+```
+
+## Telemetry volume and cost
+
+RUM volume scales with user traffic and is easy to make ruinously expensive. A browser can emit many
+loosely-related events per second, and a single content-heavy page can produce hundreds of
+resource-timing records.
+
+- **Enable a minimal set first** (e.g. Web Vitals + Errors + Navigation); add resource timing,
+  console, and user actions deliberately once you understand their volume.
+- **Restrict resource timing** with `initiatorTypes` (e.g. `['xmlhttprequest', 'fetch']`) instead of
+  capturing every script/image/font.
+- **Restrict console capture** to `['error', 'warn']` in production.
+- **Sample.** Apply head sampling in the SDK and/or sampling at the Collector edge. Because clients
+  are untrusted and chatty, edge sampling and rate limiting protect both cost and your backend.
+- **Watch cardinality.** Rich user/session context is valuable for slicing by affected cohort, but
+  high-cardinality attributes drive backend cost — balance richness against spend.
+
+## The Collector is your cost and safety valve
+
+Sending browser telemetry to an OpenTelemetry Collector (or vendor edge endpoint) rather than
+directly to a backend store is the only place to enforce policy on an untrusted client:
+
+- **Sampling and rate limiting** to cap RUM spend and absorb hostile/buggy clients.
+- **Redaction** of PII the client should not have sent — see the `redaction` processor in the
+  `otel-collector` skill.
+- **CORS termination**, keeping backend credentials out of client code.
+- **Trustworthy resource attributes** (real client IP, geo) the browser cannot self-report.
+
+## Privacy / PII (hard constraint)
+
+PII leaks into browser telemetry through URLs, console output, form fields, and click targets.
+Controlling it is partly developer discipline and partly pipeline enforcement.
+
+| Vector | Risk | Mitigation |
+|---|---|---|
+| URLs (`url.full`) | tokens, emails, IDs in path/query | `sanitizeUrl` / `defaultSanitizeUrl` on the navigation instrumentation |
+| `console.log`/`info`/`debug` | apps log user data to the console | capture only `['error', 'warn']` in prod |
+| `data-otel-*` attributes | exported verbatim | keep to non-PII business keys only |
+| Free-form custom attributes | accidental PII | review `applyCustomAttributes` / `applyCustomLogRecordData` hooks |
+| Anything the client sends | the client is untrusted | redact in the Collector as a backstop |
+
+## Performance checklist
+
+- [ ] Per-signal SDK imports; unused signal SDK tree-shaken out
+- [ ] Subpath imports for instrumentations (no barrel import)
+- [ ] `zone.js`/`ZoneContextManager` included **only** if async span stitching is required
+- [ ] Batch processors with bounded queue/batch sizes (no `Simple*` processors)
+- [ ] `forceFlush()` wired to `visibilitychange`/`pagehide`; export uses `keepalive`
+- [ ] Minimal instrumentation set enabled; resource timing restricted by `initiatorTypes`
+- [ ] Console capture limited to `error`/`warn` in production
+- [ ] Sampling configured (SDK and/or Collector edge)
+- [ ] URL sanitization on; PII redaction enforced in the Collector
+- [ ] Exporting to a Collector, not directly to a backend store
+
+## Background
+
+These durable learnings are corroborated by OpenTelemetry community talks:
+
+- **Coming soon to a browser near you: OpenTelemetry** — Browser SIG panel, Oct 2025
+  ([recap](https://embrace.io/blog/browser-opentelemetry-panel-recap/)). Events-vs-spans model,
+  sessions as the correlation primitive, the `zone.js` trade-off, bundle-size strategy.
+- **From RUM to Front-End Observability with OpenTelemetry** — Purvi Kanal, KubeCon EU 2024
+  ([video](https://www.youtube.com/watch?v=l2_wsvv-Rhs)). Connecting browser spans to backend traces.
+- **A Practical Guide to Debugging Browser Performance with OpenTelemetry** — Purvi Kanal,
+  KubeCon NA 2023 ([video](https://www.youtube.com/watch?v=0J1z599tmfY)). Core Web Vitals, page/
+  resource timing, long tasks.
+
+> The `browser.*` semantic conventions are still evolving and vendors differ in how they represent
+> Core Web Vitals. Confirm attribute names and thresholds against the current
+> [OpenTelemetry browser semantic conventions](https://opentelemetry.io/docs/specs/semconv/browser/)
+> before encoding them.

--- a/skills/otel-browser/references/setup-sdk.md
+++ b/skills/otel-browser/references/setup-sdk.md
@@ -4,9 +4,10 @@ Setting up OpenTelemetry in the browser for **traces (spans)** and **events (log
 is no MeterProvider story in the browser yet.
 
 > **Stability**: `@opentelemetry/browser-sdk` is experimental and may be unpublished — confirm with
-> `npm view @opentelemetry/browser-sdk version`. The stable path today is the web tracing SDK
-> (`@opentelemetry/sdk-trace-web`) plus event-based instrumentations from
-> `@opentelemetry/browser-instrumentation`. Both are shown below.
+> `npm view @opentelemetry/browser-sdk version`. The most settled path today wires the providers
+> directly: the **stable** web tracing SDK (`@opentelemetry/sdk-trace-web`, `@opentelemetry/context-zone`)
+> for spans, plus the **experimental** Logs SDK (`@opentelemetry/api-logs`, `@opentelemetry/sdk-logs`,
+> still on the 0.x line) for events. Both approaches are shown below.
 
 ## Core principles
 
@@ -28,7 +29,10 @@ a vendor edge endpoint) rather than directly to a backend store is what makes CO
 sampling, redaction, rate limiting, and trustworthy server-side resource attributes (real client IP,
 geo) possible. See [performance.md](performance.md#the-collector-is-your-cost-and-safety-valve).
 
-## Approach A — stable primitives
+## Approach A — direct providers
+
+Spans use the **stable** tracing SDK; events use the **experimental** Logs SDK (0.x). There is no
+stable browser events path yet — the Logs SDK is the current mechanism.
 
 ### Dependencies
 
@@ -99,9 +103,10 @@ global `LoggerProvider`. See [instrumentation.md](instrumentation.md).
 
 ## Approach B — Browser SDK (experimental)
 
-`@opentelemetry/browser-sdk` collapses the boilerplate above into one call. It is experimental and
-may be unreleased — config options change frequently, so re-check the package README (see the
-Sources of Truth in [SKILL.md](../SKILL.md#sources-of-truth)).
+`@opentelemetry/browser-sdk` collapses the boilerplate above into one call. It exports two combined
+initializers — `quickStartBrowserSdk` (simplified) and `startBrowserSdk` (deeper control) — plus
+per-signal entry points. It is experimental and may be unreleased; config options change frequently,
+so re-check the package README (see the Sources of Truth in [SKILL.md](../SKILL.md#sources-of-truth)).
 
 ```javascript
 import { quickStartBrowserSdk } from '@opentelemetry/browser-sdk';

--- a/skills/otel-browser/references/setup-sdk.md
+++ b/skills/otel-browser/references/setup-sdk.md
@@ -55,14 +55,25 @@ npm install @opentelemetry/api-logs \
 ### Tracer provider (spans)
 
 ```typescript
-import { resourceFromAttributes } from '@opentelemetry/resources';
-import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { defaultResource, resourceFromAttributes } from '@opentelemetry/resources';
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import { WebTracerProvider, BatchSpanProcessor } from '@opentelemetry/sdk-trace-web';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
+// Merge with the default resource so `telemetry.sdk.*` (and any env-detected attributes)
+// are preserved. `resourceFromAttributes()` ALONE replaces the default resource and drops
+// them — telemetry then arrives with only the attributes you listed. Reuse this one
+// `resource` for BOTH the tracer and logger providers so spans and events correlate.
+const resource = defaultResource().merge(
+  resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: 'my-web-app',
+    [ATTR_SERVICE_VERSION]: '1.0.0',
+  }),
+);
+
 const provider = new WebTracerProvider({
-  resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: 'my-web-app' }),
+  resource,
   spanProcessors: [
     new BatchSpanProcessor(
       new OTLPTraceExporter({ url: 'https://collector.example.com/v1/traces' }),
@@ -89,6 +100,9 @@ import { LoggerProvider, BatchLogRecordProcessor } from '@opentelemetry/sdk-logs
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 
 const loggerProvider = new LoggerProvider({
+  // Pass the SAME merged resource as the tracer provider. Without a resource, events carry
+  // no `service.name` and cannot be correlated with the spans from the same app.
+  resource,
   processors: [
     new BatchLogRecordProcessor(
       new OTLPLogExporter({ url: 'https://collector.example.com/v1/logs' }),
@@ -100,6 +114,44 @@ logs.setGlobalLoggerProvider(loggerProvider);
 
 The event-based instrumentations (navigation, web vitals, console, errors, …) emit through this
 global `LoggerProvider`. See [instrumentation.md](instrumentation.md).
+
+### Register the instrumentations
+
+```typescript
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+import { WebVitalsInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/web-vitals';
+
+registerInstrumentations({
+  // REQUIRED for span-based instrumentations (fetch, XHR, document-load) when you use a
+  // non-global provider: pass the WebTracerProvider you created above. Omit it and those
+  // instrumentations attach to the global no-op tracer and silently emit NO spans.
+  tracerProvider: provider,
+  instrumentations: [
+    new FetchInstrumentation(),     // span-based → uses tracerProvider above
+    new WebVitalsInstrumentation(), // event-based → uses the global LoggerProvider set above
+  ],
+});
+```
+
+Event-based instrumentations emit through whatever `logs.setGlobalLoggerProvider()` was given, so
+set that **before** `registerInstrumentations`. Span-based ones need the `tracerProvider` here.
+
+### Verify it actually emits
+
+These packages are experimental and their wiring is easy to get subtly wrong (a missing
+`tracerProvider`, a provider registered too late, an instrumentation that no-ops silently). After
+wiring up, confirm each enabled instrumentation actually produces telemetry rather than assuming it
+does:
+
+- Turn on SDK diagnostics during bring-up and watch the console:
+  `import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';`
+  `diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);` (remove for production).
+- Point at a local Collector with the `debug` exporter (`verbosity: detailed`) and check that the
+  span names and event names you expect (e.g. a `fetch` span, an `exception` event) actually arrive
+  — exercise each path (navigate, click, fetch, throw) and look for it downstream.
+- Treat "no error in the console" as **not** proof of capture: a silently inactive instrumentation
+  produces neither errors nor telemetry.
 
 ## Approach B — Browser SDK (experimental)
 
@@ -169,12 +221,15 @@ new FetchInstrumentation({
 
 - [ ] SDK initialized **before** app/framework code and before libraries patch globals
 - [ ] `service.name` (and ideally `service.version`) set as resource attributes
+- [ ] Resource built by merging the **default** resource (so `telemetry.sdk.*` survives), and the **same** resource passed to both the tracer and logger providers
 - [ ] Exporting OTLP/**HTTP** to a Collector you control (not gRPC, not directly to a backend store)
+- [ ] `tracerProvider` passed to `registerInstrumentations` for span-based instrumentations (else they no-op silently)
 - [ ] `ZoneContextManager` registered if you need trace context across async boundaries
 - [ ] `BatchSpanProcessor` / `BatchLogRecordProcessor` (not `Simple*`) for export efficiency
 - [ ] Session processor registered **before** the export processor
 - [ ] `propagateTraceHeaderCorsUrls` set and server `Access-Control-Allow-Headers` includes `traceparent`
 - [ ] Telemetry flushed on `visibilitychange`/`pagehide` (keepalive), not `unload`
+- [ ] **Verified** each enabled instrumentation actually emits to the Collector (diag logging + `debug` exporter), not just assumed
 
 ## Anti-patterns
 
@@ -187,3 +242,6 @@ new FetchInstrumentation({
 | Flushing on `unload` | Unreliable on mobile/bfcache; blocks navigation | Flush on `visibilitychange`/`pagehide` with `keepalive` |
 | Session processor after the batch processor | Records exported before `session.id` is attached | Put the session processor first |
 | Shipping `sdk-trace-web` without a context manager | Async user interactions lose parent context | Register `ZoneContextManager` |
+| `resource: resourceFromAttributes({...})` as the whole resource | Replaces the default resource; drops `telemetry.sdk.*` and env-detected attributes | Merge: `defaultResource().merge(resourceFromAttributes({...}))` |
+| Building a `LoggerProvider` with no `resource` | Events carry no `service.name`; can't be attributed or correlated with spans | Pass the same merged resource to the logger provider |
+| `registerInstrumentations` without `tracerProvider` (non-global provider) | Span-based instrumentations bind to the global no-op tracer and emit nothing | Pass `tracerProvider: provider` |

--- a/skills/otel-browser/references/setup-sdk.md
+++ b/skills/otel-browser/references/setup-sdk.md
@@ -123,19 +123,23 @@ import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
 import { WebVitalsInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/web-vitals';
 
 registerInstrumentations({
-  // REQUIRED for span-based instrumentations (fetch, XHR, document-load) when you use a
-  // non-global provider: pass the WebTracerProvider you created above. Omit it and those
-  // instrumentations attach to the global no-op tracer and silently emit NO spans.
+  // Span-based instrumentations (fetch, XHR, document-load) resolve their tracer AT THIS CALL:
+  // from `tracerProvider` if given, otherwise the global tracer provider. Passing it explicitly
+  // is the robust, order-independent choice. Relying on the global instead works only if
+  // `provider.register()` ran BEFORE this call — register after, and they bind to the no-op
+  // tracer and silently emit nothing.
   tracerProvider: provider,
   instrumentations: [
-    new FetchInstrumentation(),     // span-based → uses tracerProvider above
+    new FetchInstrumentation(),     // span-based → uses the tracer provider resolved here
     new WebVitalsInstrumentation(), // event-based → uses the global LoggerProvider set above
   ],
 });
 ```
 
-Event-based instrumentations emit through whatever `logs.setGlobalLoggerProvider()` was given, so
-set that **before** `registerInstrumentations`. Span-based ones need the `tracerProvider` here.
+**Order matters.** Each instrumentation resolves its tracer/logger when `registerInstrumentations`
+runs, so `provider.register()` and `logs.setGlobalLoggerProvider()` must run **before** it. Passing
+`tracerProvider` explicitly (above) removes the ordering dependency for spans; event-based
+instrumentations always read the global logger, so set that first regardless.
 
 ### Verify it actually emits
 
@@ -223,7 +227,7 @@ new FetchInstrumentation({
 - [ ] `service.name` (and ideally `service.version`) set as resource attributes
 - [ ] Resource built by merging the **default** resource (so `telemetry.sdk.*` survives), and the **same** resource passed to both the tracer and logger providers
 - [ ] Exporting OTLP/**HTTP** to a Collector you control (not gRPC, not directly to a backend store)
-- [ ] `tracerProvider` passed to `registerInstrumentations` for span-based instrumentations (else they no-op silently)
+- [ ] Providers registered globally (`provider.register()`, `logs.setGlobalLoggerProvider()`) **before** `registerInstrumentations`, or `tracerProvider` passed to it explicitly — else span instrumentations resolve the no-op tracer
 - [ ] `ZoneContextManager` registered if you need trace context across async boundaries
 - [ ] `BatchSpanProcessor` / `BatchLogRecordProcessor` (not `Simple*`) for export efficiency
 - [ ] Session processor registered **before** the export processor
@@ -244,4 +248,4 @@ new FetchInstrumentation({
 | Shipping `sdk-trace-web` without a context manager | Async user interactions lose parent context | Register `ZoneContextManager` |
 | `resource: resourceFromAttributes({...})` as the whole resource | Replaces the default resource; drops `telemetry.sdk.*` and env-detected attributes | Merge: `defaultResource().merge(resourceFromAttributes({...}))` |
 | Building a `LoggerProvider` with no `resource` | Events carry no `service.name`; can't be attributed or correlated with spans | Pass the same merged resource to the logger provider |
-| `registerInstrumentations` without `tracerProvider` (non-global provider) | Span-based instrumentations bind to the global no-op tracer and emit nothing | Pass `tracerProvider: provider` |
+| `registerInstrumentations` running before `provider.register()` (and no explicit `tracerProvider`) | Span instrumentations resolve the no-op tracer at registration time and emit nothing | Register the provider (or pass `tracerProvider`) **before** registering instrumentations |

--- a/skills/otel-browser/references/setup-sdk.md
+++ b/skills/otel-browser/references/setup-sdk.md
@@ -1,0 +1,184 @@
+# Browser SDK setup
+
+Setting up OpenTelemetry in the browser for **traces (spans)** and **events (log records)**. There
+is no MeterProvider story in the browser yet.
+
+> **Stability**: `@opentelemetry/browser-sdk` is experimental and may be unpublished — confirm with
+> `npm view @opentelemetry/browser-sdk version`. The stable path today is the web tracing SDK
+> (`@opentelemetry/sdk-trace-web`) plus event-based instrumentations from
+> `@opentelemetry/browser-instrumentation`. Both are shown below.
+
+## Core principles
+
+- **Load first, load synchronously.** Instrumentations patch `window`, `fetch`, `XMLHttpRequest`,
+  and `history`. Start the SDK before any framework or library patches those globals, or behavior is
+  undefined.
+- **Two signals, two providers.** Spans go through a `TracerProvider`; events go through a
+  `LoggerProvider` (events are emitted via the Logs API as `LogRecord`s).
+- **Export over OTLP/HTTP.** gRPC is not available in the browser. Use the OTLP/HTTP (protobuf or
+  JSON) exporters.
+- **Flush before the page vanishes.** Pages can be closed, backgrounded, or frozen (bfcache) with no
+  graceful shutdown. Flush on `visibilitychange`/`pagehide` with `keepalive`, not `unload`. See
+  [performance.md](performance.md#page-lifecycle-flush-before-the-page-vanishes).
+
+### A Collector (or vendor edge) in front of browsers
+
+The browser is untrusted and uncontrolled. Routing telemetry through an OpenTelemetry Collector (or
+a vendor edge endpoint) rather than directly to a backend store is what makes CORS termination,
+sampling, redaction, rate limiting, and trustworthy server-side resource attributes (real client IP,
+geo) possible. See [performance.md](performance.md#the-collector-is-your-cost-and-safety-valve).
+
+## Approach A — stable primitives
+
+### Dependencies
+
+```bash
+# Tracing (stable)
+npm install @opentelemetry/api \
+  @opentelemetry/sdk-trace-web \
+  @opentelemetry/context-zone \
+  @opentelemetry/exporter-trace-otlp-http \
+  @opentelemetry/resources \
+  @opentelemetry/semantic-conventions
+
+# Events (Logs API) for event-based instrumentations
+npm install @opentelemetry/api-logs \
+  @opentelemetry/sdk-logs \
+  @opentelemetry/exporter-logs-otlp-http \
+  @opentelemetry/instrumentation
+```
+
+### Tracer provider (spans)
+
+```typescript
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { WebTracerProvider, BatchSpanProcessor } from '@opentelemetry/sdk-trace-web';
+import { ZoneContextManager } from '@opentelemetry/context-zone';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+
+const provider = new WebTracerProvider({
+  resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: 'my-web-app' }),
+  spanProcessors: [
+    new BatchSpanProcessor(
+      new OTLPTraceExporter({ url: 'https://collector.example.com/v1/traces' }),
+    ),
+  ],
+});
+
+provider.register({
+  // ZoneContextManager keeps trace context across async user interactions
+  // (setTimeout, promises, event handlers). Without it, async callbacks lose the active span.
+  contextManager: new ZoneContextManager(),
+});
+```
+
+> `ZoneContextManager` requires `zone.js` (~1 MB). It is the only reliable way to propagate context
+> across async boundaries in the browser, but it is a heavy dependency — see the
+> [bundle-size trade-off](performance.md#bundle-size).
+
+### Logger provider (events)
+
+```typescript
+import { logs } from '@opentelemetry/api-logs';
+import { LoggerProvider, BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
+
+const loggerProvider = new LoggerProvider({
+  processors: [
+    new BatchLogRecordProcessor(
+      new OTLPLogExporter({ url: 'https://collector.example.com/v1/logs' }),
+    ),
+  ],
+});
+logs.setGlobalLoggerProvider(loggerProvider);
+```
+
+The event-based instrumentations (navigation, web vitals, console, errors, …) emit through this
+global `LoggerProvider`. See [instrumentation.md](instrumentation.md).
+
+## Approach B — Browser SDK (experimental)
+
+`@opentelemetry/browser-sdk` collapses the boilerplate above into one call. It is experimental and
+may be unreleased — config options change frequently, so re-check the package README (see the
+Sources of Truth in [SKILL.md](../SKILL.md#sources-of-truth)).
+
+```javascript
+import { quickStartBrowserSdk } from '@opentelemetry/browser-sdk';
+
+const sdk = quickStartBrowserSdk({
+  serviceName: 'my-web-app',
+  serviceVersion: '1.0',
+  exportUrl: 'https://collector.example.com', // required
+  exportHeaders: { 'x-api-key': '...' },       // optional
+});
+```
+
+`startBrowserSdk` exposes full control (`resourceAttributes`, `exportConfig`, per-signal `logs` /
+`traces` blocks with `spanLimits`/`logRecordLimits`, `contextManager`, `propagators`, `sampler`),
+and `await sdk.shutdown()` flushes and stops.
+
+### Per-signal SDKs (tree-shaking)
+
+If you need only one signal, import only that signal's entry point so the bundler drops the other.
+Each takes the **full** URL (the signal path is not appended automatically).
+
+| Subpath | Function | Default export URL |
+|---|---|---|
+| `@opentelemetry/browser-sdk/logs` | `startLogsSdk` | `http://localhost:4318/v1/logs` |
+| `@opentelemetry/browser-sdk/traces` | `startTracesSdk` | `http://localhost:4318/v1/traces` |
+
+## Sessions
+
+A **session** correlates the traces and events a single user produces over a time window, expressed
+as `session.*` attributes (e.g. `session.id`) attached to every span/log. The Browser SDK ships a
+session manager under `@opentelemetry/browser-sdk/session` (`createSessionManager`,
+`createLocalStorageSessionStore`, `createSessionSpanProcessor`, `createSessionLogRecordProcessor`),
+with configurable `maxDuration` and `inactivityTimeout`.
+
+> **Processor ordering**: register the session processor **before** the export (batch) processor so
+> `session.id` is stamped before export. If you set `processors` explicitly you own the pipeline —
+> include both the session processor and an export processor.
+
+`session.*` follows the
+[session semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/session.md).
+
+## Connecting frontend to backend traces
+
+To stitch a browser trace to the backend spans it triggers, the browser must inject the W3C
+`traceparent` header on outgoing requests, and the backend must accept it.
+
+- `instrumentation-fetch` / `instrumentation-xml-http-request` inject `traceparent` automatically.
+- Set `propagateTraceHeaderCorsUrls` so the header is sent on **cross-origin** requests — it is
+  **not** sent cross-origin by default.
+- The server must list `traceparent` (and `tracestate`/`baggage` if used) in
+  `Access-Control-Allow-Headers`, or the preflight fails and the request is blocked.
+
+```typescript
+new FetchInstrumentation({
+  propagateTraceHeaderCorsUrls: [/api\.example\.com/],
+});
+```
+
+## Setup checklist
+
+- [ ] SDK initialized **before** app/framework code and before libraries patch globals
+- [ ] `service.name` (and ideally `service.version`) set as resource attributes
+- [ ] Exporting OTLP/**HTTP** to a Collector you control (not gRPC, not directly to a backend store)
+- [ ] `ZoneContextManager` registered if you need trace context across async boundaries
+- [ ] `BatchSpanProcessor` / `BatchLogRecordProcessor` (not `Simple*`) for export efficiency
+- [ ] Session processor registered **before** the export processor
+- [ ] `propagateTraceHeaderCorsUrls` set and server `Access-Control-Allow-Headers` includes `traceparent`
+- [ ] Telemetry flushed on `visibilitychange`/`pagehide` (keepalive), not `unload`
+
+## Anti-patterns
+
+| Anti-pattern | Why it's wrong | Fix |
+|---|---|---|
+| Initializing the SDK after the framework boots | Instrumentations patch globals the framework already wrapped; spans/events go missing | Load the SDK in a synchronous entry module imported first |
+| Exporting straight to a backend store from the browser | Leaks credentials, no CORS control, no edge sampling/redaction, unbounded cost | Export to a Collector / vendor edge endpoint |
+| Expecting `traceparent` on cross-origin calls by default | The browser only propagates same-origin unless told otherwise | Set `propagateTraceHeaderCorsUrls` **and** server `Access-Control-Allow-Headers` |
+| `SimpleSpanProcessor` / `SimpleLogRecordProcessor` in production | One network request per record | Use the Batch processors |
+| Flushing on `unload` | Unreliable on mobile/bfcache; blocks navigation | Flush on `visibilitychange`/`pagehide` with `keepalive` |
+| Session processor after the batch processor | Records exported before `session.id` is attached | Put the session processor first |
+| Shipping `sdk-trace-web` without a context manager | Async user interactions lose parent context | Register `ZoneContextManager` |


### PR DESCRIPTION
## Summary

Adds a new vendor-neutral, facts-only `otel-browser` skill covering OpenTelemetry in the browser (Real User Monitoring / RUM), mirroring the `otel-go`/`otel-python` multi-reference shape.

**`SKILL.md`** carries the irreducible browser-specific facts an agent gets wrong from training:
- The **two telemetry models** — events (Logs API) vs spans; **no metrics** in the browser yet.
- The **three-repo package ecosystem + stability table** (`opentelemetry-browser`, `opentelemetry-js`, `opentelemetry-js-contrib`).
- Why browser RUM differs (process disappears, OTLP/HTTP-only, opt-in cross-origin propagation, untrusted client, PII).
- A **Sources of Truth** fetch table for live version/status lookups (not frozen numbers) and cross-references to `otel-js`, `otel-declarative-config`, `otel-semantic-conventions`, `otel-collector`.

**References:**
- `references/setup-sdk.md` — stable primitives (`WebTracerProvider` + `ZoneContextManager` + `LoggerProvider`) vs the experimental `browser-sdk`, sessions, frontend→backend `traceparent`/CORS propagation, the collector-in-front pattern, checklist + anti-patterns.
- `references/instrumentation.md` — event-based and span-based catalogs with per-instrumentation config and captured attributes, "choosing what to enable", anti-patterns.
- `references/performance.md` — bundle size, off-main-thread cost, page-lifecycle flush, telemetry volume/cost, PII vectors, checklist.

Vendor-neutral and stripped of opinion — opinions stay in the companion `skills` repo per `AGENTS.md`.

Registered in all three places: `.claude-plugin/marketplace.json`, the README Repository Structure tree, and the language-specific "Available Skills" table.

## Test plan

- [x] Directory name equals the `name:` field (`otel-browser`).
- [x] Frontmatter conforms to the agentskills.io spec (`name`, `description` with enumerated trigger phrasings).
- [x] `marketplace.json` parses; skill registered in all three places.
- [x] All intra-skill links and anchors resolve (scripted check).
- [x] Load-bearing upstream URLs verified (fixed the WebVital semconv link to `…/browser/browser-events/#webvital-event`).
- [x] Vendor-neutral, non-opinionated tone.
- [x] `otel-agent-tools` Go module untouched (no generated data changes).

Closes E-2457

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new browser OpenTelemetry skill for Real User Monitoring (RUM) and web tracing.
  * Registered the skill in the marketplace and included it in the available skills catalog.

* **Documentation**
  * Added a browser RUM entry-point guide covering stability expectations, telemetry models, and key design constraints.
  * Added detailed reference docs for instrumentation selection, SDK setup (including page-lifecycle flushing and cross-origin `traceparent` propagation), and performance/cost/privacy guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
