### PR TITLE
docs(otel-js): fix broken sdk-node CHANGELOG link

### DIFF
--- a/skills/otel-js/SKILL.md
+++ b/skills/otel-js/SKILL.md
@@ -25,7 +25,7 @@ For Node.js-specific facts:
 | Latest `@opentelemetry/sdk-node` | `npm view @opentelemetry/sdk-node version` |
 | Latest `@opentelemetry/auto-instrumentations-node` | `npm view @opentelemetry/auto-instrumentations-node version` |
 | Package status / breaking changes | `WebFetch https://www.npmjs.com/package/@opentelemetry/configuration` |
-| `sdk-node` CHANGELOG | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/opentelemetry-sdk-node/CHANGELOG.md` |
+| `sdk-node` CHANGELOG (experimental packages) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/CHANGELOG.md` |
 | Node.js getting-started docs | `WebFetch https://opentelemetry.io/docs/languages/js/getting-started/nodejs/` |
 
 ## Cross-References

--- a/skills/otel-js/references/declarative-setup.md
+++ b/skills/otel-js/references/declarative-setup.md
@@ -21,7 +21,7 @@ skill. For JS-specific facts:
 | Package status / breaking changes | `WebFetch https://www.npmjs.com/package/@opentelemetry/configuration` |
 | File config parser for current source (`file_format` acceptance) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/configuration/src/FileConfigFactory.ts` |
 | File config fixtures for current source | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/configuration/test/fixtures/sdk-config.yaml` |
-| `sdk-node` CHANGELOG | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/opentelemetry-sdk-node/CHANGELOG.md` |
+| `sdk-node` CHANGELOG (experimental packages) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/CHANGELOG.md` |
 | Node.js getting-started docs | `WebFetch https://opentelemetry.io/docs/languages/js/getting-started/nodejs/` |
 
 ## Activation


### PR DESCRIPTION
## Summary

- Fix a 404 link in `SKILL.md` and `references/declarative-setup.md`: `experimental/packages/opentelemetry-sdk-node/CHANGELOG.md` never existed — sdk-node is experimental and its entries live in the aggregate `experimental/CHANGELOG.md` (confirmed to carry the sdk-node entries).

## Verification

Full audit against today's upstream checkouts (opentelemetry-js v2.9.0, js-contrib main) found no other drift — the skill routes versions through `npm view` by design:

- `@opentelemetry/configuration` (0.220.0) still experimental; `createConfigFactory()` and `FileConfigFactory.ts` paths still valid.
- v2.0 Resource migration guidance (`resourceFromAttributes()` etc.) still accurate.
- Node engines statement consistent with upstream `^18.19.0 || >=20.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenTelemetry JavaScript SDK changelog references to point to the current consolidated changelog location.
  * Applied the corrected link in both relevant documentation sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->