### PR TITLE
docs(otel-collector): bump resource_detection defaults stamp to v0.156.0

### DIFF
--- a/skills/otel-collector/components/resource_detection/configuration.md
+++ b/skills/otel-collector/components/resource_detection/configuration.md
@@ -11,7 +11,7 @@
 
 The component embeds the standard `confighttp.ClientConfig`, so other HTTP client knobs (proxy, TLS, headers) are available for the metadata-service detectors; `timeout` is the one you will usually touch.
 
-> Defaults verified against `factory.go` (`createDefaultConfig`) and `config.go` on contrib v0.154.0: `Detectors: [env]`, `Override: true`, `RefreshInterval: 0`, client `Timeout: 5s`.
+> Defaults verified against `factory.go` (`createDefaultConfig`) and `config.go` on contrib v0.156.0: `Detectors: [env]`, `Override: true`, `RefreshInterval: 0`, client `Timeout: 5s`.
 
 ## Per-detector configuration
 


### PR DESCRIPTION
## Summary

Deep audit against the released v0.156.0 tag found the page fully accurate — all 30 detector names match the registered factories exactly (no fabrications, none missing), every per-detector config block verified in the respective `config.go`, the `fail_on_missing_metadata` six-detector list matches, and the system detector's default-attribute claim holds. Only change: the source-verified defaults stamp bumped v0.154.0 → v0.156.0.

Window changes (docker lookup bugfix, `k8s.cluster.uid` on k8s_api, GCP Cloud Run Worker Pools) are all covered by the page's existing non-enumerating entries.

Verification-run stamps stay at their actual 0.154.0 execution rather than fabricating a rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK