### PR TITLE
docs(otel-collector): deep-refresh k8s_attributes for v0.156.0

### DIFF
--- a/skills/otel-collector/components/k8s_attributes/advanced.md
+++ b/skills/otel-collector/components/k8s_attributes/advanced.md
@@ -21,11 +21,13 @@ Add resources as you extract more metadata:
 
 | Extracted metadata | Add resource | API group |
 |--------------------|--------------|-----------|
-| `k8s.deployment.name` (default path) | `replicasets` | `apps`, `extensions` |
-| `k8s.deployment.uid`, deployment labels/annotations | `deployments` | `apps` |
+| `k8s.deployment.name` (default heuristic) | *nothing extra* — derived from the pod's owner ReplicaSet name | — |
+| `k8s.deployment.uid`, or `k8s.deployment.name` with `deployment_name_from_replicaset: false` | `replicasets` | `apps`, `extensions` |
+| deployment labels/annotations (`from: deployment`) | `replicasets` + `deployments` | `apps`, `extensions` |
 | `k8s.statefulset.*` / `k8s.daemonset.*` | `statefulsets` / `daemonsets` | `apps` |
-| `k8s.job.*`, `k8s.cronjob.*` | `jobs` | `batch` |
-| `k8s.node.*` | `nodes` | `` (core) |
+| `k8s.job.*`, `k8s.cronjob.uid`, or job labels/annotations (`from: job`) | `jobs` | `batch` |
+| `k8s.cronjob.name` alone | *nothing extra* — derived from the Job name via heuristic | — |
+| `k8s.node.*` or node labels/annotations | `nodes` | `` (core) |
 
 Bind it cluster-wide with a `ClusterRoleBinding` when the collector receives telemetry from many namespaces. When the collector only handles one namespace, use a namespaced `Role` + `RoleBinding` with `filter.namespace` set — least privilege, but it **cannot** read nodes, `k8s.cluster.uid`, or namespace labels/annotations.
 
@@ -94,16 +96,17 @@ extract:
 
 Extracting `from:` a workload (deployment/statefulset/daemonset/job) makes the processor watch that resource — extra RBAC and roughly +30% memory. Only do it when you need it.
 
-## `deployment_name_from_replicaset`
+## `deployment_name_from_replicaset` (deprecated)
 
-Derive `k8s.deployment.name` by trimming the pod-template-hash off the ReplicaSet name, so you don't have to watch ReplicaSets at all:
+Since v0.153.0 this is the **default** behavior and the option is **deprecated** (slated for removal): `k8s.deployment.name` is derived by trimming the pod-template-hash off the pod's owner ReplicaSet name — no ReplicaSet watch, cheaper RBAC, less memory. You still must list `k8s.deployment.name` (or `service.name`) in `extract.metadata` for it to be produced.
+
+The heuristic sets a wrong name for pods owned by a **standalone** ReplicaSet (one with no Deployment); in rare cases deployment names of 247–253 chars come back slightly truncated. To force accurate ReplicaSet-informer lookup instead (at the cost of `replicasets` RBAC and extra memory), set it `false` or enable `k8s.deployment.uid`:
 
 ```yaml
 extract:
-  deployment_name_from_replicaset: true
+  metadata: [k8s.deployment.name]
+  deployment_name_from_replicaset: false   # force informer lookup; needs replicasets RBAC
 ```
-
-Cheaper RBAC (no `replicasets`) and less memory, but it sets a wrong name for pods owned by a **standalone** ReplicaSet (one with no Deployment), and very long deployment names (>63 chars) come back truncated. Use it only when all pods are Deployment-managed.
 
 ## `wait_for_metadata`
 
@@ -113,7 +116,7 @@ Block startup until the metadata cache has synced, so telemetry arriving immedia
 processors:
   k8s_attributes:
     wait_for_metadata: true
-    metadata_sync_timeout: 30s
+    wait_for_metadata_timeout: 30s
 ```
 
-Trade-off: guaranteed enrichment of early data, but a slower start — and if the sync doesn't finish within `metadata_sync_timeout` the collector **fails to start**. Leave it `false` (default) when fast, best-effort startup matters more than enriching the first few records.
+Trade-off: guaranteed enrichment of early data, but a slower start — and if the sync doesn't finish within `wait_for_metadata_timeout` the collector **fails to start**. Leave it `false` (default) when fast, best-effort startup matters more than enriching the first few records.

--- a/skills/otel-collector/components/k8s_attributes/configuration.md
+++ b/skills/otel-collector/components/k8s_attributes/configuration.md
@@ -26,8 +26,7 @@ service:
 
 | Key | Type | Default | Meaning |
 |-----|------|---------|---------|
-| `auth_type` | string | `serviceAccount` | How to reach the API: `serviceAccount` (in-cluster), `kubeConfig` (local dev), or `none`. |
-| `kubeconfig_path` | string | `""` | Path to a kubeconfig file; used when `auth_type: kubeConfig`. |
+| `auth_type` | string | `serviceAccount` | How to reach the API: `serviceAccount` (in-cluster), `kubeConfig` (local dev, reads `~/.kube/config` or `$KUBECONFIG`), or `none`. |
 | `context` | string | `""` | Kubeconfig context to use; only with `auth_type: kubeConfig`. |
 | `kube_api_qps` | float32 | `5` | Max queries/sec to the API. Raise if you see client-side throttling warnings. |
 | `kube_api_burst` | int | `10` | Max request burst to the API. Raise alongside `kube_api_qps` under throttling. |

--- a/skills/otel-collector/components/k8s_attributes/configuration.md
+++ b/skills/otel-collector/components/k8s_attributes/configuration.md
@@ -28,14 +28,18 @@ service:
 |-----|------|---------|---------|
 | `auth_type` | string | `serviceAccount` | How to reach the API: `serviceAccount` (in-cluster), `kubeConfig` (local dev), or `none`. |
 | `kubeconfig_path` | string | `""` | Path to a kubeconfig file; used when `auth_type: kubeConfig`. |
+| `context` | string | `""` | Kubeconfig context to use; only with `auth_type: kubeConfig`. |
+| `kube_api_qps` | float32 | `5` | Max queries/sec to the API. Raise if you see client-side throttling warnings. |
+| `kube_api_burst` | int | `10` | Max request burst to the API. Raise alongside `kube_api_qps` under throttling. |
 | `passthrough` | bool | `false` | Agent mode: only annotate the record with the pod IP (`k8s.pod.ip`), don't query the API or extract metadata. The gateway does the enrichment. |
 | `extract` | object | (see below) | Which metadata, labels, and annotations to add. |
 | `filter` | object | `{}` | Restrict which pods are watched (node/namespace/label/field). The main memory lever. |
 | `pod_association` | array | (see below) | Ordered strategies for tying a record to a pod; first match wins. |
 | `exclude` | object | excludes `jaeger-agent`, `jaeger-collector` | Pods to skip (by name, regex allowed). A pod can also opt out with the annotation `opentelemetry.io/k8s-processor.ignore: "true"`. |
 | `wait_for_metadata` | bool | `false` | Block startup until the metadata cache has synced. |
-| `metadata_sync_timeout` | duration | `10s` | Max wait for the initial sync when `wait_for_metadata: true`. Renamed from `wait_for_metadata_timeout`. |
-| `watch_sync_period` | duration | `5m` | Informer cache resync period (v0.152.0; matches the previously-hardcoded behavior). |
+| `wait_for_metadata_timeout` | duration | `10s` | Max wait for the initial sync when `wait_for_metadata: true`; on timeout the collector fails to start. |
+| `watch_sync_period` | duration | `5m` | Informer cache resync period (v0.152.0). Set `0s` to disable resync — recommended for very large clusters, where periodic resyncs cause CPU spikes and memory churn. |
+| `pod_delete_grace_period` | duration | `120s` | How long a deleted pod's metadata is kept in the cache before eviction (v0.154.0), so late-arriving records for that pod can still be enriched. |
 
 ## `extract`
 
@@ -53,7 +57,7 @@ extract:
       key: git-commit
       from: pod
   otel_annotations: true                  # auto-extract resource.opentelemetry.io/* annotations
-  deployment_name_from_replicaset: false  # derive k8s.deployment.name without watching ReplicaSets
+  deployment_name_from_replicaset: true   # deprecated; default. Derives k8s.deployment.name from the ReplicaSet name (heuristic, no ReplicaSet watch). Set false to force ReplicaSet-informer lookup.
 ```
 
 **`labels` / `annotations` fields:**
@@ -69,7 +73,7 @@ extract:
 
 ### Default-extracted metadata
 
-Even with no `extract.metadata` list, these are added: `k8s.namespace.name`, `k8s.pod.name`, `k8s.pod.uid`, `k8s.pod.start_time`, `k8s.deployment.name`, `k8s.node.name`, and (when a container identifier is present) `container.image.name` / `container.image.tag`. Set an explicit `metadata` list to narrow this.
+Even with no `extract.metadata` list, these are added: `k8s.namespace.name`, `k8s.pod.name`, `k8s.pod.uid`, `k8s.pod.start_time`, `k8s.deployment.name`, `k8s.node.name`, and (when a container identifier is present) `container.image.name`, `container.image.tag`, `container.image.tags`. Set an explicit `metadata` list to narrow this.
 
 ### Available metadata fields
 
@@ -81,7 +85,7 @@ Even with no `extract.metadata` list, these are added: `k8s.namespace.name`, `k8
 | `k8s.cronjob.name`, `k8s.cronjob.uid` | pod owned by a Job owned by a CronJob |
 | `k8s.node.name`, `k8s.node.uid` | — |
 | `k8s.cluster.uid` | reads the `kube-system` namespace UID |
-| `k8s.container.name`, `container.id`, `container.image.name`, `container.image.tag`, `container.image.repo_digests`, `container.image.tags` (v0.146.0+, feature-gated) | a container identifier on the record (see [quirks](quirks.md)) |
+| `k8s.container.name`, `container.id`, `container.image.name`, `container.image.tag` (deprecated, use `container.image.tags`), `container.image.tags`, `container.image.repo_digests` | a container identifier on the record (see [quirks](quirks.md)) |
 | `service.namespace`, `service.name`, `service.version`, `service.instance.id` | calculated (see below) |
 
 `service.name` is calculated by semantic-convention priority: `app.kubernetes.io/instance` label → `app.kubernetes.io/name` label → workload name → pod name.

--- a/skills/otel-collector/components/k8s_attributes/configuration.md
+++ b/skills/otel-collector/components/k8s_attributes/configuration.md
@@ -73,7 +73,7 @@ extract:
 
 ### Default-extracted metadata
 
-Even with no `extract.metadata` list, these are added: `k8s.namespace.name`, `k8s.pod.name`, `k8s.pod.uid`, `k8s.pod.start_time`, `k8s.deployment.name`, `k8s.node.name`, and (when a container identifier is present) `container.image.name`, `container.image.tag`, `container.image.tags`. Set an explicit `metadata` list to narrow this.
+Even with no `extract.metadata` list, these are added: `k8s.namespace.name`, `k8s.pod.name`, `k8s.pod.uid`, `k8s.pod.start_time`, `k8s.deployment.name`, `k8s.node.name`, and (when a container identifier is present) `container.image.name` plus the image-tag attribute selected by the semantic-convention gates (`container.image.tag` on v0, `container.image.tags` on v1 — see [quirks](quirks.md)). Set an explicit `metadata` list to narrow this.
 
 ### Available metadata fields
 

--- a/skills/otel-collector/components/k8s_attributes/quirks.md
+++ b/skills/otel-collector/components/k8s_attributes/quirks.md
@@ -22,7 +22,7 @@ The old `extract.labels[].regex` / `extract.annotations[].regex` fields (which p
 
 ## Semantic-convention label/annotation format is changing
 
-By default, label/annotation attributes use the **plural** v0 format (`k8s.pod.labels.<key>`). The v1 semconv form is **singular** (`k8s.pod.label.<key>`) and is gated behind `processor.k8sattributes.EmitV1K8sConventions` (emit both) and `processor.k8sattributes.DontEmitV0K8sConventions` (drop the plural form). Migrate by enabling the first gate, repointing dashboards/queries to the singular names, then enabling the second. The gates affect only the **default** `tag_name`; an explicit `tag_name` is unchanged. (The older `k8sattr.labelsAnnotationsSingular.allow` gate was **removed in v0.154.0** in favor of these.)
+By default, label/annotation attributes use the **plural** v0 format (`k8s.pod.labels.<key>`). The v1 semconv form is **singular** (`k8s.pod.label.<key>`) and is gated behind `processor.k8sattributes.EmitV1K8sConventions` (emit both) and `processor.k8sattributes.DontEmitV0K8sConventions` (drop the plural form). The same gates also switch `container.image.tag` (string) → `container.image.tags` (slice). Migrate by enabling the first gate, repointing dashboards/queries to the singular/plural names, then enabling the second. The gates affect only the **default** `tag_name`; an explicit `tag_name` is unchanged. (The older `k8sattr.labelsAnnotationsSingular.allow` gate was **removed** in v0.155.0.)
 
 ## Don't use it for sidecars, or outside Kubernetes
 
@@ -30,4 +30,4 @@ For a sidecar, inject pod metadata via the Kubernetes downward API as env vars �
 
 ## Stability caveats
 
-Traces, metrics, and logs are Beta; profiles are Development. The semconv migration gates above and the v0.151.0–v0.152.0 efficiency/metric changes (e.g. the disabled `otelcol.k8s.pod.association` internal metric, `PartialObjectMetadata` informers) mean behavior and attribute names still shift between releases — confirm against the upstream README for your exact collector version.
+Traces, metrics, and logs are Beta; profiles are Development. The semconv migration gates above and ongoing efficiency work (e.g. `PartialObjectMetadata` informers, and the `otelcol.k8s.pod.association` internal metric — disabled in v0.151.0, then re-enabled in v0.153.0 with a low-cardinality `pod_identifier` attribute) mean behavior and attribute names still shift between releases — confirm against the upstream README for your exact collector version.

--- a/skills/otel-collector/components/k8s_attributes/verification.md
+++ b/skills/otel-collector/components/k8s_attributes/verification.md
@@ -27,7 +27,7 @@ rules:
     resources: ["pods", "namespaces", "nodes"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["apps"]
-    resources: ["replicasets", "deployments"]   # needed for k8s.deployment.name
+    resources: ["replicasets", "deployments"]   # optional: only for deployment_name_from_replicaset:false or k8s.deployment.uid; the default heuristic needs neither
     verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -75,7 +75,7 @@ spec:
       serviceAccountName: otel-collector
       containers:
         - name: otel-collector
-          image: otel/opentelemetry-collector-contrib:0.152.0
+          image: otel/opentelemetry-collector-contrib:0.156.0
           args: ["--config=/etc/otel/config.yaml"]
           ports: [{containerPort: 4317}]
           volumeMounts: [{name: config, mountPath: /etc/otel}]
@@ -121,7 +121,7 @@ Resource attributes:
      -> k8s.node.name: Str(k8sattr-verify-control-plane)
 ```
 
-`k8s.deployment.name: demo` is the strongest signal — producing it means the processor resolved the pod, walked its owner ReplicaSet up to the Deployment (which is why the ClusterRole grants `replicasets` and `deployments`), and matched the record to that pod purely from the `k8s.pod.ip` we set.
+`k8s.deployment.name: demo` is the strongest signal — producing it means the processor resolved the pod purely from the `k8s.pod.ip` we set, then derived the deployment name from the pod's owner ReplicaSet name via the default heuristic (which is why the `replicasets`/`deployments` grants above are optional — needed only if you set `deployment_name_from_replicaset: false` or extract `k8s.deployment.uid`).
 
 ## Teardown
 


### PR DESCRIPTION
## Summary

Deep audit against the released v0.156.0 tag; 4 of 5 page files changed.

- **Fabricated key removed**: `metadata_sync_timeout` (with an invented "renamed from" note) — the real key is `wait_for_metadata_timeout`, in both the table and examples.
- **Missing released keys added**: `pod_delete_grace_period` (`120s`, v0.154.0 #48127), `context`, `kube_api_qps`/`kube_api_burst`; `watch_sync_period` `0s`-disables-resync documented.
- **RBAC table was inverted**: the default `k8s.deployment.name` heuristic derives from the owner ReplicaSet *name* and needs no `replicasets` grant; `replicasets`/`deployments` are needed only for `deployment_name_from_replicaset: false`, `k8s.deployment.uid`, or `from: deployment` extraction. Same nuance added for cronjob name vs uid.
- **`deployment_name_from_replicaset`**: deprecated and default-`true` since v0.153.0 (#48447); truncation caveat corrected (247–253 chars, not 63).
- **Gate/version fixes**: `k8sattr.labelsAnnotationsSingular.allow` removed in **v0.155.0** (#48977 — corrects the v0.154.0 claim from the earlier shallow sweep, PR #87); v1 gates switch to `container.image.tags` (now default-extracted, `container.image.tag` deprecated); the pod-association metric was re-enabled in v0.153.0.
- Verification example image bumped to 0.156.0 with the narrative rewritten to the released heuristic.

## Verified unchanged

Stability/signals, `pod_association` rules (max 4, `container.id` only usable resource attr), filter ops, exclude defaults, `key`/`key_regex` exclusivity, SKILL.md index row (accurate, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Kubernetes attribute processor configuration guidance and examples.
  - Clarified RBAC requirements and metadata extraction behavior.
  - Documented the deprecated ReplicaSet-based deployment name option and its default heuristic.
  - Replaced the startup synchronization timeout setting with `wait_for_metadata_timeout`.
  - Updated container image metadata fields, semantic convention notes, and verification instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->