### PR TITLE
docs(otel-browser): refresh against upstream browser-sdk 0.1.0 release

### DIFF
--- a/skills/otel-browser/SKILL.md
+++ b/skills/otel-browser/SKILL.md
@@ -47,7 +47,7 @@ are the authoritative, current map. Summary:
 | `@opentelemetry/instrumentation-xml-http-request` | opentelemetry-js | spans | experimental |
 | `@opentelemetry/browser-detector` | opentelemetry-js | resource | experimental |
 | `@opentelemetry/browser-instrumentation` | opentelemetry-browser | events | experimental |
-| `@opentelemetry/browser-sdk` | opentelemetry-browser | SDK | experimental (unreleased) |
+| `@opentelemetry/browser-sdk` | opentelemetry-browser | SDK | experimental (0.x) |
 | `@opentelemetry/auto-instrumentations-web` | opentelemetry-js-contrib | bundle | experimental |
 | `instrumentation-document-load` / `-long-task` / `-user-interaction` | opentelemetry-js-contrib | spans | experimental |
 | `instrumentation-browser-navigation` / `-web-exception` | opentelemetry-js-contrib | events | experimental |
@@ -78,7 +78,7 @@ relying on these notes.
 |---|---|
 | `opentelemetry-browser` package versions / status | `gh api repos/open-telemetry/opentelemetry-browser/releases -q '.[].tag_name'` |
 | Latest `@opentelemetry/browser-instrumentation` | `npm view @opentelemetry/browser-instrumentation version` |
-| Latest `@opentelemetry/browser-sdk` (may be unpublished) | `npm view @opentelemetry/browser-sdk version` |
+| Latest `@opentelemetry/browser-sdk` (0.x, published) | `npm view @opentelemetry/browser-sdk version` |
 | Latest `@opentelemetry/sdk-trace-web` | `npm view @opentelemetry/sdk-trace-web version` |
 | Latest `@opentelemetry/auto-instrumentations-web` | `npm view @opentelemetry/auto-instrumentations-web version` |
 | Authoritative browser package map | `WebFetch https://github.com/open-telemetry/opentelemetry-browser#browser-packages` |

--- a/skills/otel-browser/references/setup-sdk.md
+++ b/skills/otel-browser/references/setup-sdk.md
@@ -3,8 +3,8 @@
 Setting up OpenTelemetry in the browser for **traces (spans)** and **events (log records)**. There
 is no MeterProvider story in the browser yet.
 
-> **Stability**: `@opentelemetry/browser-sdk` is experimental and may be unpublished — confirm with
-> `npm view @opentelemetry/browser-sdk version`. The most settled path today wires the providers
+> **Stability**: `@opentelemetry/browser-sdk` is experimental and on the 0.x line (first published as
+> `0.1.0`) — check the current version with `npm view @opentelemetry/browser-sdk version`. The most settled path today wires the providers
 > directly: the **stable** web tracing SDK (`@opentelemetry/sdk-trace-web`, `@opentelemetry/context-zone`)
 > for spans, plus the **experimental** Logs SDK (`@opentelemetry/api-logs`, `@opentelemetry/sdk-logs`,
 > still on the 0.x line) for events. Both approaches are shown below.
@@ -161,7 +161,7 @@ does:
 
 `@opentelemetry/browser-sdk` collapses the boilerplate above into one call. It exports two combined
 initializers — `quickStartBrowserSdk` (simplified) and `startBrowserSdk` (deeper control) — plus
-per-signal entry points. It is experimental and may be unreleased; config options change frequently,
+per-signal entry points. It is experimental (0.x); config options change frequently,
 so re-check the package README (see the Sources of Truth in [SKILL.md](../SKILL.md#sources-of-truth)).
 
 ```javascript


### PR DESCRIPTION
## Summary

- `@opentelemetry/browser-sdk` is now published (`browser-sdk-v0.1.0` tag, `0.1.0` on npm): drop the "may be unpublished/unreleased" wording from the package table, sources-of-truth row, and `references/setup-sdk.md`.

## Verification

Audited the full skill against today's upstream `main` checkouts (opentelemetry-browser, opentelemetry-js v2.9.0, opentelemetry-js-contrib) plus `gh`/npm release data:

- All package names/scopes/stability rows match the browser repo README's current Browser Packages tables.
- browser-instrumentation subpath exports and every documented config option/default match the instrumentation README (v0.5.2).
- browser-sdk public API (`quickStartBrowserSdk`/`startBrowserSdk`, `./logs`/`./traces`/`./session` subpaths, session factory functions) unchanged by the upstream per-export-folder restructure — only internal files moved.
- The `browser-sdk-v0.1.0` tag has no GitHub Release object, so the skill keeps pointing at `npm view` for version lookup; no hardcoded versions added beyond the first-publish fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenTelemetry browser SDK guidance to clarify that it is experimental and currently on the 0.x release line.
  * Added references to its published status, initial version, and checking the latest npm version.
  * Aligned setup instructions with the updated package stability information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->