### PR TITLE
docs(otel-collector): document interval processor's actual validation rule

### DIFF
--- a/skills/otel-collector/components/interval/configuration.md
+++ b/skills/otel-collector/components/interval/configuration.md
@@ -22,7 +22,7 @@ service:
 | `pass_through.gauge` | bool | `false` | If `true`, gauges are forwarded unchanged instead of buffered. |
 | `pass_through.summary` | bool | `false` | If `true`, summaries are forwarded unchanged instead of buffered. |
 
-Validation: `interval` must be greater than `0`. A zero or negative value fails startup with `invalid interval value`. `pass_through` booleans have no validation.
+Validation: `interval` must be greater than `0`. A zero or negative value fails startup with `invalid interval value` (`ErrInvalidIntervalValue` in source). `pass_through` booleans have no validation.
 
 > **Doc typo, upstream:** the README's configuration block shows `summary: <boo>l`. It's a typo for `<bool>` — the parameter is a plain boolean.
 

--- a/skills/otel-collector/components/interval/configuration.md
+++ b/skills/otel-collector/components/interval/configuration.md
@@ -22,7 +22,7 @@ service:
 | `pass_through.gauge` | bool | `false` | If `true`, gauges are forwarded unchanged instead of buffered. |
 | `pass_through.summary` | bool | `false` | If `true`, summaries are forwarded unchanged instead of buffered. |
 
-Upstream documents no explicit validation rules. The Collector will reject an unparseable `interval` duration at startup.
+Validation: `interval` must be greater than `0`. A zero or negative value fails startup with `invalid interval value`. `pass_through` booleans have no validation.
 
 > **Doc typo, upstream:** the README's configuration block shows `summary: <boo>l`. It's a typo for `<bool>` — the parameter is a plain boolean.
 


### PR DESCRIPTION
## Summary

Deep audit of the `interval` page against the released v0.156.0 tag. One correction: the page said "Upstream documents no explicit validation rules" — `config.go`'s `Validate()` rejects `interval <= 0` with `ErrInvalidIntervalValue`. Now states the real rule (zero/negative fails startup; `pass_through` booleans unvalidated).

## Verified unchanged

The component had zero functional changes v0.150.0→v0.156.0 (dependency bumps only): all three config keys and defaults, aggregated-vs-passthrough semantics per metric type, stability (Alpha/metrics), distributions, and the upstream README `<boo>l` typo note (still present upstream). SKILL.md index row accurate — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the `interval` setting must be greater than zero.
  * Documented that invalid values prevent Collector startup with an error.
  * Clarified that `pass_through` boolean options do not require validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->