### PR TITLE
docs(otel-collector): add log_dedup multi-tenant config, fix OTTL paths

### DIFF
--- a/skills/otel-collector/components/log_dedup/advanced.md
+++ b/skills/otel-collector/components/log_dedup/advanced.md
@@ -22,7 +22,7 @@ processors:
   log_dedup:
     interval: 60s
     conditions:
-      - severity_number >= SEVERITY_NUMBER_ERROR
+      - log.severity_number >= SEVERITY_NUMBER_ERROR
 ```
 
 INFO/WARN/DEBUG logs pass through immediately. Only ERROR+ are buffered.
@@ -48,11 +48,11 @@ processors:
   log_dedup/access:
     interval: 10s
     conditions:
-      - 'attributes["log.type"] == "access"'
+      - 'log.attributes["log.type"] == "access"'
   log_dedup/health:
     interval: 30s
     conditions:
-      - 'attributes["log.type"] == "health_check"'
+      - 'log.attributes["log.type"] == "health_check"'
 
 service:
   pipelines:
@@ -60,6 +60,22 @@ service:
       processors: [memory_limiter, log_dedup/access, log_dedup/health]
 ```
 
+## Multi-tenant buckets with `metadata_keys`
+
+In gateway deployments where one pipeline carries logs for many tenants, aggregating across tenants would merge their counts and lose the routing metadata. `metadata_keys` partitions aggregation per unique combination of client-metadata values (gRPC/HTTP headers), and each emitted log keeps a context carrying its original metadata so a downstream `headers_setter` can re-attach the header.
+
+```yaml
+processors:
+  log_dedup:
+    interval: 30s
+    metadata_keys: [x-scope-orgid]
+    metadata_cardinality_limit: 1000
+```
+
+Always set `metadata_cardinality_limit` when using `metadata_keys` in production: `0` (the default) means the number of tenant buckets is unbounded and memory can grow without limit — the processor logs a startup warning in that case. When the limit is reached, logs with a new metadata combination are rejected with a permanent error rather than silently merged.
+
+Requires the receiver to propagate client metadata (e.g. the OTLP receiver's `include_metadata: true`).
+
 ## OTTL context for `conditions`
 
-`conditions` runs in the [OTTL log context](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottllog): `body`, `attributes["…"]`, `resource.attributes["…"]`, `severity_number`, `severity_text`, plus all OTTL converters. See the `otel-ottl` skill for full path and function inventories.
+`conditions` runs in the [OTTL log context](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottllog). Prefix paths with their context name: `log.body`, `log.attributes["…"]`, `resource.attributes["…"]`, `log.severity_number`, `log.severity_text`, plus all OTTL converters. Un-prefixed paths (`attributes["…"]`, `severity_number`) still work but are **deprecated** since v0.153.0 — the processor rewrites and logs them at startup, and support may be removed. See the `otel-ottl` skill for full path and function inventories.

--- a/skills/otel-collector/components/log_dedup/configuration.md
+++ b/skills/otel-collector/components/log_dedup/configuration.md
@@ -21,9 +21,11 @@ service:
 | `interval` | duration | `10s` | Aggregation window. Must be `> 0`. Counter resets after each emission. |
 | `log_count_attribute` | string | `log_count` | Attribute name for the duplicate count. Must be non-empty. |
 | `timezone` | string | `UTC` | IANA timezone for `first_observed_timestamp`/`last_observed_timestamp` (e.g., `America/New_York`). |
-| `conditions` | []string | `[]` | OTTL log-context expressions. Empty = deduplicate all logs. Non-empty = only deduplicate matches; non-matching logs pass through unchanged. |
+| `conditions` | []string | `[]` | OTTL log-context expressions. Empty = deduplicate all logs. Non-empty = only deduplicate logs matching at least one condition; non-matching logs pass through unchanged. Prefix paths with their context name (`log.attributes["x"]`, `resource.attributes["y"]`, `log.severity_number`). |
 | `include_fields` | []string | `[]` | Whitelist of fields used to compute log identity. Mutually exclusive with `exclude_fields`. |
 | `exclude_fields` | []string | `[]` | Fields removed before hashing **and** stripped from emitted logs. Mutually exclusive with `include_fields`. |
+| `metadata_keys` | []string | `[]` | Client-metadata keys (e.g. gRPC/HTTP headers like `x-scope-orgid`) that partition aggregation into separate buckets. Logs with different values for these keys are counted independently, and each emitted log keeps a context carrying its original metadata so downstream extensions (e.g. `headers_setter`) can route it. Case-insensitive; duplicates rejected. Empty = one shared bucket. Added in v0.155.0. |
+| `metadata_cardinality_limit` | uint32 | `0` | Caps the number of distinct `metadata_keys` combinations tracked at once. `0` = unbounded (a startup warning is logged when `metadata_keys` is set but this stays `0`). Once the cap is hit, new combinations are rejected with a permanent error. Added in v0.155.0. |
 
 ## Validation rules
 
@@ -31,6 +33,7 @@ service:
 - Field paths must start with `body.` or `attributes.`.
 - The entire `body` cannot be included or excluded — only nested fields when `body` is a map.
 - Use `.` as the nesting delimiter. Escape literal dots in keys with `\` (e.g., `attributes.host\.name`).
+- Duplicate entries in `include_fields`, `exclude_fields`, or `metadata_keys` (case-insensitive for the latter) are rejected.
 - `timezone` must resolve in the IANA database.
 
 ## Fallback behavior
@@ -41,7 +44,7 @@ If `include_fields` is set but none of the listed fields exist on a record, the 
 
 Two log records are considered identical when **all** of these match exactly: resource attributes, instrumentation scope (name, version, attributes), log body (content and type), log attributes, and severity (number and text). The processor stores a 64-bit hash per unique combination.
 
-`include_fields` / `exclude_fields` customize which parts of the record feed the hash.
+`include_fields` / `exclude_fields` customize which parts of the record feed the hash. When `metadata_keys` is set, matching happens **within** each metadata bucket — two otherwise-identical logs arriving with different metadata values are never merged (see [advanced](advanced.md#multi-tenant-buckets-with-metadata_keys)).
 
 ## What gets emitted
 

--- a/skills/otel-collector/components/log_dedup/quirks.md
+++ b/skills/otel-collector/components/log_dedup/quirks.md
@@ -5,6 +5,7 @@
 - One entry per unique hash for the duration of the interval.
 - High-cardinality fields (`request_id`, `trace_id`, timestamps) blow up memory — exclude them or use `conditions` to scope what's deduplicated.
 - Long intervals accumulate more unique entries; short intervals emit faster with smaller buffers.
+- `metadata_keys` multiplies memory: one full bucket of hashes per unique metadata combination. Leaving `metadata_cardinality_limit` at `0` (unbounded) is a memory-growth trap — cap it, and expect a startup warning if you don't.
 
 ## Telemetry
 
@@ -35,6 +36,8 @@ The processor emits a histogram `otelcol_dedup_processor_aggregated_logs` with t
 | `cannot define both exclude_fields and include_fields` | Choose one. |
 | `an excludefield must start with body or attributes` | Prefix every path with `body.` or `attributes.`. |
 | `cannot exclude the entire body` | Only nested fields are exclud-able (e.g., `body.timestamp`). |
+| `duplicate metadata_key "…"` | Remove the repeated key (comparison is case-insensitive). |
+| `too many batcher metadata-value combinations` (runtime, permanent error) | `metadata_cardinality_limit` reached — raise it, or narrow `metadata_keys`. |
 
 ## Anti-patterns
 
@@ -53,8 +56,8 @@ Scope with `conditions` so audit, security, and one-off error logs pass through 
 processors:
   log_dedup:
     conditions:
-      - 'attributes["log.type"] == "health_check"'
-      - 'attributes["log.type"] == "heartbeat"'
+      - 'log.attributes["log.type"] == "health_check"'
+      - 'log.attributes["log.type"] == "heartbeat"'
 ```
 
 **`include_fields` that includes unique IDs.**


### PR DESCRIPTION
## Summary

Deep audit of the `log_dedup` component page against the released v0.156.0 tag. The page was missing the whole multi-tenant config surface:

- **Net-new**: `metadata_keys` and `metadata_cardinality_limit` (released v0.155.0, CHANGELOG #47521): configuration table rows + validation rules, a "multi-tenant buckets" section in advanced.md (per-tenant partitioning, `headers_setter` routing, receiver `include_metadata` requirement, permanent error when the cardinality limit is hit), and quirks coverage (buckets multiply memory; unbounded-limit trap; two new error-message table rows).
- **Correction**: `conditions` examples migrated from the deprecated un-prefixed OTTL paths to the context-prefixed form required since v0.153.0 (`log.attributes[...]`, `log.severity_number`).

## Verified unchanged against v0.156.0

README stability (Alpha logs), `logdedup`→`log_dedup` rename claim (v0.151.0), metric name, all pre-existing config keys (`interval`, `log_count_attribute`, `timezone`, include/exclude field rules), the match model (confirmed in `counter.go`), and the verification recipe.

Also flagged (not edited here): SKILL.md line 62 uses a deprecated un-prefixed condition in a generic example — will be collected into a separate index-level PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded configuration guidance for log deduplication conditions, included/excluded fields, metadata-based partitioning, and cardinality limits.
  * Added examples for tenant-specific deduplication and clarified how metadata affects log matching.
  * Documented context-prefixed OTTL paths and deprecated unprefixed paths.
  * Added warnings about memory growth and validation errors for duplicate metadata keys or excessive cardinality.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->