### PR TITLE
docs(otel-collector): deep-refresh filter for v0.156.0

### DIFF
--- a/skills/otel-collector/components/filter/README.md
+++ b/skills/otel-collector/components/filter/README.md
@@ -11,9 +11,9 @@
 
 ## Description
 
-Drops telemetry — spans, span events, metrics, datapoints, log records (and, in development, profiles) — from a pipeline when it matches an OTTL condition or a legacy metric-name/attribute matcher. Conditions are evaluated per item; when any condition for a given context evaluates to `true`, that item is dropped. Multiple conditions in the same context are ORed together. Filtering is hierarchical: if a higher-level item is dropped (e.g. a span), the lower-level conditions for it (e.g. its span events) are not evaluated.
+Drops telemetry — spans, span events, metrics, datapoints, log records (and, in development, profiles) — from a pipeline when it matches an OTTL condition. Conditions are evaluated per item; when any condition evaluates to `true`, that item is dropped. Conditions in a list are ORed together. Filtering is hierarchical: if a higher-level item is dropped (e.g. a span), the lower-level conditions for it (e.g. its span events) are not evaluated.
 
-OTTL is the modern, recommended approach; the per-signal blocks (`traces`, `metrics`, `logs`) carry the condition lists. The top-level `error_mode` controls what happens when a condition fails to evaluate — `propagate` (default) fails the batch, `ignore` logs and continues, `silent` continues without logging. A legacy include/exclude form survives for metrics and logs but cannot be combined with OTTL conditions for the same signal.
+The current surface is the per-signal `trace_conditions` / `metric_conditions` / `log_conditions` / `profile_conditions` lists, which carry OTTL conditions with context-prefixed paths (`span.name`, `log.body`, …) and infer their context automatically. The top-level `error_mode` controls what happens when a condition fails to evaluate — `ignore` (default since v0.153.0) logs and continues, `propagate` fails the batch, `silent` continues without logging. Two older forms are deprecated: the fixed-context per-signal blocks (`traces.span`, `metrics.metric`, `logs.log_record`, …) and a pre-OTTL include/exclude matcher (metrics and logs only) that cannot be combined with OTTL conditions for the same signal.
 
 ## Main use-cases
 
@@ -37,7 +37,7 @@ Avoid it when:
 
 ## Details
 
-- [Configuration](configuration.md) — `error_mode`, the per-signal OTTL contexts (`traces.span`, `traces.spanevent`, `metrics.metric`, `metrics.datapoint`, `logs.log_record`), and the legacy include/exclude form.
+- [Configuration](configuration.md) — `error_mode`, the `*_conditions` lists with their inferred contexts (`resource`/`scope`/`span`/`spanevent`, `metric`/`datapoint`, `log`, `profile`), basic vs advanced style, and the deprecated per-signal blocks and include/exclude matchers.
 - [Verification](verification.md) — telemetrygen recipe that drops a subset of logs by severity so the drop is observable.
 - [Advanced use-cases](advanced.md) — combining conditions, `error_mode`, metric/datapoint filtering, resource-attribute filters, OTTL functions, named instances.
 - [Known quirks](quirks.md) — orphaned telemetry, the drop-last-datapoint rule, error-mode behavior, stability caveats, anti-patterns, troubleshooting.

--- a/skills/otel-collector/components/filter/advanced.md
+++ b/skills/otel-collector/components/filter/advanced.md
@@ -2,33 +2,51 @@
 
 ## Combining conditions
 
-Conditions within a context are ORed — any match drops the item. Use `and`/`or`/`not()` and parentheses inside a single condition for AND logic:
+Conditions within a list are ORed — any match drops the item. Use `and`/`or`/`not()` and parentheses inside a single condition for AND logic:
 
 ```yaml
 processors:
   filter:
     error_mode: ignore
-    traces:
-      span:
-        # OR across the list — drop either name
-        - 'name == "readiness"'
-        - 'name == "liveness"'
-        # AND within one condition — short, successful spans only
-        - '(end_time - start_time) < Duration("10ms") and status.code == STATUS_CODE_OK'
+    trace_conditions:
+      # OR across the list — drop either name
+      - 'span.name == "readiness"'
+      - 'span.name == "liveness"'
+      # AND within one condition — short, successful spans only
+      - '(span.end_time - span.start_time) < Duration("10ms") and span.status.code == STATUS_CODE_OK'
 ```
+
+## Advanced style: explicit context and per-group error_mode
+
+Each entry in a `*_conditions` list can be an object that pins a `context` and/or overrides `error_mode` for its group of `conditions`. Set `context` only when inference can't resolve it — e.g. a bare `IsRootSpan()` with no path prefix:
+
+```yaml
+processors:
+  filter:
+    error_mode: ignore
+    trace_conditions:
+      - context: span            # required: IsRootSpan() has no prefix to infer from
+        error_mode: propagate    # override just this group
+        conditions:
+          - IsRootSpan()
+      - conditions:
+          - spanevent.name == "grpc.timeout"
+```
+
+Basic (flat strings) and advanced (objects) styles cannot be mixed within one signal.
 
 ## error_mode
 
 ```yaml
-# Development: catch broken conditions immediately
-processors:
-  filter:
-    error_mode: propagate   # a failing condition drops the whole batch
-
-# Production: a bad condition logs but does not drop unrelated data
+# Default: ignore — a bad condition logs but does not drop unrelated data
 processors:
   filter:
     error_mode: ignore
+
+# Development: catch broken conditions immediately (must set explicitly; ignore is the default)
+processors:
+  filter:
+    error_mode: propagate   # a failing condition drops the whole batch
 
 # Noisy environments: continue without logging the error at all
 processors:
@@ -44,36 +62,31 @@ Drop whole metrics by name or type (cheapest), or individual datapoints by value
 processors:
   filter:
     error_mode: ignore
-    metrics:
-      metric:
-        - 'IsMatch(name, "internal\\..*")'
-        - 'type == METRIC_DATA_TYPE_HISTOGRAM'
-        # metric-only converters (must run in the metric context)
-        - 'HasAttrKeyOnDatapoint("internal")'
-        - 'HasAttrOnDatapoint("environment", "test")'
-      datapoint:
-        - 'metric.name == "k8s.pod.phase" and value_int == 4'
+    metric_conditions:
+      - 'IsMatch(metric.name, "internal\\..*")'
+      - 'metric.type == METRIC_DATA_TYPE_HISTOGRAM'
+      # metric-only converters (inferred as metric context)
+      - 'HasAttrKeyOnDatapoint("internal")'
+      - 'HasAttrOnDatapoint("environment", "test")'
+      - 'metric.name == "k8s.pod.phase" and datapoint.value_int == 4'
 ```
 
 Filter at `metric` level when you want to drop the whole series — it is cheaper than evaluating every datapoint. See [Known quirks](quirks.md) for the drop-last-datapoint rule.
 
 ## Filtering by resource attribute
 
-Resource attributes are visible in every context, so the same condition shape works across signals — useful for stripping an environment or service wholesale:
+Resource attributes are visible in every signal, so the same condition shape works across them — useful for stripping an environment or service wholesale:
 
 ```yaml
 processors:
   filter:
     error_mode: ignore
-    traces:
-      span:
-        - 'resource.attributes["deployment.environment"] == "dev"'
-    metrics:
-      metric:
-        - 'resource.attributes["deployment.environment"] == "dev"'
-    logs:
-      log_record:
-        - 'resource.attributes["deployment.environment"] == "dev"'
+    trace_conditions:
+      - 'resource.attributes["deployment.environment"] == "dev"'
+    metric_conditions:
+      - 'resource.attributes["deployment.environment"] == "dev"'
+    log_conditions:
+      - 'resource.attributes["deployment.environment"] == "dev"'
 ```
 
 ## OTTL function usage
@@ -84,13 +97,11 @@ The processor exposes the standard OTTL converters (see the `otel-ottl` skill) p
 processors:
   filter:
     error_mode: ignore
-    traces:
-      span:
-        - 'IsMatch(resource.attributes["k8s.pod.name"], "canary-.*")'
-    logs:
-      log_record:
-        - 'IsMatch(body, ".*(password|secret|api[_-]?key).*")'
-        - 'attributes["http.request.method"] == nil'
+    trace_conditions:
+      - 'IsMatch(resource.attributes["k8s.pod.name"], "canary-.*")'
+    log_conditions:
+      - 'IsMatch(log.body, ".*(password|secret|api[_-]?key).*")'
+      - 'log.attributes["http.request.method"] == nil'
 ```
 
 ## Named instances
@@ -99,14 +110,12 @@ processors:
 processors:
   filter/health:
     error_mode: ignore
-    traces:
-      span:
-        - 'name == "health_check"'
+    trace_conditions:
+      - 'span.name == "health_check"'
   filter/debug-logs:
     error_mode: ignore
-    logs:
-      log_record:
-        - 'severity_number < SEVERITY_NUMBER_INFO'
+    log_conditions:
+      - 'log.severity_number < SEVERITY_NUMBER_INFO'
 
 service:
   pipelines:
@@ -118,4 +127,4 @@ service:
 
 ## OTTL context
 
-The condition fields evaluate in their per-signal contexts (span, spanevent, metric, datapoint, log). Path and converter inventories live in the `otel-ottl` skill; the field summary per context is in [configuration.md](configuration.md).
+The `*_conditions` lists infer their context (`resource`/`scope`/`span`/`spanevent`, `metric`/`datapoint`, `log`, `profile`) from the path prefixes used; the filter processor does **not** expose an `exemplar` context. Path and converter inventories live in the `otel-ottl` skill; the field summary per context is in [configuration.md](configuration.md).

--- a/skills/otel-collector/components/filter/advanced.md
+++ b/skills/otel-collector/components/filter/advanced.md
@@ -63,12 +63,17 @@ processors:
   filter:
     error_mode: ignore
     metric_conditions:
-      - 'IsMatch(metric.name, "internal\\..*")'
-      - 'metric.type == METRIC_DATA_TYPE_HISTOGRAM'
-      # metric-only converters (inferred as metric context)
-      - 'HasAttrKeyOnDatapoint("internal")'
-      - 'HasAttrOnDatapoint("environment", "test")'
-      - 'metric.name == "k8s.pod.phase" and datapoint.value_int == 4'
+      # metric-only converters (HasAttrKeyOnDatapoint / HasAttrOnDatapoint) carry no
+      # path prefix, so their context can't be inferred — pin context: metric explicitly.
+      - context: metric
+        conditions:
+          - 'IsMatch(metric.name, "internal\\..*")'
+          - 'metric.type == METRIC_DATA_TYPE_HISTOGRAM'
+          - 'HasAttrKeyOnDatapoint("internal")'
+          - 'HasAttrOnDatapoint("environment", "test")'
+      # datapoint-level check, inferred separately (metric context can't see datapoint.value_int)
+      - conditions:
+          - 'metric.name == "k8s.pod.phase" and datapoint.value_int == 4'
 ```
 
 Filter at `metric` level when you want to drop the whole series — it is cheaper than evaluating every datapoint. See [Known quirks](quirks.md) for the drop-last-datapoint rule.

--- a/skills/otel-collector/components/filter/configuration.md
+++ b/skills/otel-collector/components/filter/configuration.md
@@ -6,9 +6,8 @@
 processors:
   filter:
     error_mode: ignore
-    traces:
-      span:
-        - 'name == "health_check"'
+    trace_conditions:
+      - span.name == "health_check"
 
 service:
   pipelines:
@@ -22,42 +21,87 @@ service:
 
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
-| `error_mode` | string | `propagate` | How OTTL condition-evaluation errors are handled: `propagate`, `ignore`, or `silent`. See [Error mode](#error-mode). |
-| `traces` | block | — | Trace conditions (`span`, `spanevent`). |
-| `metrics` | block | — | Metric conditions (`metric`, `datapoint`) or legacy `include`/`exclude`. |
-| `logs` | block | — | Log conditions (`log_record`) or legacy `include`/`exclude`. |
+| `error_mode` | string | `ignore` | How OTTL condition-evaluation errors are handled: `propagate`, `ignore`, or `silent`. See [Error mode](#error-mode). |
+| `trace_conditions` | list | — | Trace conditions (contexts: `resource`, `scope`, `span`, `spanevent`). |
+| `metric_conditions` | list | — | Metric conditions (contexts: `resource`, `scope`, `metric`, `datapoint`). |
+| `log_conditions` | list | — | Log conditions (contexts: `resource`, `scope`, `log`). |
+| `profile_conditions` | list | — | Profile conditions (contexts: `resource`, `scope`, `profile`). **Development** stability. |
+| `traces` / `metrics` / `logs` / `profiles` | block | — | **Deprecated** per-signal blocks and legacy `include`/`exclude` matchers. See [Legacy configuration](#legacy-configuration). |
 
-> A `processor.filter.defaultErrorModeIgnore` feature gate (alpha, disabled by default, v0.150.0+) flips the default `error_mode` from `propagate` to `ignore`. Until it is enabled, the default is `propagate`.
+> **Default `error_mode` is `ignore` since v0.153.0.** The `processor.filter.defaultErrorModeIgnore` feature gate (**beta, enabled by default**) sets the default to `ignore`. Disable it — `--feature-gates=-processor.filter.defaultErrorModeIgnore` — to restore the old `propagate` default.
 
-## Per-signal OTTL conditions
+## The `*_conditions` fields
 
-Each field below takes a list of OTTL boolean expressions. An item is **dropped** when any condition in its context evaluates to `true`. The expression language itself — operators, paths, converter functions — is covered in the `otel-ottl` skill; only the filter-specific surface is described here.
+`trace_conditions`, `metric_conditions`, `log_conditions`, and `profile_conditions` are the current, recommended surface (documented upstream from v0.146.0). Each takes a list of OTTL boolean conditions; an item is **dropped** when any condition evaluates to `true` (conditions are ORed). The expression language — operators, paths, converter functions — is covered in the `otel-ottl` skill; only the filter-specific surface is described here.
 
-| Field | OTTL context | Drops | Representative fields |
-|-------|--------------|-------|-----------------------|
-| `traces.span` | span | a span | `name`, `attributes[...]`, `status.code`, `kind`, `start_time`, `end_time`, `resource.attributes[...]`, `instrumentation_scope` |
-| `traces.spanevent` | spanevent | a span event | `name`, `attributes[...]`, `time_unix_nano`, plus the enclosing span's fields |
-| `metrics.metric` | metric | a whole metric | `name`, `description`, `unit`, `type`, `aggregation_temporality`, `resource.attributes[...]` |
-| `metrics.datapoint` | datapoint | a single datapoint | `attributes[...]`, `value_int`, `value_double`, `time_unix_nano`, `metric.name`, `metric.type` |
-| `logs.log_record` | log | a log record | `body`, `attributes[...]`, `severity_number`, `severity_text`, `resource.attributes[...]`, `instrumentation_scope` |
+### Contexts and path prefixes
 
-**OTTL-context note:** each field evaluates in its own context. You cannot reference span fields from a `spanevent` condition's top level except through the span context the spanevent inherits, and metric-level fields (`name`, `type`) are reachable from `datapoint` only via `metric.name` / `metric.type`. Two metric-only converters are added by this processor and must run in the `metrics.metric` context: `HasAttrKeyOnDatapoint(key)` (true if any datapoint carries that attribute key) and `HasAttrOnDatapoint(key, value)` (true if any datapoint has that string key/value).
+Within a `*_conditions` list, paths are **prefixed by context** and the processor **infers** the context from the prefixes used, so you rarely set it by hand.
 
-Hierarchy: if a span is dropped, its `spanevent` conditions are not evaluated; if all datapoints of a metric are dropped, the metric is removed too. See [Known quirks](quirks.md).
+| Field | Available contexts | Representative paths |
+|-------|--------------------|----------------------|
+| `trace_conditions` | `resource`, `scope`, `span`, `spanevent` | `span.name`, `span.attributes[...]`, `span.status.code`, `span.kind`, `span.start_time`, `span.end_time`, `spanevent.name`, `resource.attributes[...]`, `scope.name` |
+| `metric_conditions` | `resource`, `scope`, `metric`, `datapoint` | `metric.name`, `metric.type`, `metric.unit`, `datapoint.attributes[...]`, `datapoint.value_int`, `datapoint.value_double`, `resource.attributes[...]` |
+| `log_conditions` | `resource`, `scope`, `log` | `log.body`, `log.attributes[...]`, `log.severity_number`, `log.severity_text`, `resource.attributes[...]`, `scope.name` |
+| `profile_conditions` | `resource`, `scope`, `profile` | `profile.duration_unix_nano`, `resource.attributes[...]` |
 
-> Two surfaces are intentionally not detailed here: an **inferred-context** condition form (`trace_conditions` / `metric_conditions` / `log_conditions`, v0.146.0+) that lets a single list span multiple contexts, and a **`profiles.profile`** block (Development stability). Both are documented in the [upstream README](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor) if you need them.
+The filter processor supports **only** the contexts above — notably **no `exemplar` context** (that path exists in the `transform` processor, which mutates rather than drops).
+
+**Hierarchy.** Conditions run higher-to-lower (`resource` → `scope` → signal-specific). If a higher-level item is dropped, lower-level conditions for it are skipped: a dropped span skips its `spanevent` conditions. If all datapoints of a metric are dropped, the metric is dropped too; if all span events of a span are dropped, the span is left intact. When one condition mixes paths from two contexts, it is evaluated in the **lower** context (e.g. `resource` + `spanevent` → evaluated per span event). See [Known quirks](quirks.md).
+
+**Metric-only converters.** This processor adds two functions that must run in the **`metric`** context: `HasAttrKeyOnDatapoint(key)` (true if any datapoint carries that attribute key) and `HasAttrOnDatapoint(key, value)` (true if any datapoint has that string key/value).
+
+### Basic vs advanced style
+
+**Basic** — a flat list of OTTL strings, ORed, context inferred per condition:
+
+```yaml
+filter:
+  error_mode: ignore
+  trace_conditions:
+    - span.attributes["container.name"] == "app_container_1"
+    - resource.attributes["host.name"] == "localhost"
+    - span.name == "app_3"
+```
+
+**Advanced** — objects that pin a `context` and/or override `error_mode` for a group of `conditions`:
+
+```yaml
+filter:
+  error_mode: ignore
+  trace_conditions:
+    - context: span            # set explicitly only when inference can't (e.g. IsRootSpan())
+      error_mode: propagate    # overrides the top-level error_mode for this group
+      conditions:
+        - IsRootSpan()
+    - conditions:
+        - spanevent.name == "grpc.timeout"
+```
+
+Set `context` explicitly only when a condition has no path prefix to infer from (e.g. a bare `IsRootSpan()`), or when a combination of paths/functions/enums is not allowed in a single inferred context. Basic and advanced (and the deprecated forms) **cannot be mixed within one signal** — validation rejects mixing configuration styles.
 
 ## Error mode
 
 | Mode | Behavior | When |
 |------|----------|------|
-| `propagate` | Returns the error up the pipeline, dropping the whole payload. | **Default.** Development/testing — surfaces config mistakes immediately. |
-| `ignore` | Logs the error and moves to the next condition. | **Recommended in production** — a bad condition won't drop unrelated data. |
+| `ignore` | Logs the error and moves to the next condition. | **Default and recommended** — a bad condition won't drop unrelated data. |
 | `silent` | Continues without logging. | When error logging is too noisy. |
+| `propagate` | Returns the error up the pipeline, dropping the whole payload. | Development/testing — surfaces config mistakes immediately. |
 
-## Legacy include/exclude (metrics and logs only)
+## Legacy configuration
 
-The pre-OTTL form still works but **cannot be combined with OTTL conditions for the same signal**. Prefer OTTL for new configs.
+Two older forms still work but are **deprecated** and slated for removal; both are documented upstream only for versions before v0.146.0. Prefer `*_conditions` for new configs.
+
+**Deprecated per-signal OTTL blocks** — same conditions, unprefixed paths inside a fixed context. Migrate by moving each into the matching `*_conditions` list with the context prefix:
+
+| Deprecated | Migrate to |
+|------------|------------|
+| `traces.resource` / `traces.span` / `traces.spanevent` | `trace_conditions` with `resource.` / `span.` / `spanevent.` prefix |
+| `metrics.resource` / `metrics.metric` / `metrics.datapoint` | `metric_conditions` with `resource.` / `metric.` / `datapoint.` prefix |
+| `logs.resource` / `logs.log_record` | `log_conditions` with `resource.` / `log.` prefix |
+| `profiles.resource` / `profiles.profile` | `profile_conditions` with `resource.` / `profile.` prefix |
+
+**Pre-OTTL include/exclude** (metrics and logs only) — name/attribute/severity matchers. Cannot be combined with any OTTL conditions for the same signal.
 
 Metrics — match by name and/or resource attribute:
 

--- a/skills/otel-collector/components/filter/configuration.md
+++ b/skills/otel-collector/components/filter/configuration.md
@@ -49,7 +49,7 @@ The filter processor supports **only** the contexts above — notably **no `exem
 
 **Hierarchy.** Conditions run higher-to-lower (`resource` → `scope` → signal-specific). If a higher-level item is dropped, lower-level conditions for it are skipped: a dropped span skips its `spanevent` conditions. If all datapoints of a metric are dropped, the metric is dropped too; if all span events of a span are dropped, the span is left intact. When one condition mixes paths from two contexts, it is evaluated in the **lower** context (e.g. `resource` + `spanevent` → evaluated per span event). See [Known quirks](quirks.md).
 
-**Metric-only converters.** This processor adds two functions that must run in the **`metric`** context: `HasAttrKeyOnDatapoint(key)` (true if any datapoint carries that attribute key) and `HasAttrOnDatapoint(key, value)` (true if any datapoint has that string key/value).
+**Metric-only converters.** This processor adds two functions that must run in the **`metric`** context: `HasAttrKeyOnDatapoint(key)` (true if any datapoint carries that attribute key) and `HasAttrOnDatapoint(key, value)` (true if any datapoint has that string key/value). Because they carry no path prefix, their context **cannot be inferred** — pin `context: metric` explicitly (advanced style), or validation fails with `unable to infer context from conditions`.
 
 ### Basic vs advanced style
 

--- a/skills/otel-collector/components/filter/quirks.md
+++ b/skills/otel-collector/components/filter/quirks.md
@@ -69,9 +69,9 @@ Filter leaf/noise spans, or move whole-trace decisions to `tail_sampling`.
 **Complex negative-lookahead regex.**
 
 ```yaml
-# Hard to maintain, error-prone
+# Rejected at config load — Go's RE2 engine has no lookahead
 log_conditions:
   - 'IsMatch(log.body, "^(?!.*(error|warn|fail)).*$")'
 ```
 
-Prefer explicit positive conditions (`log.severity_number < SEVERITY_NUMBER_WARN`).
+`IsMatch` compiles with Go's RE2 engine, which does not support lookahead (`(?!`); the pattern above fails validation outright (`invalid or unsupported Perl syntax: `(?!``). Prefer explicit positive conditions (`log.severity_number < SEVERITY_NUMBER_WARN`).

--- a/skills/otel-collector/components/filter/quirks.md
+++ b/skills/otel-collector/components/filter/quirks.md
@@ -2,7 +2,7 @@
 
 ## Data is permanently dropped
 
-`filter` removes data from the pipeline; there is no recovery downstream. Test conditions with `error_mode: propagate` and `debug` logging before rolling out.
+`filter` removes data from the pipeline; there is no recovery downstream. Test conditions with `error_mode: propagate` (explicitly — the default is now `ignore`) and `debug` logging before rolling out.
 
 ## Dropping a metric's only datapoint removes the metric
 
@@ -16,9 +16,9 @@ Filtering at the `datapoint` level that empties a metric also removes the metric
 
 ## error_mode behavior
 
-- Default is `propagate`: a single failing condition (e.g. a type mismatch or a nil dereference) **drops the entire batch**, not just the offending item. This surprises people in production — set `error_mode: ignore` there.
+- Default is `ignore` since v0.153.0 (the `processor.filter.defaultErrorModeIgnore` gate went **beta / enabled by default**): a failing condition is logged and skipped, valid data survives.
+- Setting `error_mode: propagate` — or disabling the gate with `--feature-gates=-processor.filter.defaultErrorModeIgnore` — makes a single failing condition (e.g. a type mismatch or a nil dereference) **drop the entire batch**, not just the offending item. Older collectors (pre-v0.153.0) defaulted to `propagate`, so the same config behaves differently across versions unless `error_mode` is set explicitly.
 - `silent` hides evaluation errors entirely; if a filter "isn't working," confirm it isn't set to `silent`.
-- The `processor.filter.defaultErrorModeIgnore` feature gate can flip the default to `ignore`; don't assume the default without checking whether the gate is enabled.
 
 ## Stability caveats
 
@@ -27,15 +27,18 @@ All signals are **Alpha** (profiles are **Development**). Config keys can still 
 ## Troubleshooting
 
 **Nothing is dropped.**
-- Wrong context — span fields used in a `spanevent` block, or metric fields used directly in `datapoint` (use `metric.name`).
-- Attribute doesn't exist — add a nil check: `attributes["x"] != nil and attributes["x"] == "y"`.
+- Missing/wrong path prefix — in `*_conditions`, paths must be prefixed (`span.name`, `log.body`, `metric.name`, `datapoint.value_int`); the context is inferred from those prefixes.
+- Attribute doesn't exist — add a nil check: `log.attributes["x"] != nil and log.attributes["x"] == "y"`.
 - `error_mode: silent` is swallowing evaluation errors — switch to `propagate` while debugging.
 
 **Everything is dropped.**
-- Overly broad condition (`IsMatch(name, ".*")` matches all). Tighten it and re-test with debug logging.
+- Overly broad condition (`IsMatch(span.name, ".*")` matches all). Tighten it and re-test with debug logging.
 
-**Validation error: `cannot use ottl conditions and include/exclude ... at the same time`.**
-- You mixed OTTL conditions and legacy include/exclude for the same signal. Pick one.
+**Validation error: `configuring multiple configuration styles is not supported`.**
+- You mixed basic (flat string list) and advanced (`context`/`conditions` objects) forms in one signal — use one style.
+
+**Validation error: `cannot use context inferred ... conditions and the settings ... at the same time`.**
+- You mixed `*_conditions` with a deprecated per-signal block or include/exclude for the same signal. Pick one.
 
 **Verifying effectiveness.** The processor emits `processor_filter_spans.filtered`, `processor_filter_datapoints.filtered`, `processor_filter_logs.filtered` (and `processor_filter_profiles.filtered`, development) — watch these to confirm drops.
 
@@ -44,24 +47,21 @@ All signals are **Alpha** (profiles are **Development**). Config keys can still 
 **Datapoint-level filtering when a whole metric should go.**
 
 ```yaml
-# Less efficient — evaluates every datapoint
-metrics:
-  datapoint:
-    - 'resource.attributes["env"] == "test"'
+# Less efficient — inferred as datapoint context, evaluates every datapoint
+metric_conditions:
+  - 'datapoint.attributes["env"] == "test"'
 
-# Prefer — drops the whole metric in one check
-metrics:
-  metric:
-    - 'resource.attributes["env"] == "test"'
+# Prefer — resource condition drops the whole resource in one check
+metric_conditions:
+  - 'resource.attributes["env"] == "test"'
 ```
 
 **Dropping parent/correlated spans.**
 
 ```yaml
 # Risky — orphans children, breaks log correlation
-traces:
-  span:
-    - 'kind == SPAN_KIND_SERVER'
+trace_conditions:
+  - 'span.kind == SPAN_KIND_SERVER'
 ```
 
 Filter leaf/noise spans, or move whole-trace decisions to `tail_sampling`.
@@ -70,9 +70,8 @@ Filter leaf/noise spans, or move whole-trace decisions to `tail_sampling`.
 
 ```yaml
 # Hard to maintain, error-prone
-logs:
-  log_record:
-    - 'IsMatch(body, "^(?!.*(error|warn|fail)).*$")'
+log_conditions:
+  - 'IsMatch(log.body, "^(?!.*(error|warn|fail)).*$")'
 ```
 
-Prefer explicit positive conditions (`severity_number < SEVERITY_NUMBER_WARN`).
+Prefer explicit positive conditions (`log.severity_number < SEVERITY_NUMBER_WARN`).

--- a/skills/otel-collector/components/filter/verification.md
+++ b/skills/otel-collector/components/filter/verification.md
@@ -15,9 +15,8 @@ receivers:
 processors:
   filter:
     error_mode: ignore
-    logs:
-      log_record:
-        - 'severity_number >= SEVERITY_NUMBER_ERROR'
+    log_conditions:
+      - 'log.severity_number >= SEVERITY_NUMBER_ERROR'
 exporters:
   debug:
     verbosity: detailed


### PR DESCRIPTION
## Summary

Deep audit against the released v0.156.0 tag; all five page files changed. Two root causes:

1. **`error_mode` default flipped `propagate` → `ignore`** in v0.153.0 (`processor.filter.defaultErrorModeIgnore` gate beta/on-by-default, #47232) — the page claimed `propagate` throughout. Same family as the transform fix in #96.
2. **Legacy framing was inverted**: the page presented the fixed-context per-signal blocks (`traces.span`, `metrics.metric`, `logs.log_record`…) as the modern surface, but released v0.156.0 marks them `Deprecated` in config.go — `trace_/metric_/log_/profile_conditions` with inferred contexts and prefixed paths is the primary API. Rewritten accordingly, with a migration table; deprecated forms stay documented as legacy since they still function.

Also: basic vs advanced condition style (net-new), the real mixed-style validation messages (the page quoted a non-existent one), the no-`exemplar`-context note (transform-only), and all examples migrated to prefixed paths.

## Verified unchanged

Alpha stability across traces/metrics/logs (profiles Development), telemetry metric names, drop-hierarchy semantics, metric-only converters, include/exclude matcher fields, SKILL.md index row (accurate, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated filter processor guidance to reflect the current OTTL-based `*_conditions` configuration for traces, metrics, logs, and profiles.
  * Clarified condition evaluation, inferred contexts, error modes, defaults, and deprecated configuration formats.
  * Added modern examples for advanced filtering, resource attributes, metric datapoints, named instances, and troubleshooting.
  * Updated verification instructions to use severity-based log filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->