### PR TITLE
docs(otel-span-events-to-logs-migration): align with current OTEP 4430 status

### DIFF
--- a/skills/otel-span-events-to-logs-migration/SKILL.md
+++ b/skills/otel-span-events-to-logs-migration/SKILL.md
@@ -9,7 +9,9 @@ Use this skill to migrate instrumentation from the deprecated Span Event API (`A
 
 ## Background
 
-The OpenTelemetry project is deprecating `Span.AddEvent` and `Span.RecordException` in favor of emitting events and exceptions through the Logs API. The Span Event API is deprecated, but Span Events as a concept remain valid -- they are now emitted via logs that correlate to the active span.
+The OpenTelemetry project is deprecating `Span.AddEvent` and `Span.RecordException` in favor of emitting events and exceptions through the Logs API. Span Events as a concept remain valid -- they can be emitted via logs that correlate to the active span, and optionally bridged back into the span proto.
+
+Status as of 2026-07: OTEP 4430 (the deprecation plan) is accepted, log-based event/exception emission is stabilized in the Logs API, and the SDK "event to span event bridge" is specified. The trace API methods `AddEvent`/`RecordException` are not yet formally marked Deprecated in the specification -- that step is still pending. Some language SDKs have already begun deprecating their equivalents (e.g., OpenTelemetry .NET's `RecordException` extension is `[Obsolete]`).
 
 See `references/deprecation-plan.md` for the full context.
 

--- a/skills/otel-span-events-to-logs-migration/references/backward-compat.md
+++ b/skills/otel-span-events-to-logs-migration/references/backward-compat.md
@@ -5,11 +5,13 @@ When downstream systems (backends, dashboards, alerting rules) depend on span ev
 ## What It Is
 
 An SDK-based log processor that:
-1. Intercepts log records that represent events (identified by `event.name` attribute)
-2. Converts them to span events
-3. Attaches them to the active span in the current context
+1. Intercepts log records that represent events (identified by a non-empty `event_name` LogRecord field)
+2. Converts them to span events on the current span, when the record's `TraceId`/`SpanId` match the current recording span
+3. Copies the record's timestamp and attributes onto the span event
 
-This means the log-based event appears as a traditional span event in the exported span data, while also being available as a log record if a log exporter is configured.
+This means the log-based event appears as a traditional span event in the exported span data, while also being available as a log record if a log exporter is configured. Bridging does not remove the record from the normal log pipeline.
+
+The bridge is now specified in the OpenTelemetry Specification as the "Event to span event bridge" [LogRecordProcessor](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md#event-to-span-event-bridge) (Status: Development), which defines these exact bridging conditions.
 
 ## When to Use It
 
@@ -28,16 +30,17 @@ Do NOT use the bridge when:
 
 ### Via Declarative Configuration (preferred)
 
-When available for the language SDK, add the bridge processor to the log pipeline in the declarative config:
+When available for the language SDK, add the bridge processor to the log pipeline in the declarative config. The processor key is defined in the [opentelemetry-configuration](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema/logger_provider.yaml) schema as `event_to_span_event_bridge/development` (the `/development` suffix marks it experimental):
 
 ```yaml
 # OpenTelemetry SDK declarative configuration
-log_record_processors:
-  - event_to_span_event_bridge: {}
-  - batch:
-      exporter:
-        otlp:
-          endpoint: "http://collector:4318"
+logger_provider:
+  processors:
+    - event_to_span_event_bridge/development: {}
+    - batch:
+        exporter:
+          otlp_http:
+            endpoint: "http://collector:4318"
 ```
 
 ### Via Code (when declarative config is not available)

--- a/skills/otel-span-events-to-logs-migration/references/deprecation-plan.md
+++ b/skills/otel-span-events-to-logs-migration/references/deprecation-plan.md
@@ -20,20 +20,33 @@ This reference summarizes the [OTEP 4430](https://github.com/open-telemetry/open
 
 ## Phased Rollout
 
-### Specification
-1. Stabilize log-based exceptions and events
-2. Mark `Span.RecordException` as deprecated
-3. Mark `Span.AddEvent` as deprecated
+### In the proto
+Stabilize log-based Events. (The `event_name` LogRecord field is part of the stable proto.)
 
-### Per SDK
-1. Implement log-based event emission
-2. Implement the backward-compatibility SDK bridge (log processor that converts log events to span events)
-3. Mark the span methods as deprecated
+### Specification
+1. Stabilize emitting exceptions and events via the Logs API
+2. Mark `Span.RecordException` as deprecated
+3. Mark `Span.AddEvent` as deprecated (can happen in parallel with 2)
+
+### Per API and SDK
+1. Implement and stabilize log-based exception and event emission
+2. Implement the backward-compatibility SDK bridge (log processor that converts log-based events to span events)
+3. Mark `Span.RecordException` as deprecated
+4. Mark `Span.AddEvent` as deprecated (can happen in parallel with 3)
 
 ### Per Instrumentation
 - Current major version: continue using existing span event methods
-- Next major version: migrate to the Logs API
+- Next major version: migrate to the Logs API; for span-detail-without-a-timestamp cases, record span attributes instead ([semantic-conventions#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010), [opentelemetry-specification#4446](https://github.com/open-telemetry/opentelemetry-specification/issues/4446))
 - Users opt into the SDK bridge if they need span events in the proto envelope
+
+## Current Status (2026-07)
+
+- **Proto**: log-based Events are stable; `event_name` is a stable LogRecord field.
+- **Spec**: the Logs API is Stable, including the `event_name` field and the optional `Exception` parameter to Emit, so log-based exception/event emission is specified. The "event to span event bridge" `LogRecordProcessor` is now specified in `specification/logs/sdk.md` (Status: Development), with a matching `event_to_span_event_bridge/development` declarative-config key.
+- **Not yet done in spec**: `Span.AddEvent` and `Span.RecordException` are **not** yet marked Deprecated in `specification/trace/api.md`. That step remains pending.
+- **SDKs**: some have started deprecating equivalents ahead of the spec (e.g., OpenTelemetry .NET's `Activity.RecordException` extension is `[Obsolete]`, pointing to `Activity.AddException`).
+
+Treat the deprecation as the accepted direction, not a completed spec change; verify the current status of each step against the linked sources before making hard claims.
 
 ## Key Principle
 

--- a/skills/otel-span-events-to-logs-migration/references/migration-patterns.md
+++ b/skills/otel-span-events-to-logs-migration/references/migration-patterns.md
@@ -125,16 +125,22 @@ span.setStatus(StatusCode.ERROR, exception.getMessage());
 
 After:
 ```java
+// ExceptionAttributes lives in the io.opentelemetry.semconv artifact
+// (the old SemanticAttributes class was removed).
 Logger logger = GlobalOpenTelemetry.getLogsBridge().loggerBuilder("my-class").build();
 logger.logRecordBuilder()
     .setSeverity(Severity.ERROR)
-    .setAttribute(AttributeKey.stringKey("event.name"), "exception")
-    .setAttribute(SemanticAttributes.EXCEPTION_TYPE, exception.getClass().getName())
-    .setAttribute(SemanticAttributes.EXCEPTION_MESSAGE, exception.getMessage())
-    .setAttribute(SemanticAttributes.EXCEPTION_STACKTRACE, getStackTrace(exception))
+    .setEventName("exception")
+    .setAttribute(ExceptionAttributes.EXCEPTION_TYPE, exception.getClass().getName())
+    .setAttribute(ExceptionAttributes.EXCEPTION_MESSAGE, exception.getMessage())
+    .setAttribute(ExceptionAttributes.EXCEPTION_STACKTRACE, getStackTrace(exception))
     .emit();
 span.setStatus(StatusCode.ERROR, exception.getMessage());
 ```
+
+`setEventName(...)` is a first-class method on the stable `LogRecordBuilder`
+(stabilized in opentelemetry-java 1.x); prefer it over setting an
+`event.name` attribute.
 
 ### General Event
 
@@ -149,7 +155,7 @@ span.addEvent("state.transition", Attributes.of(
 After:
 ```java
 logger.logRecordBuilder()
-    .setAttribute(AttributeKey.stringKey("event.name"), "state.transition")
+    .setEventName("state.transition")
     .setAttribute(AttributeKey.stringKey("state.from"), oldState)
     .setAttribute(AttributeKey.stringKey("state.to"), newState)
     .emit();
@@ -170,8 +176,8 @@ After:
 const logger = logs.getLogger('my-module');
 logger.emit({
   severityNumber: SeverityNumber.ERROR,
+  eventName: 'exception',
   attributes: {
-    'event.name': 'exception',
     'exception.type': error.name,
     'exception.message': error.message,
     'exception.stacktrace': error.stack,
@@ -190,8 +196,8 @@ span.addEvent('queue.enqueue', { 'queue.name': queueName, 'queue.size': size });
 After:
 ```typescript
 logger.emit({
+  eventName: 'queue.enqueue',
   attributes: {
-    'event.name': 'queue.enqueue',
     'queue.name': queueName,
     'queue.size': size,
   },
@@ -200,11 +206,17 @@ logger.emit({
 
 ## .NET
 
+Note: OpenTelemetry .NET's `Activity.RecordException(...)` extension is
+`[Obsolete]` (it points callers to the runtime's `Activity.AddException(ex)`).
+Both `RecordException` and `AddException` record an exception *span event*, so
+either one is a migration source for this skill -- the target is still the
+Logs API as shown below.
+
 ### Exception Recording
 
 Before:
 ```csharp
-activity?.RecordException(ex);
+activity?.RecordException(ex); // or the newer activity?.AddException(ex);
 activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
 ```
 
@@ -233,7 +245,7 @@ logger.LogWarning("validation.failure for field {Field} rule {Rule}", fieldName,
 
 ## Key Rules Across All Languages
 
-1. The event name replaces the name from `AddEvent`. Use the dedicated API when available (e.g., `record.SetEventName(...)` in Go); otherwise set an `event.name` attribute.
+1. The event name replaces the name from `AddEvent`. Use the dedicated event-name API where available -- `record.SetEventName(...)` (Go), `.setEventName(...)` (Java `LogRecordBuilder`), `eventName:` (JS `logger.emit`) -- which maps to the `event_name` LogRecord field. Only set an `event.name` attribute where the SDK has no dedicated field (e.g., the Python stdlib logging bridge).
 2. All original attributes transfer to the log record attributes.
 3. The log record automatically inherits the active span context from `ctx` / the current context -- this is how trace correlation is maintained.
 4. `span.SetStatus` (or equivalent) is still set on the span for error cases -- the migration only moves event emission, not status.

--- a/skills/otel-span-events-to-logs-migration/scripts/scan-span-events.sh
+++ b/skills/otel-span-events-to-logs-migration/scripts/scan-span-events.sh
@@ -63,9 +63,11 @@ main() {
   printf '# Span Event API Usage Scan\n'
   printf 'directory: %s\n' "$dir"
 
-  # RecordException variants
-  if scan_pattern "$dir" "RecordException (exception recording)" \
-    '(RecordException|record_exception|recordException|RecordError|RecordErr)'; then
+  # RecordException / AddException variants
+  # AddException is the current .NET exception span-event API (the OTel
+  # RecordException extension is obsolete); both record exception span events.
+  if scan_pattern "$dir" "RecordException / AddException (exception recording)" \
+    '(RecordException|record_exception|recordException|RecordError|RecordErr|AddException)'; then
     found=1
   fi
 
@@ -77,7 +79,7 @@ main() {
 
   # Activity-based (.NET)
   if scan_pattern "$dir" "Activity span events (.NET)" \
-    '(activity\??\.(AddEvent|RecordException)|ActivityEvent)'; then
+    '(activity\??\.(AddEvent|RecordException|AddException)|ActivityEvent)'; then
     found=1
   fi
 


### PR DESCRIPTION
## Summary

First content refresh since the layout refactor. The headline fix: the skill stated "The Span Event API is deprecated" as completed fact — OTEP 4430 is *accepted* and the log-based path + SDK bridge are specified, but `AddEvent`/`RecordException` carry no deprecation markers in `specification/trace/api.md` yet.

- **SKILL.md**: dated status line replacing the overstated claim; notes .NET's `[Obsolete]` `RecordException`.
- **deprecation-plan.md**: phases aligned with the OTEP's actual wording (proto phase, 4-step SDK phase); new "Current Status (2026-07)" section.
- **migration-patterns.md**: Java `ExceptionAttributes` (old `SemanticAttributes` class removed) and `setEventName(...)`; JS `eventName:` field on `logger.emit`; .NET `Activity.AddException` note; per-language event-name setter mapping.
- **backward-compat.md**: bridge triggers on the non-empty `event_name` *field* (+ TraceId/SpanId), not an `event.name` attribute; declarative-config key corrected to `event_to_span_event_bridge/development` under `logger_provider.processors`.
- **scan-span-events.sh**: detects `AddException` (current .NET API); syntax and detection verified on a sample.

## Verification

Every claim checked against released tags (Go log/v0.20.0, Java 1.64.0, JS 2.9.0/api-logs 0.220.0, .NET core-1.16.0) and merged spec/proto main. OTEP path, proto `event_name` field 12, Go emit patterns, and the decision tree verified unchanged.

## Deliberately excluded

Go's unreleased log-attribute API change (main #8490, replaces `log.String` with `attribute.String`) — revisit when a log release ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK