### PR TITLE
docs(otel-collector): prometheus receiver v0.156.0 keys and gate states

### DIFF
--- a/skills/otel-collector/components/prometheus/README.md
+++ b/skills/otel-collector/components/prometheus/README.md
@@ -13,7 +13,7 @@
 
 Scrapes metrics from Prometheus-format HTTP endpoints and converts them to OTLP metrics. It embeds the **scrape manager and parser from `prometheus/prometheus`**, so the configuration under the top-level `config:` key is the same YAML you would put in a `prometheus.yml` — `global`, `scrape_configs`, `scrape_config_files`, service discovery, and relabeling all behave exactly as in Prometheus. The receiver is a *scrape-only* drop-in: it pulls from targets, it does not run a Prometheus server. Anything omitted under `config:` falls back to Prometheus's own defaults for that setting.
 
-Beyond the embedded Prometheus config, the receiver exposes only three extra top-level keys: `trim_metric_suffixes` (restore OTel-style metric names), `target_allocator` (fetch dynamically-assigned targets from the OpenTelemetry Operator's Target Allocator), and `api_server` (host a local Prometheus agent-mode debug API). Scraped `target_info`/`otel_scope_*` series are consumed to populate the OTel Resource and Instrumentation Scope, and native histograms are auto-converted to OTel exponential histograms.
+Beyond the embedded Prometheus config, the receiver exposes a handful of extra top-level keys: `trim_metric_suffixes` (restore OTel-style metric names), `target_allocator` (fetch dynamically-assigned targets from the OpenTelemetry Operator's Target Allocator), `api_server` (host a local Prometheus agent-mode debug API), and three start-up/shutdown scrape tuning knobs added in v0.155.0 (`scrape_on_shutdown`, `discovery_reload_on_startup`, `initial_scrape_offset`). Scraped `target_info`/`otel_scope_*` series are consumed to populate the OTel Resource and Instrumentation Scope, and native histograms are auto-converted to OTel exponential histograms.
 
 The two facts that catch people out: the receiver is **stateful and does not auto-shard** — running multiple replicas with the same config scrapes every target multiple times (duplicate metrics); use the Target Allocator or manual sharding instead. And the `$` character in the Prometheus config is interpreted by the Collector as an environment variable, so a literal `$` (in a relabel regex or replacement) must be escaped as `$$`. See [quirks.md](quirks.md).
 
@@ -39,7 +39,7 @@ Avoid when:
 
 ## Details
 
-- [Configuration](configuration.md) — the four top-level keys (`config`, `trim_metric_suffixes`, `target_allocator`, `api_server`), every validation rule, scrape protocols, and representative `scrape_config` examples.
+- [Configuration](configuration.md) — every top-level key (`config`, `trim_metric_suffixes`, `target_allocator`, `api_server`, plus the v0.155.0 `scrape_on_shutdown` / `discovery_reload_on_startup` / `initial_scrape_offset` knobs), every validation rule, scrape protocols, and representative `scrape_config` examples.
 - [Verification](verification.md) — a self-scrape recipe (the collector scrapes its own `:8888` telemetry endpoint → `debug`), verified on contrib v0.154.0. Notes why `telemetrygen` cannot drive this receiver.
 - [Advanced use-cases](advanced.md) — named instances, the Target Allocator, native histograms, the `api_server`, relabeling, and `scrape_config_files`.
 - [Known quirks](quirks.md) — the no-auto-shard/duplicate-scrape warning, `$$` escaping, the `collector_id` `${...}` trap, removed `use_start_time_metric`, rejected server features, and stability.

--- a/skills/otel-collector/components/prometheus/advanced.md
+++ b/skills/otel-collector/components/prometheus/advanced.md
@@ -51,8 +51,9 @@ replicas — it shards targets across the collectors rather than every replica s
 ## Native histograms
 
 The receiver auto-converts scraped Prometheus native histograms to OTel exponential histograms.
-The `receiver.prometheusreceiver.EnableNativeHistograms` feature gate is **stable / always enabled**,
-but you still need **two** things in the Prometheus scrape config:
+This is now unconditional — the old `receiver.prometheusreceiver.EnableNativeHistograms` gate
+graduated to stable and has been removed, so there is no gate to toggle. You still need **two**
+things in the Prometheus scrape config:
 
 1. `scrape_native_histograms: true` (globally under `global`, or per-job)
 2. `PrometheusProto` included in `scrape_protocols` (required until Prometheus supports native histograms over text formats)
@@ -83,8 +84,11 @@ receivers:
     api_server:
       enabled: true
       server_config:
-        endpoint: "localhost:9090"
+        endpoint: "localhost:9090"   # defaults to 127.0.0.1:9090 if omitted
 ```
+
+`server_config` is the standard confighttp server config (defaults: endpoint `127.0.0.1:9090`,
+`read_timeout: 10m`), and `max_connections` (default `512`) caps simultaneous HTTP connections.
 
 Endpoints mirror the Prometheus agent-mode API:
 
@@ -134,5 +138,5 @@ receivers:
 
 ## Feature gates
 
-- `receiver.prometheusreceiver.EnableCreatedTimestampZeroIngestion` (alpha, off by default, from v0.113.0) — injects created-timestamps as 0-valued samples. Off by default due to higher CPU cost at high metric volume.
-- `receiver.prometheusreceiver.IgnoreScopeInfoMetric` (from v0.148.0) — ignore `otel_scope_info` for scope attribute extraction. Promoted to **beta (on by default) in v0.156.0**; disable with `--feature-gates=-receiver.prometheusreceiver.IgnoreScopeInfoMetric` to restore the old behavior.
+- `receiver.prometheusreceiver.EnableCreatedTimestampZeroIngestion` (from v0.113.0) — **alpha, off by default**. Injects created-timestamps as 0-valued samples. Off by default due to higher CPU cost at high metric volume.
+- `receiver.prometheusreceiver.IgnoreScopeInfoMetric` (from v0.148.0) — **beta, on by default since v0.156.0**. The `otel_scope_info` metric is now ignored for scope-attribute extraction by default; scope attributes come from `otel_scope_<name>` labels. To temporarily restore the old behavior, disable it with `--feature-gates=-receiver.prometheusreceiver.IgnoreScopeInfoMetric`.

--- a/skills/otel-collector/components/prometheus/configuration.md
+++ b/skills/otel-collector/components/prometheus/configuration.md
@@ -32,6 +32,9 @@ documented in the upstream [Prometheus configuration reference][promcfg]; it is 
 | `trim_metric_suffixes` | bool | `false` | [**Experimental**] Trims unit and counter-type suffixes from metric names, e.g. `singing_duration_seconds_total` → `singing_duration`. Useful to restore OpenTelemetry-style names. |
 | `target_allocator` | object | — | Optional. Client config to fetch dynamically-assigned scrape targets from the OpenTelemetry Operator's Target Allocator. See table below and [advanced.md](advanced.md). |
 | `api_server` | object | — | Optional. Hosts a local Prometheus agent-mode API server for debugging. See table below and [advanced.md](advanced.md). |
+| `scrape_on_shutdown` | bool | `false` | Perform one final scrape before the receiver closes. This last scrape ignores the configured scrape interval. (v0.155.0) |
+| `discovery_reload_on_startup` | bool | `false` | Discover targets immediately on start-up instead of waiting for the configured interval before initializing the scrape pools. (v0.155.0) |
+| `initial_scrape_offset` | duration | `0s` | Fixed delay added before the initial scrape of targets, on top of the receiver's internal load-balancing offset. Avoids readiness races and backend rate-limits right after start-up. (v0.155.0) |
 
 [promcfg]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/
 
@@ -56,7 +59,8 @@ The block squashes the Collector `confighttp` [client configuration][confighttp]
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
 | `enabled` | bool | `false` | Turn the debug API server on. |
-| `server_config` | `confighttp.ServerConfig` | — | Standard confighttp [server config][confighttp-server] (`endpoint`, `tls`, …). If `enabled: true`, `endpoint` must be non-empty. |
+| `max_connections` | int | `512` | Maximum number of simultaneous HTTP connections the server accepts. |
+| `server_config` | `confighttp.ServerConfig` | endpoint `127.0.0.1:9090`, `read_timeout: 10m` | Standard confighttp [server config][confighttp-server] (`endpoint`, `tls`, CORS, timeouts). The endpoint is populated by default, so enabling the server does not require setting it. |
 
 [confighttp-server]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/README.md#server-configuration
 
@@ -66,7 +70,6 @@ The block squashes the Collector `confighttp` [client configuration][confighttp]
 |------|---------------|
 | At least one of `config.scrape_configs`, `config.scrape_config_files`, or `target_allocator` must be set. | `no Prometheus scrape_configs or target_allocator set` |
 | Prometheus server-only features are rejected: `remote_write`, `remote_read`, `rule_files`, `alert_config.relabel_configs`, `alert_config.alertmanagers`. | `unsupported features: …` (the offending features, one per line) |
-| If `api_server.enabled: true`, `server_config.endpoint` must be non-empty. | `invalid API server configuration settings: if api_server is enabled, it requires a non-empty server_config endpoint` |
 | `target_allocator.endpoint` must parse as a valid request URI. | `TargetAllocator endpoint is not valid: …` |
 | `target_allocator.collector_id` must be non-empty and must not contain `${`. | `CollectorID is not a valid ID` |
 | `target_allocator.interval` must be a positive duration. | `interval must be a positive duration, got …` |

--- a/skills/otel-collector/components/prometheus/configuration.md
+++ b/skills/otel-collector/components/prometheus/configuration.md
@@ -47,7 +47,7 @@ The block squashes the Collector `confighttp` [client configuration][confighttp]
 |-----|------|---------|-------|
 | `endpoint` | string | — | **Required.** Target Allocator URL. Must be a valid request URI. |
 | `interval` | duration | — | How often to refresh the target list. Must be a **positive** duration. |
-| `collector_id` | string | — | **Required.** Identifies this collector instance to the allocator. Must **not** contain `${` (see [quirks.md](quirks.md)). |
+| `collector_id` | string | — | **Required.** Identifies this collector instance to the allocator. Must be non-empty. A **literal** `${` is rejected, but `${ENV}` references are env-expanded by the Collector before validation (see [quirks.md](quirks.md)). |
 | `http_sd_config` | Prometheus HTTP SD config | — | HTTP service-discovery config used to fetch targets. |
 | `http_scrape_config` | Prometheus HTTP client config | — | HTTP client config applied when scraping the discovered targets. |
 | `tls`, `proxy_url`, … | (from `confighttp.ClientConfig`) | — | Standard confighttp client options. |

--- a/skills/otel-collector/components/prometheus/quirks.md
+++ b/skills/otel-collector/components/prometheus/quirks.md
@@ -19,13 +19,19 @@ The Collector interprets `$` in config as an environment-variable reference. To 
 `$$`. An unescaped `$foo` will be substituted (or blanked) at config load, silently breaking the
 relabel rule.
 
-## `collector_id: collector-${HOSTNAME}` is invalid
+## `collector_id: collector-${HOSTNAME}` — expanded, not rejected
 
 You may see examples using a templated `collector_id` like `collector-${HOSTNAME}` for the Target
-Allocator. The receiver's validation **rejects** any `collector_id` containing `${`
-(`CollectorID is not a valid ID`). Use a literal id such as `collector-1`. If you need per-pod
-uniqueness, set it from the environment another way (e.g. inject it via the deployment template),
-not with `${...}` inside the Collector config.
+Allocator. Contrary to what the "must not contain `${`" rule suggests, the Collector's own
+environment-variable substitution expands `${HOSTNAME}` **before** the receiver validates the
+config, so `collector-${HOSTNAME}` becomes `collector-<hostname>` and validates fine — this is
+actually a working way to get per-pod uniqueness when `HOSTNAME` is set (as it is in Kubernetes
+pods). If `HOSTNAME` is unset the value silently collapses to `collector-`.
+
+The `CollectorID is not a valid ID` validation error fires only when a **literal** `${` reaches the
+receiver — i.e. when you escape it as `$${...}` (the same `$$` escaping used for literal `$` in
+relabel rules) so it survives env-substitution. So the real trap is over-escaping: `$${HOSTNAME}`
+is rejected, plain `${HOSTNAME}` is not. An empty `collector_id` is also rejected.
 
 ## `use_start_time_metric` / `start_time_metric_regex` were removed
 
@@ -62,7 +68,7 @@ preserving the older lenient behavior. If you scrape native histograms you must 
 | `no Prometheus scrape_configs or target_allocator set` | Neither inline `scrape_configs`, nor `scrape_config_files`, nor `target_allocator` provided. | Add at least one scrape source. |
 | `unsupported features: …` | A Prometheus server-only section is present under `config:`. | Remove `remote_write`/`remote_read`/`rule_files`/`alert_config.*`. |
 | `TargetAllocator endpoint is not valid: …` | `target_allocator.endpoint` is not a valid request URI. | Use a full URL like `http://my-ta-service`. |
-| `CollectorID is not a valid ID` | `collector_id` is empty or contains `${`. | Use a literal id (e.g. `collector-1`). |
+| `CollectorID is not a valid ID` | `collector_id` is empty, or a **literal** `${` reached the receiver (e.g. escaped as `$${`). Plain `${ENV}` is env-expanded before validation and does not trigger this. | Use a literal id (e.g. `collector-1`), or a `${ENV}` that expands to a valid id. |
 | `interval must be a positive duration, got …` | `target_allocator.interval` is zero/negative/unset. | Set a positive duration (e.g. `30s`). |
 | Empty/blanked relabel replacement | Unescaped `$` was treated as an env var. | Escape literal `$` as `$$`. |
 

--- a/skills/otel-collector/components/prometheus/quirks.md
+++ b/skills/otel-collector/components/prometheus/quirks.md
@@ -61,7 +61,6 @@ preserving the older lenient behavior. If you scrape native histograms you must 
 |-------|-------|-----|
 | `no Prometheus scrape_configs or target_allocator set` | Neither inline `scrape_configs`, nor `scrape_config_files`, nor `target_allocator` provided. | Add at least one scrape source. |
 | `unsupported features: …` | A Prometheus server-only section is present under `config:`. | Remove `remote_write`/`remote_read`/`rule_files`/`alert_config.*`. |
-| `invalid API server configuration settings: if api_server is enabled, it requires a non-empty server_config endpoint` | `api_server.enabled: true` without `server_config.endpoint`. | Set `server_config.endpoint`. |
 | `TargetAllocator endpoint is not valid: …` | `target_allocator.endpoint` is not a valid request URI. | Use a full URL like `http://my-ta-service`. |
 | `CollectorID is not a valid ID` | `collector_id` is empty or contains `${`. | Use a literal id (e.g. `collector-1`). |
 | `interval must be a positive duration, got …` | `target_allocator.interval` is zero/negative/unset. | Set a positive duration (e.g. `30s`). |


### PR DESCRIPTION
## Summary

Deep audit against the released v0.156.0 tag:

- **Net-new keys**: `scrape_on_shutdown`, `discovery_reload_on_startup`, `initial_scrape_offset` (v0.155.0, #48979) and `api_server.max_connections` (default 512); `api_server.server_config` defaults corrected (`127.0.0.1:9090`, `read_timeout: 10m`).
- **Fabricated validation removed**: the claimed `invalid API server configuration settings` rule/error string doesn't exist in v0.156.0 (`git grep` confirms) — validation is just `NetAddr.Validate()` with a populated default endpoint.
- **Gate fixes**: `IgnoreScopeInfoMetric` is beta/on since v0.156.0 (#47312); `EnableNativeHistograms` was removed after graduating stable — native histograms are unconditional.
- README's "three/four extra top-level keys" undercounts fixed.

## Verified unchanged

Beta/metrics stability, rejected server features + error string, all three `target_allocator` validation rules, `fallback_scrape_protocol` default, `target_info`/scope mapping, `$$` escaping. Verification recipe stays honestly stamped at its actual 0.154.0 run.

## Index note

SKILL.md's prometheus row is accurate but doesn't list the three new keys — queued for the collected index PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK