### PR TITLE
docs(otel-ottl): refresh for collector-contrib v0.156.0

### DIFF
--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -7,7 +7,7 @@ description: OpenTelemetry Transformation Language (OTTL) expert for writing and
 
 OTTL is a domain-specific language for transforming telemetry inside the OpenTelemetry Collector. It is consumed by the `transform`, `filter`, `routing`, and `tail_sampling` processors (and a few others) in [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl).
 
-This skill targets `pkg/ottl` as of collector-contrib **v0.155.0**. Function and path availability differs across Collector releases; check the upstream `pkg/ottl/ottlfuncs/README.md` and `pkg/ottl/contexts/*/README.md` for the exact set in older or newer releases.
+This skill targets `pkg/ottl` as of collector-contrib **v0.156.0**. Function and path availability differs across Collector releases; check the upstream `pkg/ottl/ottlfuncs/README.md` and `pkg/ottl/contexts/*/README.md` for the exact set in older or newer releases.
 
 ## Statement syntax
 
@@ -24,7 +24,7 @@ set(span.attributes["env"], "prod") where resource.attributes["env"] == nil
 ## Workflow
 
 1. **Pick the processor.** `transform` rewrites; `filter` drops; `routing` fans out by pipeline; `tail_sampling` keeps/drops traces. The processor decides which contexts and function set are usable.
-2. **Pick the context.** `resource`, `scope`, `span`, `spanevent`, `metric`, `datapoint`, `log`, `profile`, `profilesample`. Operate at the lowest level that gives you the data — using `datapoint` to set attributes is much cheaper than walking through `metric.data_points` from the metric context.
+2. **Pick the context.** `resource`, `scope`, `span`, `spanevent`, `metric`, `datapoint`, `exemplar`, `log`, `profile`, `profilesample`. Operate at the lowest level that gives you the data — using `datapoint` to set attributes is much cheaper than walking through `metric.data_points` from the metric context.
 3. **Write statements.** Reach for `references/quick-reference.md` for common recipes; `references/contexts.md` for paths/enums; `references/functions.md` for the editor and converter catalog.
 4. **Set `error_mode`.** `ignore` (default) keeps the pipeline running and logs errors; `silent` does the same but quietly; `propagate` aborts on first failure (use only when you want a bad config to fail loud in tests).
 5. **Verify.** OTTL gotchas are the kind that pass the eye test (see [Common gotchas](#common-gotchas)). Use the [telemetrygen verification recipe](../telemetrygen/SKILL.md#verifying-a-collector-config) — `otelcol-contrib` + file exporter + telemetrygen — to confirm the snippet does what the prose claims before shipping.
@@ -41,6 +41,7 @@ OTTL paths are scoped by signal. Higher levels are reachable from lower ones (e.
 | Span Event | `spanevent.name`, `spanevent.attributes["…"]`, `spanevent.event_index` |
 | Metric | `metric.name`, `metric.unit`, `metric.type`, `metric.aggregation_temporality` |
 | DataPoint | `datapoint.value_double`, `datapoint.value_int`, `datapoint.attributes["…"]` |
+| Exemplar | `exemplar.double_value`, `exemplar.int_value`, `exemplar.filtered_attributes["…"]` (transform `metric_statements` only, v0.156+) |
 | Log | `log.body`, `log.body.string`, `log.severity_number`, `log.attributes["…"]` |
 | Profile | `profile.profile_id`, `profile.attributes["…"]` (Development) |
 
@@ -225,6 +226,7 @@ Recently added (still useful to know which release introduced them when supporti
 
 | Feature | Since |
 |---------|-------|
+| Exemplar context (transform `metric_statements` only) | v0.156 |
 | Profile / ProfileSample contexts | v0.124 / v0.132 (Development) |
 | Cache paths require context prefix; `spanevent` rename | v0.120 (breaking) |
 | `delete_index` editor | v0.145 |

--- a/skills/otel-ottl/references/contexts.md
+++ b/skills/otel-ottl/references/contexts.md
@@ -1,6 +1,6 @@
 # OTTL Contexts Reference
 
-Context paths and enums for collector-contrib **v0.155.0**. Higher-level contexts are reachable from lower ones (a span statement can read `resource.attributes`); the reverse is not true. Always pick the most specific context for the work — using `datapoint` to set metric-point attributes is much cheaper than walking through `metric.data_points` from the metric context.
+Context paths and enums for collector-contrib **v0.156.0**. Higher-level contexts are reachable from lower ones (a span statement can read `resource.attributes`); the reverse is not true. Always pick the most specific context for the work — using `datapoint` to set metric-point attributes is much cheaper than walking through `metric.data_points` from the metric context.
 
 ## Context hierarchy
 
@@ -8,7 +8,7 @@ Context paths and enums for collector-contrib **v0.155.0**. Higher-level context
 Resource
   └── Scope (instrumentation library)
       ├── Span → Span Event
-      ├── Metric → DataPoint
+      ├── Metric → DataPoint → Exemplar
       ├── Log
       └── Profile → Profile Sample
 ```
@@ -194,6 +194,28 @@ set(datapoint.attributes["value_range"], "high")
 # Rename an attribute
 set(datapoint.attributes["host.name"], datapoint.attributes["hostname"])
 delete_key(datapoint.attributes, "hostname")
+```
+
+## Exemplar context (v0.156+)
+
+Individual metric exemplars. Available only in the `transform` processor's `metric_statements` (the `filter` processor does not expose it). Reachable up through `datapoint.*`, `metric.*`, `scope`, and `resource`.
+
+```ottl
+exemplar.time_unix_nano
+exemplar.time                        # time.Time
+exemplar.double_value
+exemplar.int_value
+exemplar.trace_id / exemplar.trace_id.string
+exemplar.span_id  / exemplar.span_id.string
+exemplar.filtered_attributes         # map
+exemplar.filtered_attributes["key"]
+exemplar.cache["key"]
+# datapoint.*, metric.*, scope, resource paths are reachable.
+```
+
+```ottl
+# Redact a filtered attribute carried on exemplars
+delete_matching_keys(exemplar.filtered_attributes, "(?i).*(token|secret).*")
 ```
 
 ## Log context (Beta)

--- a/skills/otel-ottl/references/functions.md
+++ b/skills/otel-ottl/references/functions.md
@@ -1,6 +1,6 @@
 # OTTL Functions Catalog
 
-Editor and converter reference for collector-contrib **v0.155.0**. Editors mutate telemetry; converters return values for use in expressions. See the upstream `pkg/ottl/ottlfuncs/README.md` for the authoritative source.
+Editor and converter reference for collector-contrib **v0.156.0**. Editors mutate telemetry; converters return values for use in expressions. See the upstream `pkg/ottl/ottlfuncs/README.md` for the authoritative source.
 
 ## Editors (data manipulation)
 


### PR DESCRIPTION
## Summary

The skill last targeted collector-contrib v0.155.0 (2026-07-03 refresh); v0.156.0 released 2026-07-07. The only user-facing OTTL change in that release is the new **exemplar context**:

- `SKILL.md`: version bump, `exemplar` added to the workflow context list, an Exemplar row in the contexts-at-a-glance table (transform `metric_statements` only), and a versioning-notes entry.
- `references/contexts.md`: version bump, `DataPoint → Exemplar` in the hierarchy, and a full exemplar-context section (paths, transform-only availability, reachable `datapoint.*`/`metric.*`).
- `references/functions.md`: version bump only — upstream `pkg/ottl/ottlfuncs/README.md` is byte-identical between v0.155.0 and v0.156.0 (verified with `git diff --quiet`).

## Verified unchanged

All other context paths/enums, processor wiring (transform/filter/routing/tail_sampling), error-mode defaults, and gotchas. Filter processor confirmed to NOT support the exemplar context (transform-only), reflected in the edits.

## Deliberately excluded

- Lambda converters (`Any`, `All`, `MapEach`, `When`, `Filter`) — merged upstream but unreleased; add when v0.157.0 ships.
- `ottlotelcol` context — pre-existing coverage gap, not drift; would be a scope expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OTTL guidance and references to collector-contrib v0.156.0.
  * Added documentation for the new Exemplar context, including supported fields and usage examples.
  * Updated context hierarchy information to show Exemplar support under Metric data points.
  * Added Exemplar to the list of available OTTL contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->