### PR TITLE
docs(otel-dotnet): use db.system.name in manual DB example

### DIFF
--- a/skills/otel-dotnet/references/instrumentation-libraries.md
+++ b/skills/otel-dotnet/references/instrumentation-libraries.md
@@ -220,7 +220,7 @@ Semconv reference: `otel-semantic-conventions` → HTTP client spans.
 
 ```csharp
 using var activity = ActivitySource.StartActivity("SELECT users", ActivityKind.Client);
-activity?.SetTag("db.system", "postgresql");
+activity?.SetTag("db.system.name", "postgresql");
 activity?.SetTag("db.namespace", databaseName);
 activity?.SetTag("db.operation.name", "SELECT");
 activity?.SetTag("db.collection.name", "users");


### PR DESCRIPTION
## Summary

- `references/instrumentation-libraries.md`: manual DB-call example used `db.system`, which upstream `DbAttributes.cs` marks `[Obsolete("Replaced by db.system.name")]`. Also removes an internal inconsistency — `api.md` already used `db.system.name`.

## Verification

Full audit against today's upstream checkouts (opentelemetry-dotnet core-1.16.0, contrib main) found no other drift — the skill fetches versions dynamically by design:

- All 11 contrib builder extensions still exist under the named packages.
- MassTransit deprecation guidance, OTLP gRPC-vs-HttpProtobuf defaults per TFM, resource packages, and the "no declarative config in .NET" claim (tracking issue #6380 still open) all verified current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK