### PR TITLE
docs(otel-go): refresh against released core/contrib v1.44.0

### DIFF
--- a/skills/otel-go/references/api.md
+++ b/skills/otel-go/references/api.md
@@ -8,7 +8,7 @@ import (
     "go.opentelemetry.io/otel"                    // Global API
     "go.opentelemetry.io/otel/trace"              // Tracing API
     "go.opentelemetry.io/otel/metric"             // Metrics API
-    "go.opentelemetry.io/otel/log"                // Logs API (stable as of v1.34.0)
+    "go.opentelemetry.io/otel/log"                // Logs API (separate v0.x line — see note below)
     "go.opentelemetry.io/otel/log/global"         // Global LoggerProvider
     "go.opentelemetry.io/otel/attribute"          // Attributes
     "go.opentelemetry.io/otel/codes"              // Status codes
@@ -222,7 +222,11 @@ propagator.Inject(ctx, propagation.HeaderCarrier(w.Header()))
 
 ## Logs API
 
-The Logs API became stable in v1.34.0. It provides a bridge for existing logging libraries.
+The Logs API and SDK are versioned on a **separate v0.x line** (currently `otel/log` and
+`otel/sdk/log` v0.20.0, released alongside core v1.44.0) and are **not yet declared stable** —
+interfaces may still change without a major bump. They are production-usable and primarily
+provide a bridge for existing logging libraries. Track their version independently from the
+stable v1.x traces/metrics signals (see the module-versioning table in SKILL.md).
 
 ### Core Types
 ```go
@@ -238,9 +242,8 @@ log.Severity           // Log severity level
 // Get logger (use import path as name)
 logger := global.GetLoggerProvider().Logger("github.com/user/pkg")
 
-// Check if logging is enabled
-var params log.EnabledParameters
-params.SetSeverity(log.SeverityInfo)
+// Check if logging is enabled (EnabledParameters is a plain struct; set fields directly)
+params := log.EnabledParameters{Severity: log.SeverityInfo}
 if logger.Enabled(ctx, params) {
     var rec log.Record
     rec.SetTimestamp(time.Now())

--- a/skills/otel-go/references/breaking-changes.md
+++ b/skills/otel-go/references/breaking-changes.md
@@ -42,7 +42,7 @@ RPC attribute changes:
 
 ## Baggage limits (core v1.44.0)
 
-- The 8192-byte baggage size limit is now enforced during extraction/parsing (`otel/baggage`, `otel/propagation`); malformed/oversized baggage headers are rejected rather than silently accepted.
+- The 8192-byte baggage size limit is now enforced during extraction/parsing (`otel/baggage`, `otel/propagation`): baggage strings over the limit are rejected outright, while malformed members are skipped — valid members are retained and an error is reported.
 
 ## HTTP instrumentation behaviour (contrib v1.44.0)
 

--- a/skills/otel-go/references/breaking-changes.md
+++ b/skills/otel-go/references/breaking-changes.md
@@ -10,6 +10,9 @@ version selection, fetch from the Sources of Truth table in the `otel-go` skill 
 - `go.opentelemetry.io/contrib/config` is deprecated (contrib v1.35.0). Use `go.opentelemetry.io/contrib/otelconf` instead. The API is identical.
 - `WithMetricAttributesFn` deprecated in otelhttp (contrib v1.41.0). Use `Labeler` instead.
 - otelgrpc: prefer stats handlers (`NewServerHandler` / `NewClientHandler`) over deprecated interceptors for new code.
+- `attribute.INVALID` deprecated (core v1.43.0) — an empty value is now valid; use `attribute.EMPTY` instead.
+- `attribute.Value.Emit` deprecated (core v1.44.0). Use `attribute.Value.String` instead.
+- `OTEL_EXPERIMENTAL_CONFIG_FILE` deprecated in `otelconf` (contrib v1.43.0). Use `OTEL_CONFIG_FILE`.
 
 ## Removed APIs (contrib v1.40.0+)
 
@@ -28,6 +31,33 @@ RPC attribute changes:
 ## otelgrpc (contrib v1.42.0)
 
 - No longer emits `rpc.message` span events, `rpc.*.request/response.size` metrics, or `network.*` attributes — even with `WithMessageEvents`.
+
+## Metric SDK cardinality limit (core v1.44.0)
+
+- `sdk/metric` now enforces a **default cardinality limit of 2000** series per instrument. Series past the limit are dropped into an overflow series (`otel.metric.overflow=true`). Breaking change from the previous unlimited default. Restore unlimited with `sdkmetric.WithCardinalityLimit(0)`; the `OTEL_GO_X_CARDINALITY_LIMIT` env var is deprecated. Per-instrument-kind limits: `sdkmetric.WithCardinalityLimitSelector` (v1.43.0).
+
+## OTLP exporter request-size cap (core v1.44.0)
+
+- All OTLP exporters cap requests at **64 MiB** by default (applied before compression); oversized requests become non-retryable errors. Configure with `WithMaxRequestSize`.
+
+## Baggage limits (core v1.44.0)
+
+- The 8192-byte baggage size limit is now enforced during extraction/parsing (`otel/baggage`, `otel/propagation`); malformed/oversized baggage headers are rejected rather than silently accepted.
+
+## HTTP instrumentation behaviour (contrib v1.44.0)
+
+- Unknown or empty HTTP methods now report `_OTHER` instead of `GET` across all HTTP instrumentations (otelhttp, otelmux).
+- The default server span name is now `{method} {route}` (e.g. `GET /foo/{id}`) when a route is available, or `{method}` otherwise — conforming to HTTP semconv.
+
+## Removed / renamed contrib APIs (contrib v1.43.0–v1.44.0)
+
+- otelgrpc removed the deprecated `WithSpanOptions` option (v1.44.0).
+- `otelconf`: experimental config types moved from `otelconf` to the `otelconf/x` subpackage (v1.43.0). The `host` resource detector no longer sets `host.id` (v1.43.0).
+- otelgrpc added `OTEL_SEMCONV_STABILITY_OPT_IN` (values `rpc` default, `rpc/dup`, `rpc/old`) to stage RPC semconv migration (v1.43.0).
+
+## Log bridges attach errors via SetErr (contrib v1.43.0–v1.44.0)
+
+- otelslog, otelzap, otellogrus, and otellogr now record fields implementing `error` (e.g. `zap.Error`, `slog` error values) via `log.Record.SetErr` instead of emitting them as plain or `exception.*` attributes. The SDK then derives the `exception.*` attributes from the record error.
 
 ## Behavioural Notes
 

--- a/skills/otel-go/references/declarative-setup.md
+++ b/skills/otel-go/references/declarative-setup.md
@@ -48,7 +48,7 @@ import (
     "go.opentelemetry.io/otel"
     "go.opentelemetry.io/otel/log/global"
     "go.opentelemetry.io/otel/propagation"
-    semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+    semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
     otelconf "go.opentelemetry.io/contrib/otelconf"
 )
 ```

--- a/skills/otel-go/references/instrumentation-libraries.md
+++ b/skills/otel-go/references/instrumentation-libraries.md
@@ -277,12 +277,13 @@ func (c *CustomClient) CallExternalAPI(ctx context.Context, endpoint string) err
 
 ```go
 func (r *Repository) CreateUser(ctx context.Context, userData *UserData) (*User, error) {
+    // semconv helpers below track go.opentelemetry.io/otel/semconv/v1.41.0
     ctx, span := r.tracer.Start(ctx, "INSERT users",
         trace.WithAttributes(
-            semconv.DBSystem("postgresql"),
+            semconv.DBSystemNamePostgreSQL,        // db.system.name (was DBSystem/db.system)
             semconv.DBNamespace(r.dbName),
-            semconv.DBOperation("INSERT"),
-            semconv.DBSQLTable("users")))
+            semconv.DBOperationName("INSERT"),      // db.operation.name (was DBOperation)
+            semconv.DBCollectionName("users")))     // db.collection.name (was DBSQLTable/db.sql.table)
     defer span.End()
 
     query := `INSERT INTO users (email, name, tier) VALUES ($1, $2, $3) RETURNING id, created_at`
@@ -322,8 +323,8 @@ func (p *Publisher) PublishOrderEvent(ctx context.Context, order *Order) error {
     ctx, span := p.tracer.Start(ctx, "send queue.orders",
         trace.WithSpanKind(trace.SpanKindProducer),
         trace.WithAttributes(
-            semconv.MessagingSystem("nats"),
-            semconv.MessagingOperationTypePublish,
+            semconv.MessagingSystemKey.String("nats"), // messaging.system (no NATS enum const)
+            semconv.MessagingOperationTypeSend,        // was MessagingOperationTypePublish
             semconv.MessagingDestinationName("orders"),
             attribute.String("order.id", order.ID)))
     defer span.End()
@@ -346,7 +347,7 @@ func (c *Consumer) HandleOrderEvent(ctx context.Context, msg []byte) error {
     ctx, span := c.tracer.Start(ctx, "consume queue.orders",
         trace.WithSpanKind(trace.SpanKindConsumer),
         trace.WithAttributes(
-            semconv.MessagingSystem("nats"),
+            semconv.MessagingSystemKey.String("nats"), // messaging.system (no NATS enum const)
             semconv.MessagingOperationTypeReceive,
             semconv.MessagingDestinationName("orders")))
     defer span.End()

--- a/skills/otel-go/references/performance.md
+++ b/skills/otel-go/references/performance.md
@@ -209,8 +209,9 @@ Metric attribute cardinality is the product of unique values across all recorded
 > **Default cardinality limit (v1.44.0+):** `sdk/metric` now enforces a default cardinality
 > limit of **2000** series per instrument (spec-compliant). Series beyond the limit are dropped
 > and aggregated into an overflow series marked `attribute.Bool("otel.metric.overflow", true)`.
-> This is a breaking change from the previous unlimited default. Override per reader with
-> `sdkmetric.WithCardinalityLimit(n)` (use `0` for unlimited), or per instrument kind with
+> This is a breaking change from the previous unlimited default. Override globally with the
+> MeterProvider option `sdkmetric.WithCardinalityLimit(n)` (zero or negative disables the
+> limit), or per instrument kind with the reader option
 > `sdkmetric.WithCardinalityLimitSelector` (v1.43.0+). Views remain the correct tool for
 > *shaping* cardinality; the limit is a backstop.
 
@@ -329,8 +330,8 @@ Retries honor `Retry-After` headers from the backend.
 
 All OTLP exporters (trace/metric/log, gRPC and HTTP) cap the request payload at **64 MiB** by
 default. The limit is applied *before* compression; oversized requests are treated as
-non-retryable errors and dropped. Tune with `WithMaxRequestSize(bytes)` on the exporter (`0`
-keeps the default).
+non-retryable errors and dropped. Tune with `WithMaxRequestSize(bytes)` on the exporter —
+zero or negative disables the limit entirely (not recommended).
 
 ### Timeout Tuning
 

--- a/skills/otel-go/references/performance.md
+++ b/skills/otel-go/references/performance.md
@@ -16,10 +16,10 @@ Performance tuning reference for OpenTelemetry Go SDK. Covers sampling, batch pr
 
 | Parameter | Default | Environment Variable |
 |-----------|---------|---------------------|
-| Batch span queue size | 2048 | -- |
-| Batch span export size | 512 | `OTEL_TRACES_EXPORTER_MAX_EXPORT_BATCH_SIZE` |
-| Batch schedule delay | 5s | `OTEL_TRACES_EXPORTER_BATCH_SCHEDULE_DELAY` |
-| Batch export timeout | 30s | `OTEL_TRACES_EXPORTER_TIMEOUT` |
+| Batch span queue size | 2048 | `OTEL_BSP_MAX_QUEUE_SIZE` |
+| Batch span export size | 512 | `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` |
+| Batch schedule delay | 5s | `OTEL_BSP_SCHEDULE_DELAY` |
+| Batch export timeout | 30s | `OTEL_BSP_EXPORT_TIMEOUT` |
 | Span attribute limit | 128 | `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` |
 | Span event limit | 128 | `OTEL_SPAN_EVENT_COUNT_LIMIT` |
 | Span link limit | 128 | `OTEL_SPAN_LINK_COUNT_LIMIT` |
@@ -206,6 +206,14 @@ mp := sdkmetric.NewMeterProvider(
 
 Metric attribute cardinality is the product of unique values across all recorded attributes. Attributes like user IDs or request IDs are unbounded and produce one time series per unique value. Attributes like HTTP method (~10 values) or status code (~50 values) are bounded.
 
+> **Default cardinality limit (v1.44.0+):** `sdk/metric` now enforces a default cardinality
+> limit of **2000** series per instrument (spec-compliant). Series beyond the limit are dropped
+> and aggregated into an overflow series marked `attribute.Bool("otel.metric.overflow", true)`.
+> This is a breaking change from the previous unlimited default. Override per reader with
+> `sdkmetric.WithCardinalityLimit(n)` (use `0` for unlimited), or per instrument kind with
+> `sdkmetric.WithCardinalityLimitSelector` (v1.43.0+). Views remain the correct tool for
+> *shaping* cardinality; the limit is a backstop.
+
 ---
 
 ## Attribute Allocation Patterns
@@ -316,6 +324,13 @@ The OTLP exporters use exponential backoff with jitter:
 | Max elapsed time | 1min |
 
 Retries honor `Retry-After` headers from the backend.
+
+### Request Size Cap (v1.44.0+)
+
+All OTLP exporters (trace/metric/log, gRPC and HTTP) cap the request payload at **64 MiB** by
+default. The limit is applied *before* compression; oversized requests are treated as
+non-retryable errors and dropped. Tune with `WithMaxRequestSize(bytes)` on the exporter (`0`
+keeps the default).
 
 ### Timeout Tuning
 


### PR DESCRIPTION
## Summary

Refresh of the `otel-go` skill against today's upstream checkouts (opentelemetry-go and opentelemetry-go-contrib at v1.44.0, both fast-forwarded to upstream main).

- **Logs API stability corrected**: the skill claimed "stable as of v1.34.0"; `otel/log` / `otel/sdk/log` are still independently versioned on v0.x (v0.20.0, per `log/doc.go`).
- **Compile fix**: `log.EnabledParameters` has exported fields, no `SetSeverity` method — example now uses a struct literal.
- **Env var fix**: batch processor vars are `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` / `OTEL_BSP_SCHEDULE_DELAY` / `OTEL_BSP_EXPORT_TIMEOUT` / `OTEL_BSP_MAX_QUEUE_SIZE` (the skill listed nonexistent `OTEL_TRACES_EXPORTER_*` names).
- **New v1.44.0 behavior documented**: default metric cardinality limit of 2000 (verified in `sdk/metric/config.go`) and the 64 MiB OTLP request-size cap.
- **Breaking-changes reference extended** from its previous ceiling (v1.42) through released core/contrib v1.43–v1.44.
- **Semconv helper drift fixed** in examples against released `semconv/v1.41.0` (`DBSystemNamePostgreSQL`, `DBOperationName`, `DBCollectionName`, `MessagingOperationTypeSend`); example import bumped v1.40.0 → v1.41.0.

## Policy notes

- Examples pin to the newest **released** semconv (v1.41.0); v1.42.0 exists only in `[Unreleased]` on main.
- Unreleased contrib breaking changes intentionally excluded.
- opentelemetry-go-instrumentation (eBPF) left out — adding it would be new scope, not a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Go OpenTelemetry Logs API guidance to reflect its separate unstable v0.x release line.
  - Revised logging examples and semantic convention examples to use current APIs.
  - Added breaking-change notes for recent core and contrib releases.
  - Documented metric cardinality limits, OTLP request-size caps, and updated batch processor configuration variables.
  - Updated declarative setup guidance to the latest semantic conventions version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->