### PR TITLE
docs(otel-collector): deep-refresh routing connector for v0.156.0

### DIFF
--- a/skills/otel-collector/components/routing/README.md
+++ b/skills/otel-collector/components/routing/README.md
@@ -13,7 +13,7 @@
 
 Routes telemetry to different pipelines based on OTTL conditions, keeping the **same signal type** (traces→traces, metrics→metrics, logs→logs) — it forwards data unchanged, it does not transform it. As a connector it is wired as the **exporter** of an input pipeline and the **receiver** of one or more output pipelines; the input pipeline hands its data to `routing`, which then dispatches it to the matching output pipelines.
 
-The decision is driven by an ordered `table` of routes, each an OTTL `condition` (or a `route() where …` `statement`) evaluated in a chosen `context` (resource/span/metric/datapoint/log/request). Routes are evaluated **in order** and each piece of telemetry matches **at most one route** — to fan out to several pipelines, list them all under that route's `pipelines`. Telemetry that matches no route goes to `default_pipelines`, or is **dropped** if none is set. This replaces the deprecated `routingprocessor`. The OTTL expression language itself lives in the `otel-ottl` skill; this page documents the connector's config surface.
+The decision is driven by an ordered `table` of routes, each an OTTL `condition` (or a `route() where …` `statement`) evaluated in a `context`. Since v0.156.0 the context is **inferred** from context-qualified paths (`resource.attributes[...]`, `span.…`, `log.…`, `metric.…`, `datapoint.…`, `otelcol.…`), so the `context` field is usually omitted; the deprecated `request` context is the exception. Routes are evaluated **in order** and, under the default `action: move`, each piece of telemetry matches **at most one route** — to fan out to several pipelines, list them all under that route's `pipelines`, or use `action: copy` to keep matched data available to later routes. Telemetry that matches no route goes to `default_pipelines`, or is **dropped** if none is set. This replaces the deprecated `routingprocessor`. The OTTL expression language itself lives in the `otel-ottl` skill; this page documents the connector's config surface.
 
 ## Main use-cases
 
@@ -37,7 +37,7 @@ Avoid when:
 
 ## Details
 
-- [Configuration](configuration.md) — full config tables for top-level keys and `table` items, supported contexts per signal, statement-vs-condition rules, `error_mode` semantics, and the connector pipeline wiring.
+- [Configuration](configuration.md) — full config tables for top-level keys and `table` items, context inference, supported contexts per signal, `otelcol.*` request-metadata routing, statement-vs-condition rules, `error_mode` semantics, and the connector pipeline wiring.
 - [Verification](verification.md) — telemetrygen recipe that splits telemetry across two pipelines, each writing to its own `file` exporter, proving routing and the default fallback.
-- [Advanced use-cases](advanced.md) — named instances, fan-out, multi-tenant request routing, severity/environment routing, `action: move` vs `copy`, and migrating from `routingprocessor` / the removed `match_once`.
-- [Known quirks](quirks.md) — dropped unmatched data, `error_mode` data loss, mutual exclusivity, request-context grammar limits, split Resource bundles, a validation-error→fix table, and stability caveats.
+- [Advanced use-cases](advanced.md) — named instances, fan-out, multi-tenant `otelcol.*` routing, severity/environment routing, `action: copy` vs the default `move`, and migrating from `routingprocessor` / the removed `match_once`.
+- [Known quirks](quirks.md) — dropped unmatched data, `error_mode` data loss, `move`-vs-`copy` defaults, mutual exclusivity, the deprecated `request` context, split Resource bundles, a validation-error→fix table, and stability caveats.

--- a/skills/otel-collector/components/routing/README.md
+++ b/skills/otel-collector/components/routing/README.md
@@ -13,7 +13,7 @@
 
 Routes telemetry to different pipelines based on OTTL conditions, keeping the **same signal type** (traces→traces, metrics→metrics, logs→logs) — it forwards data unchanged, it does not transform it. As a connector it is wired as the **exporter** of an input pipeline and the **receiver** of one or more output pipelines; the input pipeline hands its data to `routing`, which then dispatches it to the matching output pipelines.
 
-The decision is driven by an ordered `table` of routes, each an OTTL `condition` (or a `route() where …` `statement`) evaluated in a `context`. Since v0.156.0 the context is **inferred** from context-qualified paths (`resource.attributes[...]`, `span.…`, `log.…`, `metric.…`, `datapoint.…`, `otelcol.…`), so the `context` field is usually omitted; the deprecated `request` context is the exception. Routes are evaluated **in order** and, under the default `action: move`, each piece of telemetry matches **at most one route** — to fan out to several pipelines, list them all under that route's `pipelines`, or use `action: copy` to keep matched data available to later routes. Telemetry that matches no route goes to `default_pipelines`, or is **dropped** if none is set. This replaces the deprecated `routingprocessor`. The OTTL expression language itself lives in the `otel-ottl` skill; this page documents the connector's config surface.
+The decision is driven by an ordered `table` of routes, each an OTTL `condition` (or a `route() where …` `statement`) evaluated in a `context`. Since v0.156.0 the context is **inferred** from context-qualified paths (`resource.attributes[...]`, `span.…`, `log.…`, `metric.…`, `datapoint.…`, `otelcol.…`), so the `context` field is usually omitted; the deprecated `request` context is the exception. Routes are evaluated **in order** and, under the default `action: move`, each piece of telemetry matches **at most one route** — to fan out to several pipelines, list them all under that route's `pipelines`, or use `action: copy` to keep matched data available to later routes. Telemetry that matches no route goes to `default_pipelines`, or is **dropped** if none is set. This replaces the `routingprocessor`, which has since been removed from contrib. The OTTL expression language itself lives in the `otel-ottl` skill; this page documents the connector's config surface.
 
 ## Main use-cases
 
@@ -33,7 +33,7 @@ Avoid when:
 - `filter` — drops telemetry via OTTL; use it when the goal is to remove data, not redirect it.
 - `transform` — mutates telemetry via OTTL; use it to rewrite data rather than route it.
 - `otel-ottl` skill — the `condition`/`statement` expression language, contexts, and functions used in the routing `table`.
-- `routingprocessor` — the deprecated processor this connector replaces (see [Known quirks](quirks.md) for migration).
+- `routingprocessor` — the removed processor this connector replaces (see [Known quirks](quirks.md) for migration).
 
 ## Details
 

--- a/skills/otel-collector/components/routing/advanced.md
+++ b/skills/otel-collector/components/routing/advanced.md
@@ -1,22 +1,24 @@
 # `routing`: advanced use-cases
 
+Examples below use context-qualified paths (`resource.attributes[...]`, `span.…`, `log.…`), the recommended style since v0.156.0 — the `context` field is inferred and omitted. Bare paths with an explicit `context` still work for backward compatibility.
+
 ## Named instances for independent dimensions
 
-Each piece of telemetry matches at most one route, so a single `routing` instance can't route on two independent dimensions at once. Use one named instance per dimension and list both as exporters of the input pipeline — each gets an independent copy of the data:
+Under the default `action: move`, each piece of telemetry matches at most one route, so a single `routing` instance can't route on two independent dimensions at once. Use one named instance per dimension and list both as exporters of the input pipeline — each gets an independent copy of the data:
 
 ```yaml
 connectors:
   routing/tenant:
     table:
-      - condition: attributes["tenant"] == "acme"
+      - condition: resource.attributes["tenant"] == "acme"
         pipelines: [logs/acme]
-      - condition: attributes["tenant"] == "ecorp"
+      - condition: resource.attributes["tenant"] == "ecorp"
         pipelines: [logs/ecorp]
   routing/region:
     table:
-      - condition: attributes["region"] == "us-east"
+      - condition: resource.attributes["region"] == "us-east"
         pipelines: [logs/east]
-      - condition: attributes["region"] == "us-west"
+      - condition: resource.attributes["region"] == "us-west"
         pipelines: [logs/west]
 
 service:
@@ -32,40 +34,35 @@ To send the same matched telemetry to several pipelines, list them all under one
 
 ```yaml
 table:
-  - context: span
-    condition: duration > 5000000000          # > 5s
+  - condition: span.end_time_unix_nano - span.start_time_unix_nano > 5000000000   # > 5s
     pipelines: [traces/slow, traces/all]       # slow traces go to BOTH
 ```
 
 ## Multi-tenant routing on request metadata
 
-`request` context routes once per incoming request, before telemetry is parsed — ideal for tenant isolation from an HTTP header or gRPC metadata. It requires `condition` and supports only `==`/`!=`:
+Route on HTTP headers or gRPC metadata using the `otelcol.client.metadata` (HTTP/client) and `otelcol.grpc.metadata` (gRPC) paths — valid in every signal context. Metadata values are lists, so index with `[0]`:
 
 ```yaml
 connectors:
   routing:
     default_pipelines: [logs/default]
     table:
-      - context: request
-        condition: request["X-Tenant"] == "acme"
+      - condition: otelcol.client.metadata["X-Tenant"][0] == "acme"
         pipelines: [logs/acme]
-      - context: request
-        condition: request["X-Tenant"] == "ecorp"
+      - condition: otelcol.client.metadata["X-Tenant"][0] == "ecorp"
         pipelines: [logs/ecorp]
 ```
 
-HTTP headers match case-insensitively; for gRPC metadata use lowercase keys (`request["x-tenant"]`).
+For gRPC traffic use lowercase keys: `otelcol.grpc.metadata["x-tenant"][0]`. The older `request["X-Tenant"]` / `context: request` form still works but is **deprecated as of v0.156.0** (see [quirks](quirks.md)).
 
 ## Severity and environment routing
 
 ```yaml
 # logs: cheap storage for low severity, expensive for errors
 table:
-  - context: log
-    condition: severity_number < SEVERITY_NUMBER_ERROR
+  - condition: log.severity_number < SEVERITY_NUMBER_ERROR
     pipelines: [logs/cheap]
-  - context: log
-    condition: severity_number >= SEVERITY_NUMBER_ERROR
+  - condition: log.severity_number >= SEVERITY_NUMBER_ERROR
     pipelines: [logs/important]
 ```
 
@@ -75,24 +72,26 @@ connectors:
   routing:
     default_pipelines: [traces/dev]
     table:
-      - context: resource
-        condition: attributes["deployment.environment"] == "production"
+      - condition: resource.attributes["deployment.environment"] == "production"
         pipelines: [traces/prod]
 ```
 
 Order routes from specific to general — the first match wins, so a broad route placed first will shadow a narrower one below it.
 
-## `action: move` vs `copy`
+## `action: copy` vs the default `move`
 
-`copy` (default) leaves matched data available to later routes and `default_pipelines`; `move` removes it from any further evaluation. Use `move` when a match is terminal and the data must not also reach the default:
+`move` (the default) removes matched data from any further evaluation, so it never also reaches later routes or `default_pipelines`. `copy` leaves matched data available downstream — use it for an "archive everything, then route" pattern where the same data must hit both the archive route and a more specific one:
 
 ```yaml
 table:
-  - context: log
-    condition: severity_number >= SEVERITY_NUMBER_ERROR
-    action: move                       # errors leave here, never hit default_pipelines
-    pipelines: [logs/errors]
+  - condition: resource.attributes["archive"] == "true"
+    action: copy                       # copied to archive, still evaluated below
+    pipelines: [logs/archive]
+  - condition: log.severity_number >= SEVERITY_NUMBER_ERROR
+    pipelines: [logs/errors]           # default move: errors leave here
 ```
+
+Because `move` is already the default, you rarely set it explicitly; reach for `copy` only when a match must not be terminal.
 
 ## Migrating from `routingprocessor`
 
@@ -120,8 +119,7 @@ connectors:
   routing:
     default_pipelines: [logs/default]
     table:
-      - context: resource
-        condition: attributes["X-Tenant"] == "acme"
+      - condition: otelcol.client.metadata["X-Tenant"][0] == "acme"
         pipelines: [logs/acme]
 service:
   pipelines:
@@ -132,9 +130,9 @@ service:
 
 ## Migrating from `match_once`
 
-`match_once` was removed in v0.120.0; each item now matches at most one route. To reproduce the old `match_once: false` (multi-match) behavior:
+`match_once` was removed in v0.120.0; each item now matches at most one route (under the default `move`). To reproduce the old `match_once: false` (multi-match) behavior:
 
 - **Parallel routers** — split independent dimensions into separate named instances (see above). Each gets its own copy, so an item can match in both. Simplest when no `default_pipelines` is needed.
-- **Enumerate combinations** — for a small fixed set, write one route per combination and list all target pipelines in it (e.g. `condition: env=="prod" and region=="east"` → `pipelines: [logs/prod, logs/east]`). Practical only for a handful of dimensions.
+- **Enumerate combinations** — for a small fixed set, write one route per combination and list all target pipelines in it (e.g. `condition: resource.attributes["env"] == "prod" and resource.attributes["region"] == "east"` → `pipelines: [logs/prod, logs/east]`). Practical only for a handful of dimensions.
 
 Prefer parallel routers; enumeration grows combinatorially.

--- a/skills/otel-collector/components/routing/advanced.md
+++ b/skills/otel-collector/components/routing/advanced.md
@@ -95,7 +95,7 @@ Because `move` is already the default, you rarely set it explicitly; reach for `
 
 ## Migrating from `routingprocessor`
 
-The connector replaces the deprecated `routingprocessor`. The processor sat inside one pipeline and routed to **exporters** via a `from_attribute` + `value` table; the connector bridges pipelines and routes to **pipelines** via OTTL.
+The connector replaces the `routingprocessor`, which has since been removed from contrib entirely — the OLD config below no longer loads on current releases. The processor sat inside one pipeline and routed to **exporters** via a `from_attribute` + `value` table; the connector bridges pipelines and routes to **pipelines** via OTTL.
 
 ```yaml
 # OLD (routingprocessor)

--- a/skills/otel-collector/components/routing/configuration.md
+++ b/skills/otel-collector/components/routing/configuration.md
@@ -43,7 +43,7 @@ service:
 | Key | Type | Default | Required | Meaning |
 |-----|------|---------|----------|---------|
 | `context` | string | inferred from path | no | OTTL context the expression runs in: `resource`, `span`, `metric`, `datapoint`, `log`, `otelcol`, or the deprecated `request`. Usually omit it — the context is inferred from context-qualified paths (see below). If set, it takes precedence over inference and must be valid for the pipeline's signal (see table below). |
-| `statement` | string | — | one of `statement`/`condition` | OTTL statement in `route() where <expr>` form. **Mutually exclusive with `condition`.** Not allowed for the deprecated `request` context. |
+| `statement` | string | — | one of `statement`/`condition` | OTTL statement: `route() where <expr>` to route unchanged, or `<editor> where <expr>` (e.g. `delete_key(resource.attributes, "k") where …`) to mutate matched data in the same pass. **Mutually exclusive with `condition`.** Not allowed for the deprecated `request` context. |
 | `condition` | string | — | one of `statement`/`condition` | OTTL boolean expression (no `route() where`). **Mutually exclusive with `statement`.** Required for the deprecated `request` context. |
 | `action` | string | `move` | no | `move` (default) removes matched data from further route evaluation and `default_pipelines`; `copy` leaves it available to later routes and the default. |
 | `pipelines` | array of pipeline IDs | — | **yes** (≥1) | Output pipelines this route forwards matching telemetry to. Listing several fans the data out to all of them. |
@@ -87,9 +87,11 @@ Both express the same boolean test in OTTL; they differ only in syntax and which
 - condition: resource.attributes["env"] == "prod"
   pipelines: [logs/prod]
 
-# statement: route() where <expr> — lets you also run editors (e.g. delete_key)
-#            against the data in the same step, before it is routed
-- statement: route() where resource.attributes["env"] == "prod" and delete_key(resource.attributes, "internal.debug")
+# statement: <editor> where <expr> — the editor (e.g. delete_key) is the statement's
+#            function; it runs against matched data in the same pass, then the data is
+#            routed. Plain routing without mutation is `route() where <expr>`. You cannot
+#            chain an editor onto route() with `and` — that is invalid OTTL syntax.
+- statement: delete_key(resource.attributes, "internal.debug") where resource.attributes["env"] == "prod"
   pipelines: [logs/prod]
 ```
 

--- a/skills/otel-collector/components/routing/configuration.md
+++ b/skills/otel-collector/components/routing/configuration.md
@@ -8,11 +8,10 @@ connectors:
     error_mode: ignore
     default_pipelines: [logs/default]
     table:
-      - context: resource
-        condition: attributes["tenant"] == "acme"
+      # context inferred from the qualified path — no `context` field needed
+      - condition: resource.attributes["tenant"] == "acme"
         pipelines: [logs/acme]
-      - context: log
-        condition: severity_number >= SEVERITY_NUMBER_ERROR
+      - condition: log.severity_number >= SEVERITY_NUMBER_ERROR
         pipelines: [logs/errors]
 
 service:
@@ -35,33 +34,49 @@ service:
 
 | Key | Type | Default | Required | Meaning |
 |-----|------|---------|----------|---------|
-| `table` | array of RoutingTableItem | — | **yes** (≥1 route) | The routing table. Routes are evaluated in order; each piece of telemetry matches at most one route. |
+| `table` | array of RoutingTableItem | — | **yes** (≥1 route) | The routing table. Routes are evaluated in order; under the default `action: move` each piece of telemetry matches at most one route. |
 | `default_pipelines` | array of pipeline IDs | none | no | Pipelines for telemetry that matches no route. **If unset, unmatched telemetry is dropped.** |
-| `error_mode` | string | version-dependent; set explicitly | no | How OTTL evaluation errors are handled: `propagate`, `ignore`, or `silent` (see below). |
+| `error_mode` | string | `propagate` | no | How OTTL evaluation errors are handled: `propagate`, `ignore`, or `silent` (see below). Defaults to `ignore` when the `connector.routing.defaultErrorModeIgnore` feature gate (alpha, since v0.155.0) is enabled — set it explicitly rather than relying on the default. |
 
 ## RoutingTableItem reference
 
 | Key | Type | Default | Required | Meaning |
 |-----|------|---------|----------|---------|
-| `context` | string | `resource` | no | OTTL context the expression runs in: `resource`, `span`, `metric`, `datapoint`, `log`, or `request`. Must be valid for the pipeline's signal (see table below). |
-| `statement` | string | — | one of `statement`/`condition` | OTTL statement in `route() where <expr>` form. **Mutually exclusive with `condition`.** Not allowed for `request` context. |
-| `condition` | string | — | one of `statement`/`condition` | OTTL boolean expression (no `route() where`). **Mutually exclusive with `statement`.** Required for `request` context. |
-| `action` | string | `copy` | no | `copy` leaves matched data available to later routes and `default_pipelines`; `move` removes it from further evaluation. |
+| `context` | string | inferred from path | no | OTTL context the expression runs in: `resource`, `span`, `metric`, `datapoint`, `log`, `otelcol`, or the deprecated `request`. Usually omit it — the context is inferred from context-qualified paths (see below). If set, it takes precedence over inference and must be valid for the pipeline's signal (see table below). |
+| `statement` | string | — | one of `statement`/`condition` | OTTL statement in `route() where <expr>` form. **Mutually exclusive with `condition`.** Not allowed for the deprecated `request` context. |
+| `condition` | string | — | one of `statement`/`condition` | OTTL boolean expression (no `route() where`). **Mutually exclusive with `statement`.** Required for the deprecated `request` context. |
+| `action` | string | `move` | no | `move` (default) removes matched data from further route evaluation and `default_pipelines`; `copy` leaves it available to later routes and the default. |
 | `pipelines` | array of pipeline IDs | — | **yes** (≥1) | Output pipelines this route forwards matching telemetry to. Listing several fans the data out to all of them. |
 
 Exactly one of `statement` / `condition` must be set per route — setting both, or neither, fails validation.
 
+## Context inference (recommended)
+
+Since v0.156.0 the connector infers the `context` from **context-qualified paths** in the condition/statement, so the `context` field is usually unnecessary. Prefix each path with its context and drop the field:
+
+```yaml
+table:
+  - condition: resource.attributes["env"] == "prod"     # -> resource context
+    pipelines: [logs/prod]
+  - condition: span.attributes["http.method"] == "GET"  # -> span context
+    pipelines: [traces/http]
+  - condition: log.severity_text == "ERROR"             # -> log context
+    pipelines: [logs/errors]
+```
+
+The inferred (or explicit) context must be compatible with the pipeline signal — e.g. a `span` context only works in a traces pipeline. A condition with no OTTL paths (e.g. the literal `"true"`) can't be inferred, so it still needs an explicit `context`. Bare paths with an explicit `context` (`context: resource` + `attributes["env"]`) remain valid for backward compatibility.
+
 ## Supported contexts by signal
 
-A route's `context` must be supported by the signal of the pipeline it routes:
+A route's context (inferred or explicit) must be supported by the signal of the pipeline it routes:
 
 | Signal | Supported contexts |
 |--------|--------------------|
-| Traces | `resource`, `span`, `request` |
-| Metrics | `resource`, `metric`, `datapoint`, `request` |
-| Logs | `resource`, `log`, `request` |
+| Traces | `resource`, `span`, `otelcol` (+ deprecated `request`) |
+| Metrics | `resource`, `metric`, `datapoint`, `otelcol` (+ deprecated `request`) |
+| Logs | `resource`, `log`, `otelcol` (+ deprecated `request`) |
 
-Coarser contexts are cheaper: `resource` evaluates once per resource bundle, while `span`/`metric`/`log` evaluate per item and `datapoint` per data point. Use the coarsest context that expresses your condition. `request` evaluates once per incoming request, before telemetry is parsed.
+`otelcol` (request metadata) is valid in every signal. Coarser contexts are cheaper: `resource` evaluates once per resource bundle, while `span`/`metric`/`log` evaluate per item and `datapoint` per data point. Use the coarsest context that expresses your condition.
 
 ## `statement` vs `condition`
 
@@ -69,30 +84,39 @@ Both express the same boolean test in OTTL; they differ only in syntax and which
 
 ```yaml
 # condition: a bare boolean expression
-- condition: attributes["env"] == "prod"
+- condition: resource.attributes["env"] == "prod"
   pipelines: [logs/prod]
 
 # statement: route() where <expr> — lets you also run editors (e.g. delete_key)
 #            against the data in the same step, before it is routed
-- statement: route() where attributes["env"] == "prod" and delete_key(attributes, "internal.debug")
+- statement: route() where resource.attributes["env"] == "prod" and delete_key(resource.attributes, "internal.debug")
   pipelines: [logs/prod]
 ```
 
-Use `condition` for a plain match (recommended for clarity); reach for `statement` only when you want to mutate the data in the same pass. For the full expression language — paths, converters, editors — see the `otel-ottl` skill.
+Use `condition` for a plain match (recommended for clarity); reach for `statement` only when you want to mutate the data in the same pass. Beyond the standard converters, the connector exposes only the `delete_key` and `delete_matching_keys` editors. For the full expression language — paths, converters, editors — see the `otel-ottl` skill.
 
-### `request` context (limited grammar)
+## Request metadata routing (`otelcol.*`)
 
-> **Deprecated in v0.156.0.** The `request` context and `request["key"]` syntax are deprecated in favor of the `otelcol.*` OTTL paths — `otelcol.client.metadata["key"][0]` for HTTP/client metadata and `otelcol.grpc.metadata["key"][0]` for gRPC metadata. Those paths work in **any** signal context (no `error_mode`/grammar limits below) and the connector logs a warning when `request` is still configured. Prefer them in new configs; the `request` form still works for now.
+To route on HTTP headers or gRPC metadata, use the `otelcol.client.metadata` (HTTP/client) and `otelcol.grpc.metadata` (gRPC) paths. Metadata values are lists, so index the first element with `[0]`. These paths are valid in every signal context and, unlike the deprecated `request` context, support the full OTTL grammar (`and`/`or`, statements, etc.):
 
-`request` reads HTTP headers / gRPC metadata and requires `condition` (a `statement` is rejected). It supports only a single simple comparison — `==` or `!=` — with no `and`/`or`:
+```yaml
+- condition: otelcol.client.metadata["X-Tenant"][0] == "acme"
+  pipelines: [logs/acme]
+- condition: otelcol.grpc.metadata["x-tenant"][0] == "acme"
+  pipelines: [logs/acme]
+```
+
+gRPC metadata keys are lowercased, so use lowercase keys for gRPC traffic. The receiver must propagate request metadata (the `otlp` receiver does).
+
+### Deprecated `request` context
+
+The `request` context is **deprecated as of v0.156.0** (a warning is logged when it is used) — prefer `otelcol.client.metadata` / `otelcol.grpc.metadata`. It requires `condition` (a `statement` is rejected) and supports only a single simple comparison — `==` or `!=`, no `and`/`or`:
 
 ```yaml
 - context: request
   condition: request["X-Tenant"] == "acme"
   pipelines: [logs/acme]
 ```
-
-HTTP headers are matched case-insensitively; gRPC metadata keys are lowercased, so use lowercase keys when routing gRPC traffic (`request["x-tenant"]`). The receiver must propagate request metadata (the `otlp` receiver does).
 
 ## `error_mode`
 
@@ -104,7 +128,7 @@ Controls what happens when an OTTL expression fails to evaluate (missing attribu
 | `ignore` | The error is logged and the payload is sent to `default_pipelines`. |
 | `silent` | Same as `ignore`, but the error is not logged. |
 
-Prefer `ignore` in production so a transient OTTL error doesn't drop data. Set `error_mode` explicitly in reusable configs because defaults can change across Collector versions and feature gates.
+Prefer `ignore` in production so a transient OTTL error doesn't drop data. Set `error_mode` explicitly in reusable configs because the default is `propagate` today but flips to `ignore` under the `connector.routing.defaultErrorModeIgnore` feature gate.
 
 ## Pipeline wiring
 

--- a/skills/otel-collector/components/routing/quirks.md
+++ b/skills/otel-collector/components/routing/quirks.md
@@ -6,15 +6,19 @@ If a piece of telemetry matches no route and `default_pipelines` is not set, it 
 
 ## `error_mode: propagate` drops the payload on OTTL errors
 
-With the default `error_mode: propagate`, any OTTL evaluation error — a missing attribute, a type mismatch — makes the connector return an error and the **whole payload is dropped** from the collector. In production use `error_mode: ignore`, which logs the error and sends the payload to `default_pipelines` instead — so `ignore` only actually rescues data when `default_pipelines` is set; without it the errored payload still has nowhere to go. Guard fragile conditions with nil checks (`attributes["k"] != nil and attributes["k"] == "v"`) so a missing key doesn't error in the first place.
+With the default `error_mode: propagate`, any OTTL evaluation error — a missing attribute, a type mismatch — makes the connector return an error and the **whole payload is dropped** from the collector. In production use `error_mode: ignore`, which logs the error and sends the payload to `default_pipelines` instead — so `ignore` only actually rescues data when `default_pipelines` is set; without it the errored payload still has nowhere to go. Guard fragile conditions with nil checks (`resource.attributes["k"] != nil and resource.attributes["k"] == "v"`) so a missing key doesn't error in the first place. The default flips to `ignore` under the `connector.routing.defaultErrorModeIgnore` feature gate (alpha, since v0.155.0), so don't assume `propagate` — set `error_mode` explicitly.
+
+## `action` defaults to `move`, so matched data skips `default_pipelines`
+
+The default `action` is `move`: a matched item is removed from further route evaluation and does **not** also reach `default_pipelines` or later routes. Use `action: copy` when you want matched data to stay available for subsequent routes and the default (e.g. an archive-everything route placed first).
 
 ## `statement` and `condition` are mutually exclusive
 
 Each route needs **exactly one** of `statement` or `condition`. Setting both, or neither, fails config validation. `statement` is the `route() where <expr>` form (and can also run editors like `delete_key` in the same pass); `condition` is a bare boolean expression. Pick one per route.
 
-## `request` context has a limited grammar
+## `request` context is deprecated and has a limited grammar
 
-`request` routing supports only a single `==` or `!=` comparison — no `and`/`or`, and a `statement` is rejected (it must be `condition`). For compound request logic, use multiple `request` routes or move the decision to `resource` context. HTTP headers match case-insensitively, but gRPC metadata keys are lowercased — use lowercase keys (`request["x-tenant"]`) for gRPC traffic. The receiver must actually propagate request metadata (the `otlp` receiver does; file-based receivers don't).
+The `request` context is **deprecated as of v0.156.0** (a warning is logged when it is used) — prefer the `otelcol.client.metadata["key"][0]` (HTTP) / `otelcol.grpc.metadata["key"][0]` (gRPC) paths, which are valid in every signal context and support the full OTTL grammar. The legacy `request` context supports only a single `==` or `!=` comparison — no `and`/`or`, and a `statement` is rejected (it must be `condition`). gRPC metadata keys are lowercased, so use lowercase keys (`request["x-tenant"]` / `otelcol.grpc.metadata["x-tenant"][0]`) for gRPC traffic. The receiver must actually propagate request metadata (the `otlp` receiver does; file-based receivers don't).
 
 ## Item-level contexts can split a Resource bundle across pipelines
 
@@ -28,8 +32,9 @@ Each route needs **exactly one** of `statement` or `condition`. Setting both, or
 | `no condition or statement provided` | route has neither | Add one of `statement`/`condition`. |
 | `both condition and statement provided` | route has both | Remove one. |
 | `no pipelines defined` | route missing `pipelines` | Add at least one pipeline ID. |
-| `'request' context requires a 'condition'` | `request` route used a `statement` | Use `condition` for `request` context. |
-| `invalid context: <name>` | unsupported/typo context | Use `resource`, `span`, `metric`, `datapoint`, `log`, or `request` (and one valid for the signal). |
+| `invalid routing action: if provided should be one of move/copy` | `action` set to something other than `move`/`copy` | Use `move` or `copy` (or omit for the `move` default). |
+| `"request" context requires a 'condition'` | `request` route used a `statement` | Use `condition` for `request` context (or migrate to `otelcol.*` paths). |
+| `invalid context: <name>` | unsupported/typo context | Use `resource`, `span`, `metric`, `datapoint`, `log`, `otelcol`, or the deprecated `request` (and one valid for the signal). |
 
 ## `match_once` was removed in v0.120.0
 

--- a/skills/otel-collector/components/routing/quirks.md
+++ b/skills/otel-collector/components/routing/quirks.md
@@ -14,7 +14,7 @@ The default `action` is `move`: a matched item is removed from further route eva
 
 ## `statement` and `condition` are mutually exclusive
 
-Each route needs **exactly one** of `statement` or `condition`. Setting both, or neither, fails config validation. `statement` is the `route() where <expr>` form (and can also run editors like `delete_key` in the same pass); `condition` is a bare boolean expression. Pick one per route.
+Each route needs **exactly one** of `statement` or `condition`. Setting both, or neither, fails config validation. `statement` is the `route() where <expr>` form — or `<editor> where <expr>` (e.g. `delete_key(...) where …`) when you also want to mutate matched data in the same pass (you can't chain an editor onto `route()` with `and`); `condition` is a bare boolean expression. Pick one per route.
 
 ## `request` context is deprecated and has a limited grammar
 
@@ -32,7 +32,7 @@ The `request` context is **deprecated as of v0.156.0** (a warning is logged when
 | `no condition or statement provided` | route has neither | Add one of `statement`/`condition`. |
 | `both condition and statement provided` | route has both | Remove one. |
 | `no pipelines defined` | route missing `pipelines` | Add at least one pipeline ID. |
-| `invalid routing action: if provided should be one of move/copy` | `action` set to something other than `move`/`copy` | Use `move` or `copy` (or omit for the `move` default). |
+| `invalid Action string: <value>` (inside a `cannot unmarshal the configuration` error) | `action` set to something other than `move`/`copy` | Use `move` or `copy` (or omit for the `move` default). |
 | `"request" context requires a 'condition'` | `request` route used a `statement` | Use `condition` for `request` context (or migrate to `otelcol.*` paths). |
 | `invalid context: <name>` | unsupported/typo context | Use `resource`, `span`, `metric`, `datapoint`, `log`, `otelcol`, or the deprecated `request` (and one valid for the signal). |
 
@@ -42,4 +42,4 @@ The `request` context is **deprecated as of v0.156.0** (a warning is logged when
 
 ## Stability caveats
 
-All three signal pairs (traces, metrics, logs) are **Alpha**. Config surface and behavior can shift between releases — confirm against the upstream README for your exact collector version. The connector replaces the deprecated `routingprocessor`; new configs should use the connector form.
+All three signal pairs (traces, metrics, logs) are **Alpha**. Config surface and behavior can shift between releases — confirm against the upstream README for your exact collector version. The connector replaces the `routingprocessor`, which has been removed from contrib (v0.156.0 rejects it as an unknown type); existing configs must migrate to the connector form.


### PR DESCRIPTION
## Summary

Deep audit against the released v0.156.0 tag; 4 of 5 page files changed.

- **`action` default corrected**: `move`, not `copy` (`config.go`: `item.Action = Move`) — wrong since at least v0.150.0. Includes the operational consequence: matched data skips `default_pipelines` under the default, so the "at most one route" framing now says when it holds.
- **Fabricated path removed**: `duration > 5000000000` — `duration` is not an ottlspan path; replaced with the end-minus-start form.
- **Net-new v0.156.0**: context inference from qualified paths (`context` now optional/inferred), the `otelcol` context with `otelcol.client.metadata[...][0]`/`otelcol.grpc.metadata[...][0]` request-metadata routing across all signals, and `request` demoted to deprecated with migration guidance (completing the note added in #87).
- **`error_mode`**: default `propagate`, with the alpha `connector.routing.defaultErrorModeIgnore` gate (v0.155.0+) documented.
- Validation table fixed to released error strings; only `delete_key`/`delete_matching_keys` editors exposed; all examples modernized.

## Verified unchanged

Alpha stability across all pairs, distributions, module path, remaining validation substrings, SKILL.md index row (accurate, untouched), verification.md (backward-compatible explicit-context form, honest 0.152.0 run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK