### PR TITLE
docs(otel-collector): otlp receiver v1.62.0 corrections

### DIFF
--- a/skills/otel-collector/components/otlp/configuration.md
+++ b/skills/otel-collector/components/otlp/configuration.md
@@ -1,6 +1,6 @@
 # `otlp` receiver: configuration
 
-All keys live under the receiver instance (`receivers: { otlp: { … } }`). The only top-level key is `protocols:`, which holds two optional sub-blocks. Facts below trace to the core **v1.60.0** source (`receiver/otlpreceiver/config.go`, `config/configgrpc/configgrpc.go` `ServerConfig`, `config/confighttp/server.go` `ServerConfig`, and `config/configtls`).
+All keys live under the receiver instance (`receivers: { otlp: { … } }`). The only top-level key is `protocols:`, which holds two optional sub-blocks. Facts below trace to the core **v1.62.0 / v0.156.0** source (`receiver/otlpreceiver/config.go`, `config/configgrpc/configgrpc.go` `ServerConfig`, `config/confighttp/server.go` `ServerConfig`, and `config/configtls`).
 
 ## Top-level
 
@@ -32,7 +32,7 @@ enables both at their defaults. Listing only `grpc:` disables HTTP, and vice ver
 | Key | Type | Default | Meaning |
 |-----|------|---------|---------|
 | `endpoint` | string | `localhost:4317` | Listen address. Set `0.0.0.0:4317` to accept non-loopback traffic. |
-| `transport` | string | `tcp` | Socket type: `tcp`, `tcp4`, `tcp6`, `udp`, `unix`, … |
+| `transport` | string | `tcp` | Socket type. gRPC servers accept only `tcp` or `unix`. |
 | `tls` | object | — (plaintext) | Server TLS (see [TLS](#tls-server)). |
 | `max_recv_msg_size_mib` | int | 4 (gRPC default) | Max received message size, in MiB. Raise for large batches. |
 | `max_concurrent_streams` | uint32 | 0 (unlimited) | Max concurrent HTTP/2 streams per connection. |
@@ -79,7 +79,7 @@ enables both at their defaults. Listing only `grpc:` disables HTTP, and vice ver
 | `keep_alives_enabled` | bool | `true` | Whether to allow HTTP keep-alives. |
 | `middlewares` | list | — | HTTP server middleware extensions. |
 
-There is **no profiles URL-path field** — the HTTP config exposes only traces/metrics/logs paths.
+There is **no profiles URL-path field** — the HTTP config exposes only traces/metrics/logs override keys. Profiles (Alpha) are still served over HTTP, but on a fixed, non-configurable path: `/v1development/profiles`.
 
 The HTTP endpoint accepts both **OTLP/protobuf** and **OTLP/JSON** on the same paths; the encoding is selected by `Content-Type`.
 
@@ -89,6 +89,7 @@ The HTTP endpoint accepts both **OTLP/protobuf** and **OTLP/JSON** on the same p
 |-----|------|---------|
 | `allowed_origins` | list of string | Origins permitted to make cross-origin OTLP requests (e.g. browser RUM). |
 | `allowed_headers` | list of string | Additional request headers allowed cross-origin. |
+| `exposed_headers` | list of string | Response headers browsers may expose to the caller (`Access-Control-Expose-Headers`). |
 | `max_age` | int | Seconds browsers may cache the CORS preflight. |
 
 ## TLS (server)

--- a/skills/otel-collector/components/otlp/quirks.md
+++ b/skills/otel-collector/components/otlp/quirks.md
@@ -34,10 +34,10 @@ The HTTP endpoint accepts both OTLP/protobuf and **OTLP/JSON** on the same paths
 
 Per-request headers/metadata are dropped unless `include_metadata: true`. Header-based auth extensions, metadata [`routing`](../routing/README.md), and [`load_balancing`](../load_balancing/README.md) keyed on client-metadata attributes all silently see no metadata without it. There is no error — the feature just behaves as if the headers weren't sent.
 
-## No profiles URL path
+## No configurable profiles URL path
 
-The HTTP config exposes `traces_url_path`, `metrics_url_path`, and `logs_url_path` only. There is no profiles URL-path override — profiles are **Alpha** stability.
+The HTTP config exposes `traces_url_path`, `metrics_url_path`, and `logs_url_path` overrides only. There is no `profiles_url_path` key — profiles (Alpha) are still served over HTTP, but on a fixed path the receiver hardcodes: `/v1development/profiles`. (Note: the upstream README mentions a `profiles_url_path` and a `/v1/profiles` default; neither exists in the config struct or the handler — the path is fixed.)
 
 ## Stability is per signal
 
-Traces, metrics, and logs are **Stable**; **profiles** are **Alpha**. Treat profile ingestion as experimental and subject to breaking change, even though the same receiver serves it.
+Traces, metrics, and logs are **Stable**; **profiles** are **Alpha**. Treat profile ingestion as still-evolving and subject to breaking change, even though the same receiver serves it.


### PR DESCRIPTION
## Summary

Deep audit against core tag v1.62.0/v0.156.0:

- **profiles → Alpha** in the page README signals row and prose (the component-page half of the promotion; the SKILL.md index cell is queued for the collected index PR).
- **gRPC `transport`**: only `tcp`/`unix` are valid for a gRPC server — the page listed the whole confignet enum.
- **Net-new**: CORS `exposed_headers` key.
- **Profiles path**: served over HTTP at the hardcoded `/v1development/profiles`; quirks now warn that upstream's README documents a nonexistent `profiles_url_path` field and a wrong `/v1/profiles` default (no such field in `HTTPConfig`; handler uses `defaultProfilesURLPath`).

## Verified unchanged

All gRPC keys/defaults (4 MiB recv, 512 KiB read buffer, keepalive sub-keys), HTTP keys/defaults (20 MiB body cap, zeroed timeouts, URL-path overrides), `compression_algorithms` incl. permanently-default `x-snappy-framed` (gate stabilized), the exact at-least-one-protocol validation string, TLS keys, all example YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK