### PR TITLE
docs(otel-collector): use prefixed OTTL path in SKILL.md log_dedup example

### DIFF
--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -59,7 +59,7 @@ processors:
   log_dedup/health-checks:
     interval: 30s
     conditions:
-      - 'attributes["log.type"] == "health_check"'
+      - 'log.attributes["log.type"] == "health_check"'
   log_dedup/access-logs:
     interval: 10s
 


### PR DESCRIPTION
## Summary

The collected index-level fix from the 21-component deep audit: the `type/name` example in SKILL.md used the un-prefixed OTTL condition form deprecated since v0.153.0 — log_dedup `conditions` take context-prefixed paths (`log.attributes[...]`). Companion to #97.

The two other index flags raised during the audit were verified non-issues on main: otlp/otlp_grpc profiles cells already say Alpha (#87), and the Development (profiles) cells on `resource`/`k8s_attributes`/`resource_detection` match their released `metadata.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK