### PR TITLE
docs(otel-collector): deep-refresh tail_sampling for v0.156.0

### DIFF
--- a/skills/otel-collector/components/tail_sampling/advanced.md
+++ b/skills/otel-collector/components/tail_sampling/advanced.md
@@ -94,7 +94,7 @@ exporters:
     resolver:
       dns:
         hostname: tail-sampling-layer
-        port: 4317
+        port: "4317"
 service:
   pipelines:
     traces:

--- a/skills/otel-collector/components/tail_sampling/advanced.md
+++ b/skills/otel-collector/components/tail_sampling/advanced.md
@@ -19,7 +19,7 @@ Sample only traces that are **both** an error **and** slow:
           threshold_ms: 1000
 ```
 
-`and` accepts all policy types except `composite`, `and`, and `drop`.
+`and` accepts all policy types except `composite`, `and`, and `drop`. A `not` sub-policy can be nested inside `and_sub_policy` (and inside `drop_sub_policy`), letting you AND a negated condition without a separate top-level policy.
 
 ## `composite` — tiered sampling with rate allocation
 

--- a/skills/otel-collector/components/tail_sampling/configuration.md
+++ b/skills/otel-collector/components/tail_sampling/configuration.md
@@ -31,7 +31,8 @@ service:
 
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
-| `decision_wait` | duration | `30s` | Time from first span arrival before the decision is made. Buffers spans for this long. |
+| `sampling_strategy` | enum | `trace-complete` | `trace-complete`: evaluate the accumulated trace on the timer path (most flexible, higher memory). `span-ingest`: evaluate each incoming batch at ingest — terminal `sampled`/`dropped` outcomes finalize immediately, non-terminal traces finalize as not-sampled on cleanup (rejects stateful policies). Invalid values fail validation. |
+| `decision_wait` | duration | `30s` | Time from first span arrival before the decision is made. Buffers spans for this long. Under `span-ingest` it instead controls pending-cleanup finalization timing. |
 | `decision_wait_after_root_received` | duration | `0s` | Decide this long after the root span arrives; `0` disables (only `decision_wait` is used). |
 | `num_traces` | int | `50000` | Max traces kept in memory. When full, the oldest are evicted (before decision) unless `block_on_overflow`. |
 | `expected_new_traces_per_sec` | int | `0` | Hint for pre-allocating the trace buffer; `0` disables pre-allocation. |
@@ -42,5 +43,7 @@ service:
 | `decision_cache.sampled_cache_size` | int | `0` | LRU cache of sampled trace IDs so late spans inherit the decision; `0` disables. |
 | `decision_cache.non_sampled_cache_size` | int | `0` | LRU cache of dropped trace IDs; `0` disables. |
 | `policies` | list | (required) | Sampling policies. At least one is required. |
+
+`tail_storage` (a component ID) offloads span buffering to a tail-storage extension instead of memory, but is behind the alpha `processor.tailsamplingprocessor.tailstorageextension` feature gate — setting it without the gate fails validation.
 
 For the full catalog of policy types and their sub-fields, see [Policy types](policies.md).

--- a/skills/otel-collector/components/tail_sampling/policies.md
+++ b/skills/otel-collector/components/tail_sampling/policies.md
@@ -10,13 +10,13 @@ Each policy has `name` and `type`, plus a config block named after the type.
 | `probabilistic` | Sample a fixed percentage of traces via trace-ID hash. |
 | `status_code` | Sample if any span has a matching status code. |
 | `string_attribute` | Sample by string span/resource attribute value (exact or regex). |
-| `rate_limiting` | Sample up to a maximum spans-per-second. |
+| `rate_limiting` | Sample up to a maximum spans-per-second via a token bucket; `spans_per_second` (required) + `burst_capacity` (optional, default 2× the rate). A trace with more spans than the burst never passes. |
 | `bytes_limiting` | Sample up to a maximum bytes-per-second via a token bucket; `bytes_per_second` (required) + `burst_capacity` (optional, default 2× the rate). |
 | `span_count` | Sample by number of spans in the trace. |
 | `trace_state` | Sample by W3C TraceState key/value. |
-| `trace_flags` | Sample if the W3C `sampled` flag is set on any span; config `flags: ["sampled"]`. |
+| `trace_flags` | Sample if the W3C `sampled` trace flag is set on any span in the trace. No sub-config. |
 | `boolean_attribute` | Sample by boolean attribute value. |
-| `ottl_condition` | Sample when OTTL conditions on spans/span-events match. |
+| `ottl_condition` | Sample when OTTL conditions on spans/span-events match (`span:` and `spanevent:` lists, plus `error_mode`). Prefer path-qualified context (e.g. `span.attributes[...]`, `resource.attributes[...]`, `spanevent.name`) over bare `attributes[...]` to avoid future breaking changes. |
 | `and` | Combine sub-policies with AND — all must match to sample. |
 | `composite` | Combine sub-policies with priority order and per-policy rate allocation. |
 | `not` | Invert the decision of a single wrapped sub-policy via `not_sub_policy`. |
@@ -61,17 +61,18 @@ Key sub-fields for the common policies:
   probabilistic:
     sampling_percentage: 10.0
 
-# rate_limiting: cap spans per second
+# rate_limiting: cap spans per second (token bucket)
 - name: cap
   type: rate_limiting
   rate_limiting:
     spans_per_second: 1000
+    burst_capacity: 2000   # optional; default 2× spans_per_second
 ```
 
 ## Decision precedence
 
 All policies are evaluated (unless `sample_on_first_match: true`), then a single decision is chosen: a `drop` decision wins over everything; otherwise any `sample` decision keeps the trace; if no policy matches, the trace is **not** sampled.
 
-> **`invert_match` note:** as of recent contrib releases the legacy "inverted decisions" are disabled — `invert_match: true` now yields a plain sample/not-sample on the negated condition and no longer vetoes other policies. To explicitly suppress traces, use a `drop` policy; to sample on the opposite of a wrapped policy's decision, use a `not` policy instead.
+> **`invert_match` note:** the legacy "inverted decisions" behavior is gone — the `disableinvertdecisions` feature gate was stabilized and then removed, so as of v0.156.0 `invert_match: true` always yields a plain sample/not-sample on the negated condition and no longer vetoes other policies. `invert_match` still exists on the `numeric_attribute`, `string_attribute`, and `boolean_attribute` policies. To explicitly suppress traces, use a `drop` policy; to sample on the opposite of a wrapped policy's decision, use a `not` policy instead.
 
 The `and`, `composite`, `not`, and `drop` policy types compose other policies; see [Advanced use-cases](advanced.md) for worked examples.


### PR DESCRIPTION
## Summary

Deep audit of the `tail_sampling` page against the released v0.156.0 tag (all 17 policy types + every top-level key checked against `config.go`/`factory.go`):

- **Fabricated config removed**: `trace_flags` was documented with `flags: ["sampled"]` — no such field exists; the policy is built with no sub-config.
- **Net-new**: `sampling_strategy` top-level key (`trace-complete` default / `span-ingest`, validated, #46762) and a surface-level `tail_storage` note (requires the alpha `tailstorageextension` gate; setting it without the gate is a validation error).
- **rate_limiting**: now a token bucket with optional `burst_capacity` (default 2× rate, #48226) — was described as a plain spans-per-second counter.
- **invert_match**: inverted decisions permanently removed as of v0.156.0 (`disableinvertdecisions` stabilized #47650 then removed #48976); replaced the vague "recent releases" wording. `invert_match` itself remains on match policies.
- **ottl_condition** sub-fields and `not`-inside-`and`/`drop` nesting (#47382) documented.

## Verified unchanged

README stability row, quirks (memory model, `decision_wait`, dropped-too-early metric), verification recipe, SKILL.md index row (accurate, untouched).

Note: upstream's own v0.156.0 README still describes the removed inverted-decision flow — the page now states actual runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration guidance for selecting complete-trace or span-ingest sampling modes.
  * Documented validation requirements and the alpha feature gate for tail-storage buffering.
  * Clarified supported combinations for `and` policies, including nested negation.
  * Expanded guidance for rate limiting, trace flags, and OTTL conditions.
  * Updated policy precedence and `invert_match` behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->