### PR TITLE
docs(otel-collector): add memory_limiter GC backoff caps and health reporting

### DIFF
--- a/skills/otel-collector/components/memory_limiter/README.md
+++ b/skills/otel-collector/components/memory_limiter/README.md
@@ -11,7 +11,7 @@
 
 ## Description
 
-A safety valve that keeps the Collector from being OOM-killed. A background goroutine reads Go heap allocation (`runtime.MemStats.Alloc`) every `check_interval` and compares it against two thresholds derived from the configured limit: a **soft limit** (`limit_mib - spike_limit_mib`) and a **hard limit** (`limit_mib`). Above the soft limit the processor sets a `mustRefuse` flag and every data path returns a **non-permanent** `ErrDataRefused` to the preceding component — backpressure that well-behaved receivers retry with backoff. Above the hard limit it additionally forces a `runtime.GC()`. When heap drops back below the soft limit it resumes normally; no manual intervention.
+A safety valve that keeps the Collector from being OOM-killed. A background goroutine reads Go heap allocation (`runtime.MemStats.Alloc`) every `check_interval` and compares it against two thresholds derived from the configured limit: a **soft limit** (`limit_mib - spike_limit_mib`) and a **hard limit** (`limit_mib`). Above the soft limit the processor sets a `mustRefuse` flag and every data path returns a **non-permanent** `ErrDataRefused` to the preceding component — backpressure that well-behaved receivers retry with backoff. Above the hard limit it additionally forces a `runtime.GC()` (with exponential backoff when a GC proves ineffective, capped by the `max_gc_interval_*` keys). It also reports its health via `componentstatus` — recoverable-error while refusing, OK once recovered. When heap drops back below the soft limit it resumes normally; no manual intervention.
 
 It measures **heap**, not process RSS — total process memory runs 50–100 MiB higher, so container limits should sit above `limit_mib`. The processor does not mutate data (`MutatesData: false`); it only accepts or refuses. It is a safety net, not a sizing or performance tool — a chronically undersized collector will simply refuse data constantly. Use it together with the `GOMEMLIMIT` environment variable so Go's GC paces toward the same target.
 
@@ -34,7 +34,7 @@ Avoid it when:
 
 ## Details
 
-- [Configuration](configuration.md) — full config table (`check_interval`, `limit_mib` vs `limit_percentage`, spike limits, GC intervals), validation rules, and the soft/hard-limit mechanism.
+- [Configuration](configuration.md) — full config table (`check_interval`, `limit_mib` vs `limit_percentage`, spike limits, min/max GC intervals), validation rules, and the soft/hard-limit mechanism with GC backoff.
 - [Verification](verification.md) — telemetrygen recipe that forces refusal with a deliberately tiny limit and shows `ErrDataRefused` in the logs.
 - [Advanced use-cases](advanced.md) — `GOMEMLIMIT` pairing, percentage mode for Kubernetes, spike sizing for bursty traffic, multi-pipeline singleton behavior.
 - [Known quirks](quirks.md) — heap-vs-RSS, required fields, `limit_percentage` cgroup detection, GC-interval ordering, the singleton checker, the experimental extension variant, stability caveats.

--- a/skills/otel-collector/components/memory_limiter/advanced.md
+++ b/skills/otel-collector/components/memory_limiter/advanced.md
@@ -67,15 +67,17 @@ service:
 
 ## Tuning the GC intervals
 
-The two `min_gc_interval_*` keys throttle forced GC so it does not pin the CPU when memory hovers near the limit. Keep the soft-limited interval `>=` the hard-limited one (the hard limit is more urgent, so it should GC at least as eagerly):
+Four keys shape forced GC so it does not pin the CPU when memory hovers near the limit. The `min_gc_interval_*` keys are the **floor** between forced GCs; the `max_gc_interval_*` keys **cap the exponential backoff** the processor applies when a GC reclaims `< 5%` of heap (memory pinned by live references — see [Known quirks](quirks.md)). Keep the soft-limited interval `>=` the hard-limited one on both pairs (the hard limit is more urgent, so it should GC at least as eagerly):
 
 ```yaml
 processors:
   memory_limiter:
     check_interval: 1s
     limit_mib: 4000
-    min_gc_interval_when_soft_limited: 10s   # default — opportunistic
+    min_gc_interval_when_soft_limited: 10s   # default — opportunistic floor
     min_gc_interval_when_hard_limited: 0s    # default — GC every over-hard-limit check
+    max_gc_interval_when_soft_limited: 30s   # default — backoff cap
+    max_gc_interval_when_hard_limited: 30s   # default — backoff cap
 ```
 
-Reach for these only if debug logs show `Forcing a GC` firing so often that CPU suffers; the defaults are right for most deployments.
+Reach for these only if debug logs show `Forcing a GC` firing so often that CPU suffers (raise the `min`), or the backoff messages (`Forced GC did not reclaim enough memory…`) show GC still burning CPU during a downstream outage (lower the `max`, or set it to `0` only if you want to keep GC pinned at the `min`). The defaults are right for most deployments.

--- a/skills/otel-collector/components/memory_limiter/configuration.md
+++ b/skills/otel-collector/components/memory_limiter/configuration.md
@@ -28,8 +28,10 @@ Hard limit 4000 MiB, soft limit 3200 MiB, checked every second. `memory_limiter`
 | `spike_limit_mib` | uint32 | 20% of `limit_mib` | Expected max heap increase between checks. Must be `< limit_mib`. Soft limit = `limit_mib - spike_limit_mib`. |
 | `limit_percentage` | uint32 | `0` | Hard limit as a percentage of total memory (`> 0`, `<= 100`). Used **only when `limit_mib` is unset/0**. On Linux reads the cgroup limit, falling back to `/proc/meminfo`; on non-Linux it reads total *system* memory (rarely a container limit). See [Known quirks](quirks.md). |
 | `spike_limit_percentage` | uint32 | 20% of `limit_percentage` | Spike as a percentage of total memory. Must be `< limit_percentage` and `<= 100`. Only used with `limit_percentage`. |
-| `min_gc_interval_when_soft_limited` | duration | `10s` | Minimum time between forced GCs while above the soft limit. Must be `>= min_gc_interval_when_hard_limited`. |
-| `min_gc_interval_when_hard_limited` | duration | `0s` | Minimum time between forced GCs while above the hard limit (`0s` = GC on every over-limit check). Should be `<=` the soft-limited interval. |
+| `min_gc_interval_when_soft_limited` | duration | `10s` | Minimum (floor) time between forced GCs while above the soft limit. Must be `>= min_gc_interval_when_hard_limited`. |
+| `min_gc_interval_when_hard_limited` | duration | `0s` | Minimum (floor) time between forced GCs while above the hard limit (`0s` = GC on every over-limit check). Should be `<=` the soft-limited interval. |
+| `max_gc_interval_when_soft_limited` | duration | `30s` | Caps the exponential backoff between forced GCs on the soft-limit path. When a forced GC reclaims `< 5%` of heap the interval doubles (from the min floor, or 95% of `check_interval`, whichever is larger) up to this cap, then resets once a GC is effective or heap drops. `0` disables backoff (GC stays at the min). Must be `>= min_gc_interval_when_soft_limited` unless `0`; and `>= max_gc_interval_when_hard_limited` when both caps are set. |
+| `max_gc_interval_when_hard_limited` | duration | `30s` | Same backoff mechanism for the hard-limit path. Must be `>= min_gc_interval_when_hard_limited` unless `0`. |
 
 One of `limit_mib` or `limit_percentage` is mandatory; `check_interval` is always mandatory.
 
@@ -40,10 +42,12 @@ The processor derives two thresholds and acts on the current heap allocation:
 | State | Threshold | Action |
 |-------|-----------|--------|
 | Below soft limit | heap `< limit - spike` | Normal operation; data accepted. |
-| Above soft limit | heap `>= limit - spike` | Refuse data (`ErrDataRefused`); opportunistic GC, throttled by `min_gc_interval_when_soft_limited`. Logs *"Memory usage is above soft limit. Refusing data."* |
-| Above hard limit | heap `>= limit` | Refuse data; aggressive GC, throttled by `min_gc_interval_when_hard_limited`. Logs *"Memory usage is above hard limit. Forcing a GC."* |
+| Above soft limit | heap `>= limit - spike` | Refuse data (`ErrDataRefused`); opportunistic GC throttled between `min_gc_interval_when_soft_limited` and `max_gc_interval_when_soft_limited`. Logs *"Memory usage is above soft limit. Refusing data."* |
+| Above hard limit | heap `>= limit` | Refuse data; aggressive GC throttled between `min_gc_interval_when_hard_limited` and `max_gc_interval_when_hard_limited`. Logs *"Memory usage is above hard limit. Forcing a GC."* |
 
-Refusal is a **non-permanent** error, so receivers retry with backoff and clients can rate-limit. Recovery is automatic: once heap falls below the soft limit it logs *"Memory usage back within limits. Resuming normal operation."*
+If a forced GC reclaims `< 5%` of heap (e.g. the memory is held by live references in exporter queues during a downstream outage), the processor treats it as ineffective and **exponentially backs off** the GC interval on that path — doubling up to the `max_gc_interval_*` cap — to avoid burning CPU on futile collections during recovery. The interval resets as soon as a GC frees memory or heap drops on its own.
+
+Refusal is a **non-permanent** error, so receivers retry with backoff and clients can rate-limit. Recovery is automatic: once heap falls below the soft limit it logs *"Memory usage back within limits. Resuming normal operation."* The processor also reports its health via `componentstatus` — a **recoverable-error** status while refusing, and `StatusOK` once back within limits — visible through status-aware extensions (e.g. `healthcheckv2`).
 
 ## Validation rules
 
@@ -54,7 +58,12 @@ Startup fails (config error) when:
 | `check_interval` not `> 0` | `'check_interval' must be greater than zero` |
 | Neither limit set | `'limit_mib' or 'limit_percentage' must be greater than zero` |
 | `spike_limit_mib >= limit_mib` | `'spike_limit_mib' must be smaller than 'limit_mib'` |
+| `spike_limit_percentage >= limit_percentage` (percentage mode) | `'spike_limit_percentage' must be smaller than 'limit_percentage'` |
+| `limit_percentage > 100` or `spike_limit_percentage > 100` | `'limit_percentage' and 'spike_limit_percentage' must be greater than zero and less than or equal to hundred` |
 | `min_gc_interval_when_soft_limited < min_gc_interval_when_hard_limited` | `'min_gc_interval_when_soft_limited' should be larger than 'min_gc_interval_when_hard_limited'` |
+| `max_gc_interval_when_soft_limited` set but `< min_gc_interval_when_soft_limited` | `'max_gc_interval_when_soft_limited' must be greater than or equal to 'min_gc_interval_when_soft_limited' (or 0 to disable)` |
+| `max_gc_interval_when_hard_limited` set but `< min_gc_interval_when_hard_limited` | `'max_gc_interval_when_hard_limited' must be greater than or equal to 'min_gc_interval_when_hard_limited' (or 0 to disable)` |
+| both max caps set and `max_gc_interval_when_soft_limited < max_gc_interval_when_hard_limited` | `'max_gc_interval_when_soft_limited' should be larger than or equal to 'max_gc_interval_when_hard_limited' (when both are set)` |
 
 ## Pipeline placement
 

--- a/skills/otel-collector/components/memory_limiter/quirks.md
+++ b/skills/otel-collector/components/memory_limiter/quirks.md
@@ -62,12 +62,12 @@ receivers:
   otlp:
     protocols:
       grpc:
-        middlewares: [memory_limiter]
+        middlewares: [{id: memory_limiter}]
 service:
   extensions: [memory_limiter]
 ```
 
-It is **experimental** — use the processor form for production.
+It is **experimental** — use the processor form for production. Note: the extension is **not compiled into the stock `otelcol-contrib` distribution** (verified on v0.156.0, which rejects it with `'extensions' unknown type: "memory_limiter"`); it requires a custom build.
 
 ## Stability caveats
 

--- a/skills/otel-collector/components/memory_limiter/quirks.md
+++ b/skills/otel-collector/components/memory_limiter/quirks.md
@@ -23,7 +23,15 @@ If both are set, `limit_mib` is used and `limit_percentage` is ignored — silen
 
 ## GC-interval ordering is enforced
 
-`min_gc_interval_when_soft_limited` must be `>=` `min_gc_interval_when_hard_limited` (the hard limit is more urgent, so it cannot GC *less* often). Inverting them fails startup with `'min_gc_interval_when_soft_limited' should be larger than 'min_gc_interval_when_hard_limited'`.
+`min_gc_interval_when_soft_limited` must be `>=` `min_gc_interval_when_hard_limited` (the hard limit is more urgent, so it cannot GC *less* often). Inverting them fails startup with `'min_gc_interval_when_soft_limited' should be larger than 'min_gc_interval_when_hard_limited'`. The same ordering holds for the `max_gc_interval_*` caps when both are set, and each `max` (unless `0`) must be `>=` its own `min` — see the [validation rules](configuration.md#validation-rules).
+
+## GC backs off when it stops helping
+
+Since v0.156.0, forced GC no longer fires unconditionally on every over-limit check. When a GC reclaims `< 5%` of heap — typically because the memory is pinned by live references such as exporter sending queues during a downstream outage — the processor treats it as ineffective and **doubles** the interval before the next forced GC, up to `max_gc_interval_when_soft_limited` / `max_gc_interval_when_hard_limited` (both default `30s`). This prevents a CPU-burning GC loop that would starve recovery. The interval resets the moment a GC frees memory or heap drops. Set the relevant `max_gc_interval_*` to `0` to opt out and keep GC pinned at the `min` interval.
+
+## It reports component health
+
+Since v0.156.0 the processor publishes health events via `componentstatus.ReportStatus`: a **recoverable-error** event while it is refusing data and `StatusOK` once heap is back within limits. Status-aware extensions (e.g. `healthcheckv2`) surface this, so a collector under memory pressure can report unhealthy without you scraping logs or refusal metrics.
 
 ## `limit_percentage` needs cgroups to be useful
 
@@ -31,7 +39,7 @@ Percentage mode reads the container's memory limit from cgroups v2 (`/sys/fs/cgr
 
 ## It is a safety net, not a sizing tool
 
-The limiter does not make a small collector handle more load — below capacity it simply **refuses data constantly** (refusal metrics, persistent *"Refusing data"* logs, receivers seeing backpressure). Memory-limiter metric names have changed across Collector releases, so check the exact Collector version before writing alerts. The fix is to size the collector for the workload or scale out, then keep `memory_limiter` as the backstop. Treat sustained refusal as an under-provisioning signal, not a tuning problem.
+The limiter does not make a small collector handle more load — below capacity it simply **refuses data constantly** (refusal metrics, persistent *"Refusing data"* logs, receivers seeing backpressure). Memory-limiter metric names have changed across Collector releases — v0.156.0 renamed them to a component-specific prefix (`otelcol_processor_memory_limiter_accepted_*` / `otelcol_processor_memory_limiter_refused_*`) — so check the exact Collector version before writing alerts. The fix is to size the collector for the workload or scale out, then keep `memory_limiter` as the backstop. Treat sustained refusal as an under-provisioning signal, not a tuning problem.
 
 ## Refusal is non-permanent — receivers must retry
 


### PR DESCRIPTION
## Summary

Deep audit against the core `processor/memorylimiterprocessor/v0.156.0` tag (= v1.62.0/v0.156.0). The v0.156.0 net-new surface the earlier shallow sweep deliberately skipped is now covered:

- **`max_gc_interval_when_soft_limited` / `max_gc_interval_when_hard_limited`** (both default `30s`, verified in `NewDefaultConfig`) — config rows, YAML examples, and the soft/hard action table.
- **Exponential GC backoff** documented: a GC reclaiming <5% of heap (`gcEffectivenessThreshold = 5`) doubles the interval up to the cap.
- **Component-health reporting**: recoverable-error status while refusing, `StatusOK` on recovery.
- **Four missing validation rules** added with verbatim error strings (both percentage-mode errors, both `max >= min` ordering rules).
- Metrics-rename note sharpened to `otelcol_processor_memory_limiter_accepted_*`/`_refused_*`.

## Verified unchanged

All pre-existing keys/defaults (no fabrications; the `min_gc_interval_*` keys are absent from upstream's README but real in `config.go` — an upstream doc gap, kept), refuse-vs-drop semantics, heap-vs-RSS, cgroup detection, SKILL.md index row (accurate, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK