### PR TITLE
docs(otel-weaver): refresh for weaver 0.24.2

### DIFF
--- a/skills/otel-weaver/SKILL.md
+++ b/skills/otel-weaver/SKILL.md
@@ -21,7 +21,7 @@ If a companion skill is unavailable:
 
 Three moving parts:
 
-1. **Registry** — directory of YAML files. `manifest.yaml` is required and names the registry, declares `semconv_version` and `schema_url`. The rest declare `attributes`, `metrics`, `spans`, `events`, `entities`. The local registry's `semconv_version` is yours to manage; bump it on changes.
+1. **Registry** — directory of YAML files. `manifest.yaml` is required; its `schema_url` (OTel schema URL format, `http[s]://host/path/<version>`) both names the registry and carries its version in the final path segment. The rest declare `attributes`, `metrics`, `spans`, `events`, `entities`. The version segment of `schema_url` is yours to manage; bump it on changes. (`semconv_version` and `schema_base_url` are deprecated in favor of `schema_url`.)
 2. **Templates** — directory of Jinja2 files plus a `weaver.yaml` per target language describing which templates to run, with what filter, in what `application_mode`, and with what output filename.
 3. **Policies** — Rego rules. Built-in OTel policies are the floor; custom policies layer on org rules.
 
@@ -34,7 +34,7 @@ These three replace a hand-rolled `const.go` (or equivalent): const blocks becom
 - Every entry needs `stability`. Weaver refuses to generate without it.
 - Use a domain prefix (e.g. `ecommerce.`, `acme.`) for org-local attributes, metrics, and spans.
 - Run the language formatter (`gofmt -w`, `prettier`, `ruff format`, ...) on generated output. Jinja whitespace produces multiple blank lines; without formatting, the diff check in CI will fail spuriously.
-- Confirm the resolved schema shape before writing a template. Run `weaver registry resolve -r <reg> -f json -o /tmp/r.json` and inspect — input `key`/`name`/`type` fields are renamed at resolve time (see `references/template-authoring.md`).
+- Confirm the resolved schema shape before writing a template. Input `key`/`name`/`type` fields are renamed by the jq helpers that feed the template `ctx` (see `references/template-authoring.md` for how to dump the exact shape).
 
 ## Workflow
 
@@ -52,12 +52,8 @@ These cost time and are not obvious from the upstream docs:
 2. Generated output is not formatter-clean. Always run the language formatter after `weaver registry generate`.
 3. Resolved field names differ from input. Attribute input `key` → resolved `name`. Metric input `name` → resolved `metric_name`. Span input `type` → resolved `id` of the form `span.<type>`, with a flat `name` string equal to the input `name.note`. Always resolve and inspect before writing a template.
 4. The `comment` Jinja filter takes a keyword argument: `attr.brief | comment(format="go")`. It already emits the `// ` prefix; do not add another.
-5. There is no prebuilt jq filter for spans. Use:
-   ```
-   semconv_signal("span"; {}) | group_by(.root_namespace) | map({root_namespace: .[0].root_namespace, spans: . | sort_by(.id)})
-   ```
-   It **must be single-quoted** in `weaver.yaml`; the colons in jq syntax collide with YAML mapping rules otherwise.
-6. `weaver registry check` emits "File format `definition/2` is not yet stable" on every run as of 0.22.1. This is normal; do not treat it as a failure.
+5. Spans, events, and entities have prebuilt grouped jq filters — `semconv_grouped_spans`, `semconv_grouped_events`, `semconv_grouped_entities` — alongside `semconv_grouped_attributes` and `semconv_grouped_metrics`. Use `semconv_grouped_spans` (a bareword, like the others). Only a raw multi-clause jq expression needs single-quoting in `weaver.yaml`, because the colons collide with YAML mapping rules.
+6. `weaver registry check` emits "File format `definition/2` is not yet stable" (a warning) on every run as of 0.24.2. This is normal; do not treat it as a failure.
 7. `--future` is opt-in but breaks today on `definition/2`. Note this in CI guidance and re-enable once the format goes stable.
 8. CLI argument ordering for `generate`: target directory name is positional **after** `--registry` and `--templates`; the output directory follows. `--templates` points at the **parent** that contains target dirs, not at the language-specific subdir.
 9. Span name in registry vs. runtime: required schema fields are `type`, `kind` (`client`/`server`/`producer`/`consumer`/`internal`), `brief`, `stability`, and a structured `name: { note: "..." }`. For internal business spans, putting the dotted type identifier in `name.note` and using the resolved `span.name` string at runtime is clean.
@@ -97,13 +93,13 @@ Report the final check with:
 - `[ ]` unresolved
 
 Use these items:
-- registry has `manifest.yaml` with `name`, `semconv_version`, `schema_url`
+- registry has `manifest.yaml` with a `schema_url` whose final path segment is the version
 - every entry has `stability`
 - org-local attributes/metrics/spans use a domain prefix
 - no boundary-domain (http/db/messaging/rpc/network/gen-ai) entries duplicated locally
 - counter names have no `.total` suffix
 - duration histograms use `s` (seconds)
-- templates use jq filters that match the resolved schema, with the spans filter single-quoted
+- templates use jq filters that match the resolved schema (prefer the prebuilt `semconv_grouped_*` helpers; single-quote only raw jq expressions)
 - generated output is formatter-clean
 - CI runs `check`, `generate` + `git diff --exit-code`, and `diff` against the base branch
 - changed files were re-read

--- a/skills/otel-weaver/references/ci-integration.md
+++ b/skills/otel-weaver/references/ci-integration.md
@@ -30,7 +30,7 @@ jobs:
         run: |
           docker run --rm \
             -v "$WORKSPACE:/work" \
-            otel/weaver:v0.22.1 \
+            otel/weaver:v0.24.2 \
             registry check \
               --registry /work/telemetry/registry/
 
@@ -40,7 +40,7 @@ jobs:
         run: |
           docker run --rm \
             -v "$WORKSPACE:/work" \
-            otel/weaver:v0.22.1 \
+            otel/weaver:v0.24.2 \
             registry generate \
               --registry /work/telemetry/registry/ \
               --templates /work/telemetry/templates/ \
@@ -60,7 +60,7 @@ jobs:
           docker run --rm \
             -v "$WORKSPACE:/work" \
             -v /tmp/base:/baseline \
-            otel/weaver:v0.22.1 \
+            otel/weaver:v0.24.2 \
             registry diff \
               --baseline-registry /baseline/telemetry/registry/ \
               --registry /work/telemetry/registry/ \
@@ -69,19 +69,19 @@ jobs:
 
 ## Notes
 
-- **Pin the Weaver version.** `otel/weaver:v0.22.1` (or the version your registry was authored against). Don't use `latest` — schema validation behavior changes between versions.
+- **Pin the Weaver version.** `otel/weaver:v0.24.2` (or the version your registry was authored against). Don't use `latest` — schema validation behavior changes between versions.
 - **Format before diffing.** Without `gofmt -w` (or your language's formatter), Jinja whitespace produces multi-blank-line diffs that fail the `git diff --exit-code` gate spuriously.
-- **`--future` is opt-in but breaks today.** It enables upcoming validation rules — useful for catching tightening rules early — but at 0.22.1 it errors on `definition/2` itself. Re-enable once the format goes stable.
+- **`--future` is opt-in but breaks today.** It enables upcoming validation rules — useful for catching tightening rules early — but as of 0.24.2 it errors on `definition/2` itself. Re-enable once the format goes stable.
 - **Expected stderr noise.** `weaver registry check` emits `File format definition/2 is not yet stable`. Do not treat it as a failure.
 - **The diff job is informational.** It produces markdown breaking-change output; failing the build on it is too aggressive while a registry is young. Promote to a hard gate once the registry stabilizes.
 
 ## Local equivalent
 
 ```bash
-docker run --rm -v "$PWD:/work" otel/weaver:v0.22.1 \
+docker run --rm -v "$PWD:/work" otel/weaver:v0.24.2 \
   registry check --registry /work/telemetry/registry/
 
-docker run --rm -v "$PWD:/work" otel/weaver:v0.22.1 \
+docker run --rm -v "$PWD:/work" otel/weaver:v0.24.2 \
   registry generate \
     --registry /work/telemetry/registry/ \
     --templates /work/telemetry/templates/ \

--- a/skills/otel-weaver/references/registry-authoring.md
+++ b/skills/otel-weaver/references/registry-authoring.md
@@ -20,13 +20,12 @@ Files other than `manifest.yaml` are discovered by their `file_format: definitio
 Minimal example:
 
 ```yaml
-name: ecommerce
+schema_url: https://example.com/schemas/ecommerce/0.1.0
 description: "Telemetry conventions for the ecommerce monolith"
-semconv_version: 0.1.0
-schema_url: https://example.com/schemas/ecommerce
+stability: development
 ```
 
-`semconv_version` is yours to manage — bump it on any schema change. `schema_url` is what consumers see; pick a stable URL even if it does not yet resolve.
+`schema_url` is required and must follow the OTel schema URL format `http[s]://host/path/<version>`. The registry name is derived from the path (`example.com/schemas/ecommerce`) and the version from the final segment (`0.1.0`) — bump that segment on any schema change. Pick a stable URL even if it does not yet resolve. `description`, `stability`, and `dependencies` are optional. (The older `name` and `semconv_version`/`schema_base_url` fields are deprecated in favor of `schema_url`.)
 
 ## Attributes
 
@@ -42,7 +41,6 @@ attributes:
 
   - key: ecommerce.payment.method
     type:
-      allow_custom_values: true
       members:
         - id: credit_card
           value: credit_card
@@ -59,7 +57,7 @@ attributes:
 Notes:
 - Required fields: `key`, `type`, `stability`, `brief`.
 - Primitive `type` values: `string`, `int`, `double`, `boolean`, plus their `[]` array variants.
-- Enum types use the `members` form. Set `allow_custom_values: false` to refuse anything outside the listed `id`s.
+- Enum types use the `members` form. Semantic-convention enums are open by definition — values outside the listed `id`s are allowed (the removed `allow_custom_values` flag no longer applies). The member `value` type (`string`/`int`/`boolean`) determines the attribute type.
 - Provide `examples` for non-enum strings; it improves generated docs and helps reviewers.
 
 ## Metrics
@@ -143,4 +141,4 @@ Fast feedback loop:
 weaver registry check -r ./telemetry/registry/
 ```
 
-Expected stderr noise: `File format definition/2 is not yet stable`. This is normal as of 0.22.1.
+Expected stderr noise: `File format definition/2 is not yet stable` (a warning). This is normal as of 0.24.2.

--- a/skills/otel-weaver/references/template-authoring.md
+++ b/skills/otel-weaver/references/template-authoring.md
@@ -1,21 +1,33 @@
 # Template Authoring
 
-Templates render the **resolved** registry, not the input YAML. Resolved field names differ — always confirm the shape before writing a template:
+Templates render the output of the `weaver.yaml` jq `filter`, not the input YAML. Field names differ — always confirm the shape before writing a template. The most reliable way to see the exact `ctx` a template receives is to render it through the real filter with a throwaway template:
 
 ```
-weaver registry resolve -r ./telemetry/registry/ -f json -o /tmp/r.json
-jq '.' /tmp/r.json | less
+# templates/registry/dbg/weaver.yaml
+#   templates:
+#     - template: dump.j2
+#       filter: semconv_grouped_spans   # or semconv_grouped_attributes, etc.
+#       application_mode: single
+#       file_name: dump.json
+# templates/registry/dbg/dump.j2 contains only: {{ ctx | tojson }}
+weaver registry generate --registry ./telemetry/registry/ --templates ./telemetry/templates/ dbg /tmp/out
+jq '.' /tmp/out/dump.json | less
 ```
+
+(`weaver registry resolve` still works for a raw dump but is deprecated — and it errors under `--future` — and its raw shape differs from the filtered `ctx` above.)
 
 ## Resolved-shape cheat sheet
 
-| Input field            | Resolved field                                        |
+Field names as they appear in the template `ctx` after the `semconv_grouped_*` filters:
+
+| Input field            | In `ctx`                                              |
 |------------------------|-------------------------------------------------------|
 | attribute `key`        | `name`                                                |
 | metric `name`          | `metric_name`                                         |
 | span `type`            | `id` of the form `span.<type>`, plus flat `name` (= input `name.note`) |
+| span `kind`            | `span_kind`                                           |
 
-Other resolved fields are mostly verbatim (`brief`, `stability`, `unit`, `instrument`, `kind`, `attributes`, ...).
+The `semconv_grouped_*` helpers wrap each signal list in `[{ root_namespace, <attributes|metrics|spans|events|entities> }]`. Other fields are mostly verbatim (`brief`, `stability`, `unit`, `instrument`, `attributes`, ...).
 
 ## Layout
 
@@ -62,15 +74,15 @@ templates:
     file_name: "metrics_gen.go"
 
   - template: spans.go.j2
-    filter: 'semconv_signal("span"; {}) | group_by(.root_namespace) | map({root_namespace: .[0].root_namespace, spans: . | sort_by(.id)})'
+    filter: semconv_grouped_spans
     application_mode: single
     file_name: "spans_gen.go"
 ```
 
 Notes:
 - `application_mode: single` renders the template once with the filter result bound to `ctx`.
-- Bundled jq filters (`semconv_grouped_attributes`, `semconv_grouped_metrics`, `semconv_signal`, ...) live in [`defaults/jq/semconv.jq`](https://github.com/open-telemetry/weaver/blob/main/defaults/jq/semconv.jq) in the Weaver repo.
-- **The spans filter must be single-quoted.** Colons in jq syntax collide with YAML mapping rules; an unquoted form fails with `mapping values are not allowed in this context`.
+- Bundled jq filters live in [`defaults/jq/semconv.jq`](https://github.com/open-telemetry/weaver/blob/main/defaults/jq/semconv.jq) in the Weaver repo. Each signal has a grouped helper: `semconv_grouped_attributes`, `semconv_grouped_metrics`, `semconv_grouped_spans`, `semconv_grouped_events`, `semconv_grouped_entities` (all barewords).
+- **Single-quote only raw jq expressions.** The `semconv_grouped_*` helpers are barewords and need no quoting. If you write a custom multi-clause jq expression, single-quote it — colons in jq syntax otherwise collide with YAML mapping rules (`mapping values are not allowed in this context`).
 - `acronyms` shapes how `pascal_case_const` and similar filters split words.
 - `comment_formats` lets `comment(format="go")` know what comment prefix to emit.
 
@@ -168,4 +180,4 @@ Equivalents: `prettier -w`, `ruff format`, `rustfmt`, etc.
 
 ## Inspecting the resolved schema
 
-`scripts/inspect-resolved.sh` wraps `weaver registry resolve` and pretty-prints with `jq`. Useful when a template field is missing or named differently than expected.
+`scripts/inspect-resolved.sh` wraps `weaver registry resolve` and pretty-prints with `jq`. Useful for a quick raw dump, but note `resolve` is deprecated and its raw shape is pre-filter — to see the exact fields a template gets, dump `{{ ctx | tojson }}` through the real `semconv_grouped_*` filter as shown at the top of this file.

--- a/skills/otel-weaver/scripts/inspect-resolved.sh
+++ b/skills/otel-weaver/scripts/inspect-resolved.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 # Resolve a Weaver registry to JSON and pretty-print a slice with jq.
 #
-# Use this before writing or debugging a template — resolved field names
-# differ from input field names (key→name, name→metric_name, type→id).
+# Use this for a quick raw dump of the resolved schema. Note: `weaver registry
+# resolve` is deprecated (still works; errors under --future), and its raw shape
+# is PRE-filter — it differs from the `ctx` a template receives via the
+# semconv_grouped_* jq helpers. To see the exact template fields, render
+# {{ ctx | tojson }} through the real filter (see references/template-authoring.md).
 #
 # Usage:
 #   inspect-resolved.sh <registry-dir> [jq-filter]


### PR DESCRIPTION
## Summary

First real refresh of this skill (it had only seen a layout refactor), catching drift across weaver 0.22–0.24:

- **Manifest schema**: `name`/`semconv_version` no longer declared — both derive from `schema_url` (version = final path segment); `semconv_version`/`schema_base_url` deprecated. Example rewritten with `stability`.
- **Enums**: `allow_custom_values` was removed upstream (semconv enums are open by definition) — dropped from example and note.
- **jq filters**: `semconv_grouped_spans`/`_events`/`_entities` now exist, so the "no prebuilt filter for spans" gotcha was false; spans template example now uses `semconv_grouped_spans`.
- **Inspection**: `weaver registry resolve` is deprecated and its raw output differs from the template `ctx` shape — guidance now recommends `{{ ctx | tojson }}` through the real filter; `inspect-resolved.sh` header notes the deprecation.
- **Version pins**: `otel/weaver:v0.22.1` → `v0.24.2` everywhere (latest release, 2026-06-23).

## Verification

Every claim checked against the upstream checkout at main and empirically against a live `weaver` binary resolving a sample registry (binary was 0.23.0; each conclusion cross-checked against 0.24.2 source). Docker/action install paths, resolved-shape cheat sheet, `--future` behavior, and v2 field forms verified unchanged.

## Deliberately excluded

Additive features (`weaver serve`, `registry infer`/`package`/`mcp`, live-check `--fail-on`, `.weaver.toml`) — explicitly out of scope per the skill; refresh is currency-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK