### PR TITLE
docs(otel-collector): fix transform error_mode default, add exemplar context

### DIFF
--- a/skills/otel-collector/components/transform/README.md
+++ b/skills/otel-collector/components/transform/README.md
@@ -13,7 +13,7 @@
 
 Mutates telemetry — spans, span events, metrics, datapoints, log records (and, in development, profiles) — **in place** by running OTTL statements against it. You supply a per-signal list of statements (`trace_statements`, `metric_statements`, `log_statements`); each statement executes sequentially against incoming data, optionally guarded by a `where` clause. Unlike `filter`, which drops items, `transform` rewrites them: set, delete, rename, redact, convert types, parse structured fields, and more.
 
-The top-level `error_mode` controls what happens when a statement fails to evaluate — `propagate` (default) drops the whole payload, `ignore` logs and continues to the next statement, `silent` continues without logging. Statement groups run in the order written, so later statements see the effects of earlier ones. The OTTL language itself (functions, paths, editors/converters, grammar) lives in the `otel-ottl` skill; this page documents only the processor's config surface.
+The top-level `error_mode` controls what happens when a statement fails to evaluate — `ignore` (default) logs and continues to the next statement, `silent` continues without logging, `propagate` drops the whole payload. (The default became `ignore` in v0.153.0, when the `processor.transform.defaultErrorModeIgnore` gate reached beta / on-by-default; earlier versions defaulted to `propagate`.) Statement groups run in the order written, so later statements see the effects of earlier ones. The OTTL language itself (functions, paths, editors/converters, grammar) lives in the `otel-ottl` skill; this page documents only the processor's config surface.
 
 ## Main use-cases
 

--- a/skills/otel-collector/components/transform/configuration.md
+++ b/skills/otel-collector/components/transform/configuration.md
@@ -21,13 +21,13 @@ service:
 
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
-| `error_mode` | string | `propagate` | How OTTL statement-evaluation errors are handled: `propagate`, `ignore`, or `silent`. See [Error mode](#error-mode). |
+| `error_mode` | string | `ignore` | How OTTL statement-evaluation errors are handled: `ignore`, `silent`, or `propagate`. See [Error mode](#error-mode). |
 | `trace_statements` | list | `[]` | Statements run against trace data. |
 | `metric_statements` | list | `[]` | Statements run against metric data. |
 | `log_statements` | list | `[]` | Statements run against log data. |
 | `profile_statements` | list | `[]` | Statements run against profile data (Development stability). |
 
-> A `processor.transform.defaultErrorModeIgnore` feature gate (alpha, disabled by default, v0.150.0+) flips the default `error_mode` from `propagate` to `ignore`. Until it is enabled, the default is `propagate`.
+> The default `error_mode` is `ignore`, set by the `processor.transform.defaultErrorModeIgnore` feature gate, which reached **beta (enabled by default) in v0.153.0**. To restore the old `propagate` default, disable it: `--feature-gates=-processor.transform.defaultErrorModeIgnore`.
 
 > A `flatten_data` boolean (default `false`, behind the `transform.flatten.logs` alpha feature gate) gives each log record a distinct copy of its resource and scope before transformation, then regroups afterwards — useful when log-level data drives resource/scope edits. It copies and hashes every record, so enable only when needed.
 
@@ -35,9 +35,9 @@ service:
 
 | Mode | Behavior | When |
 |------|----------|------|
-| `propagate` | Returns the error up the pipeline, dropping the whole payload. | **Default.** Development/testing — surfaces config mistakes immediately. |
-| `ignore` | Logs the error and moves to the next statement. | **Recommended in production** — one bad statement won't drop unrelated data. |
+| `ignore` | Logs the error and moves to the next statement. | **Default** (since v0.153.0) and **recommended in production** — one bad statement won't drop unrelated data. |
 | `silent` | Continues without logging. | When error logging is too noisy. |
+| `propagate` | Returns the error up the pipeline, dropping the whole payload. | Development/testing — surfaces config mistakes immediately. Was the default before v0.153.0. |
 
 The top-level `error_mode` can be overridden per statement group (see below).
 
@@ -90,9 +90,11 @@ Context determines which paths the statements can reach. Contexts are hierarchic
 | Signal | Contexts (broad → specific) | Reaches |
 |--------|------------------------------|---------|
 | traces | `resource`, `scope`, `span`, `spanevent` | `spanevent` can read `resource`, `scope`, `span`, `spanevent` |
-| metrics | `resource`, `scope`, `metric`, `datapoint` | `datapoint` can read `resource`, `scope`, `metric`, `datapoint` |
+| metrics | `resource`, `scope`, `metric`, `datapoint`, `exemplar` | `exemplar` can read `resource`, `scope`, `metric`, `datapoint`, `exemplar` |
 | logs | `resource`, `scope`, `log` | `log` can read `resource`, `scope`, `log` |
 | profiles | `resource`, `scope`, `profile` | `profile` can read `resource`, `scope`, `profile` (Development) |
+
+The `exemplar` metric context (reaching a datapoint's exemplars) was added in v0.156.0; on older versions `metric_statements` stops at `datapoint`.
 
 Some path/function combinations can't share a context (e.g. a metric-context-only function alongside a `datapoint` path). When inference fails, split the conflicting statements into separate groups. See [Known quirks](quirks.md).
 

--- a/skills/otel-collector/components/transform/configuration.md
+++ b/skills/otel-collector/components/transform/configuration.md
@@ -28,7 +28,7 @@ service:
 | `profile_statements` | list | `[]` | Statements run against profile data (Development stability). |
 
 > The default `error_mode` is `ignore`, set by the `processor.transform.defaultErrorModeIgnore` feature gate, which reached **beta (enabled by default) in v0.153.0**. To restore the old `propagate` default, disable it: `--feature-gates=-processor.transform.defaultErrorModeIgnore`.
-
+>
 > A `flatten_data` boolean (default `false`, behind the `transform.flatten.logs` alpha feature gate) gives each log record a distinct copy of its resource and scope before transformation, then regroups afterwards — useful when log-level data drives resource/scope edits. It copies and hashes every record, so enable only when needed.
 
 ## Error mode

--- a/skills/otel-collector/components/transform/quirks.md
+++ b/skills/otel-collector/components/transform/quirks.md
@@ -20,13 +20,13 @@ A `resource`-context statement runs once per resource and changes are seen by **
 
 ## `error_mode: propagate` drops the whole batch on error
 
-The default is `propagate`: the first statement that errors (a type mismatch, a nil dereference like `log.cache["x"]["y"]` when `x` is nil) **drops the entire payload**, not just the offending item, and the remaining statements never run. In production set `error_mode: ignore` (or `silent`), and nil-check before accessing nested fields:
+Under `propagate`, the first statement that errors (a type mismatch, a nil dereference like `log.cache["x"]["y"]` when `x` is nil) **drops the entire payload**, not just the offending item, and the remaining statements never run. The default is now `ignore` (since v0.153.0), but any config or group that still sets `propagate` behaves this way. Keep `error_mode: ignore` (or `silent`) in production, and nil-check before accessing nested fields:
 
 ```yaml
 - set(log.attributes["uid"], log.cache["user"]["id"]) where log.cache["user"] != nil
 ```
 
-`silent` hides evaluation errors entirely — if a transform "isn't working," confirm it isn't set to `silent`. The `processor.transform.defaultErrorModeIgnore` feature gate (alpha, v0.150.0+) can flip the default to `ignore`; don't assume the default without checking whether the gate is on.
+`silent` hides evaluation errors entirely — if a transform "isn't working," confirm it isn't set to `silent`. The default was flipped from `propagate` to `ignore` by the `processor.transform.defaultErrorModeIgnore` feature gate, which reached beta / on-by-default in v0.153.0; on pre-v0.153.0 collectors the default is still `propagate`, and the gate can be disabled (`--feature-gates=-processor.transform.defaultErrorModeIgnore`) to restore it. Don't assume the default without knowing the running version.
 
 ## Context performance
 


### PR DESCRIPTION
## Summary

Deep audit of the `transform` component page against the released v0.156.0 tag:

- **`error_mode` default corrected** (`propagate` → `ignore`): the `processor.transform.defaultErrorModeIgnore` gate went beta / on-by-default in v0.153.0 (PR #48415). Fixed in README.md, the configuration keys table, the error-mode table, and both quirks passages; the stale "alpha, disabled by default" gate callout now documents how to disable the gate to restore `propagate`.
- **Net-new**: metrics context row lists the `exemplar` context (v0.156.0, PR #49023) — the processor-level surface of the context documented in otel-ottl PR #86.

## Verified unchanged against v0.156.0

Stability/signals (Beta ×3, profiles Development), full config schema (`*_statements`, `flatten_data` behind the still-alpha `transform.flatten.logs` gate), error-mode enum, flat vs explicit-group forms, statement ordering semantics, verification recipe. SKILL.md index row confirmed accurate — untouched.

## Flagged for a separate pass

Net-new OTTL *functions* in this window (`ParseCLF`, `ParseLEEF`, histogram bucket converters) belong to the `otel-ottl` skill, not this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated transform processor documentation to reflect the `ignore` default for statement evaluation errors since v0.153.0.
  * Clarified how to restore the previous `propagate` behavior using the feature gate.
  * Documented error handling recommendations and clarified payload-dropping behavior.
  * Added metrics `exemplar` context details, including version availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->