### PR TITLE
docs(otel-collector): add file_storage max_size key (v0.156.0)

### DIFF
--- a/skills/otel-collector/components/file_storage/advanced.md
+++ b/skills/otel-collector/components/file_storage/advanced.md
@@ -80,6 +80,8 @@ allocated MiB
 
 Raise the thresholds if your steady-state working set is large (so normal operation never trips compaction); lower them if you want space reclaimed more eagerly after smaller spikes. `compaction.max_transaction_size` (default `65536`) bounds how many items move per compaction transaction.
 
+To hard-cap growth instead of just reclaiming after the fact, set `max_size` (bytes, default `0` = unlimited). It bounds **each** per-consumer bbolt file: once a file is at the cap, a write that needs to grow it is rejected with a storage-full error (writes that fit existing free space still succeed), so a runaway persistent queue can't fill the disk. If you also enable `on_rebound`, both rebound thresholds (×1,048,576) must be ≤ `max_size` or validation fails — see [quirks.md](quirks.md).
+
 ## `create_directory` / `directory_permissions` for ephemeral and container environments
 
 In containers or fresh hosts the data directory often does not exist yet. Rather than pre-creating it in an init step, let the extension do it:

--- a/skills/otel-collector/components/file_storage/advanced.md
+++ b/skills/otel-collector/components/file_storage/advanced.md
@@ -9,6 +9,10 @@ extensions:
   file_storage:
     directory: /var/lib/otelcol/storage
     create_directory: true
+receivers:
+  otlp:
+    protocols:
+      grpc:
 exporters:
   otlp:
     endpoint: backend:4317

--- a/skills/otel-collector/components/file_storage/advanced.md
+++ b/skills/otel-collector/components/file_storage/advanced.md
@@ -84,7 +84,7 @@ allocated MiB
 
 Raise the thresholds if your steady-state working set is large (so normal operation never trips compaction); lower them if you want space reclaimed more eagerly after smaller spikes. `compaction.max_transaction_size` (default `65536`) bounds how many items move per compaction transaction.
 
-To hard-cap growth instead of just reclaiming after the fact, set `max_size` (bytes, default `0` = unlimited). It bounds **each** per-consumer bbolt file: once a file is at the cap, a write that needs to grow it is rejected with a storage-full error (writes that fit existing free space still succeed), so a runaway persistent queue can't fill the disk. If you also enable `on_rebound`, both rebound thresholds (×1,048,576) must be ≤ `max_size` or validation fails — see [quirks.md](quirks.md).
+To hard-cap growth instead of just reclaiming after the fact, set `max_size` (bytes, default `0` = unlimited). It bounds **each** per-consumer bbolt file: once a file is at the cap, a write that needs to grow it is rejected with a storage-full error (writes that fit existing free space still succeed), so a runaway persistent queue can't fill the disk. If you also enable `on_rebound`, both rebound thresholds (×1,048,576) must be ≤ `max_size` or validation fails — see [quirks.md](quirks.md). In practice keep `rebound_needed_threshold_mib × 1,048,576` strictly **below** `max_size`: the "needed" flag only arms once allocation *exceeds* the threshold, and allocation can never exceed `max_size`, so a threshold exactly at the cap validates but can never fire.
 
 ## `create_directory` / `directory_permissions` for ephemeral and container environments
 

--- a/skills/otel-collector/components/file_storage/configuration.md
+++ b/skills/otel-collector/components/file_storage/configuration.md
@@ -1,6 +1,6 @@
 # `file_storage`: configuration
 
-All keys live under the extension instance (e.g. `extensions: { file_storage: { … } }`), and the extension must be listed under `service.extensions:` to load. Facts below are traced to the `v0.154.0` contrib source (`config.go`, `factory.go`, `default_others.go`).
+All keys live under the extension instance (e.g. `extensions: { file_storage: { … } }`), and the extension must be listed under `service.extensions:` to load. Facts below are traced to the `v0.156.0` contrib source (`config.go`, `factory.go`, `default_others.go`).
 
 ## Top-level keys
 
@@ -8,6 +8,7 @@ All keys live under the extension instance (e.g. `extensions: { file_storage: { 
 |-----|------|---------|---------|
 | `directory` | string | `/var/lib/otelcol/file_storage` (non-Windows) / `%ProgramData%\Otelcol\FileStorage` (Windows) | Dedicated data directory holding the per-consumer bbolt files. **Must already exist** unless `create_directory: true`. |
 | `timeout` | duration | `1s` | Max time to wait for a file lock before failing the operation. Rarely needs changing. |
+| `max_size` | int (bytes) | `0` | Max on-disk size of **each** per-consumer bbolt file, in bytes. A write that would grow the file past this is rejected with a storage-full error; writes that fit in already-allocated free space still succeed. `0` means unlimited. **Must be ≥ 0** and not exceed `math.MaxInt`. Added in v0.156.0. |
 | `fsync` | bool | `false` | When `true`, force an `fsync` after each DB write (integrity over performance; flips bbolt's `DB.NoSync`). |
 | `create_directory` | bool | `false` | When `true`, create the data (and compaction) directory if missing instead of failing validation. |
 | `directory_permissions` | string (octal) | `"0750"` (rwxr-x---) | Permissions used when creating directories, minus the process umask. Only relevant when `create_directory: true`. |
@@ -31,6 +32,8 @@ bbolt is mmap-backed: when usage spikes, the file's allocated size grows and doe
 | `compaction.cleanup_on_start` | bool | `false` | Remove leftover `tempdb*` files from the compaction directory at start (left behind if a prior process was killed mid-compaction). |
 
 **Rebound (online) compaction** reclaims space after a transient spike drains: the flag arms only once allocated size has exceeded `rebound_needed_threshold_mib`, then compaction fires when usage drops back below `rebound_trigger_threshold_mib`. See [advanced.md](advanced.md) for tuning.
+
+When `max_size` is set (> 0) **and** `on_rebound: true`, both rebound thresholds (converted MiB → bytes, i.e. ×1,048,576) must be ≤ `max_size`, or validation fails — otherwise the rebound machinery could never fire within the cap. See the validation table in [quirks.md](quirks.md).
 
 ## Per-consumer files and naming
 

--- a/skills/otel-collector/components/file_storage/quirks.md
+++ b/skills/otel-collector/components/file_storage/quirks.md
@@ -13,6 +13,10 @@ All from `config.go` `Validate()`:
 | `directory` (or `compaction.directory` when `on_start`/`on_rebound` is set) does not exist, and `create_directory: false` | `directory must exist: … You can enable the create_directory option to automatically create it` | Create the dir, or set `create_directory: true`. |
 | Path exists but is not a directory | `<path> is not a directory` | Point `directory` at an actual directory. |
 | `compaction.max_transaction_size` < 0 | `max transaction size for compaction cannot be less than 0` | Use `0` (ignore sizes) or a positive value. |
+| `max_size` < 0 | `max size cannot be less than 0` | Use `0` (unlimited) or a positive byte count. |
+| `max_size` > `math.MaxInt` | `max size is too large` | Keep `max_size` within `math.MaxInt` bytes. |
+| `max_size` > 0, `on_rebound: true`, `rebound_needed_threshold_mib` × 1,048,576 > `max_size` | `compaction rebound needed threshold cannot be greater than max size` | Lower `rebound_needed_threshold_mib` or raise `max_size`. |
+| `max_size` > 0, `on_rebound: true`, `rebound_trigger_threshold_mib` × 1,048,576 > `max_size` | `compaction rebound trigger threshold cannot be greater than max size` | Lower `rebound_trigger_threshold_mib` or raise `max_size`. |
 | `compaction.on_rebound: true` with `check_interval <= 0` | `compaction check interval must be positive when rebound compaction is set` | Set `compaction.check_interval` to a positive duration (default `5s`). |
 | `create_directory: true` with non-octal `directory_permissions` | `directory_permissions value must be a valid octal representation` | Use a valid octal string, e.g. `"0750"`. |
 | `directory_permissions` with bits outside `0777` | `directory_permissions contain invalid bits for file access` | Keep permissions within `0777` (file-access bits only). |


### PR DESCRIPTION
## Summary

Deep audit against the released v0.156.0 tag. One net-new released key was missing — `max_size` (PR #48580, v0.156.0):

- Configuration row (int bytes, default `0` = unlimited, caps each per-consumer bbolt file, ≥0 and ≤ MaxInt) plus the constraint that with `on_rebound: true` both rebound thresholds (×1,048,576) must fit under `max_size`.
- Four new `Validate()` error→fix rows in quirks.md, matching the exact source strings.
- A rebound-tuning paragraph in advanced.md (hard cap, storage-full rejection semantics).

## Verified unchanged

All existing defaults (`directory`, `timeout` 1s, `fsync` false, `directory_permissions` 0750, full compaction block), Beta stability, verification recipe (honestly kept at its actual 0.154.0 run — behavior identical), SKILL.md index row (accurate, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the new `max_size` setting for file storage, including its default, limits, and storage-full behavior.
  * Added guidance on how `max_size` interacts with rebound compaction settings.
  * Expanded validation guidance with examples for invalid size and compaction configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->