### PR TITLE
docs: prepare repo for external contributors

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "otel-collector",
       "source": "./skills/otel-collector",
-      "description": "OpenTelemetry Collector component configuration: config keys, defaults, validation rules, signal support, stability, and gotchas. Progressive disclosure via components/<type>.md; currently covers log_dedup and interval processors."
+      "description": "OpenTelemetry Collector component configuration: config keys, defaults, validation rules, signal support, stability, and gotchas. Progressive disclosure via components/<name>/README.md plus on-demand detail files."
     },
     {
       "name": "otel-declarative-config",

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Agent involvement
+
+<!-- We welcome PRs authored and implemented by AI coding agents (see CONTRIBUTING.md).
+     Note here whether an agent wrote/implemented this change, and confirm a human reviewed it. -->
+
+## Harness results (required for new or substantively changed skills)
+
+<!-- A/B comparison proving the skill helps, per CONTRIBUTING.md:
+     - Prompt(s) used
+     - Model + harness (e.g. Claude Code X.Y with claude-opus-N)
+     - Baseline run (without the skill): what it got wrong, outdated, or wasteful
+     - Skill run (same prompt, same model): what improved
+     - Links to transcripts (gist is fine)
+     Delete this section for changes that don't touch skill content. -->
+
+## Checklist
+
+- [ ] `skills-ref validate skills/<skill-name>` passes ([Agent Skills spec](https://agentskills.io/specification))
+- [ ] Skill registered in all three places (skill directory, `.claude-plugin/marketplace.json`, `README.md` table + tree) — if adding/renaming a skill
+- [ ] Content is vendor-neutral, non-opinionated, DRY, and token-efficient
+- [ ] Harness comparison results included above — if skill content changed
+- [ ] Commit messages follow Conventional Commits
+- [ ] I have signed (or will sign via the CLA bot on this PR) the [OllyGarden CLA](../CLA.md)

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: CLA Assistant
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        # contributor-assistant/github-action is archived (2026-03); upstream states all
+        # existing releases remain functional and recommends forking for future development.
+        # Accepted risk: pinned to an immutable SHA, so the code cannot change under us.
+        # If GitHub API changes ever break it, fork into the ollygarden org and repoint.
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,33 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types:
+      - created
+  pull_request_target:
+    types:
+      - opened
+      - closed
+      - synchronize
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: blacksmith
+
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: signatures/cla.json
+          path-to-document: https://github.com/ollygarden/opentelemetry-agent-skills/blob/main/CLA.md
+          branch: cla-signatures
+          allowlist: jpkroehling,bot*,dependabot*,renovate*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Each skill is a self-contained directory under `skills/<skill-name>/`:
 
 - `SKILL.md` (required) — YAML frontmatter (`name`, `description`, optional `license`, `compatibility`, `metadata`) followed by the instruction body.
 - `references/` (optional) — task-focused docs the SKILL.md links to for detail it doesn't inline (e.g. `otel-go/references/` splits setup, API, instrumentation libraries, performance, breaking changes).
-- `components/` (skill-specific) — `otel-collector` uses one file per Collector component for progressive disclosure.
+- `components/` (skill-specific) — `otel-collector` uses one directory per Collector component (`README.md` plus `configuration.md`, `advanced.md`, `quirks.md`, `verification.md`) for progressive disclosure.
 - `scripts/` (optional) — helper or lookup scripts (e.g. `otel-semantic-conventions` ships a query script).
 
 Two hard rules that are easy to get wrong:
@@ -36,6 +36,15 @@ A new skill is only "registered" when it appears in **all** of these. Missing an
 1. The directory `skills/<name>/` with a `SKILL.md`.
 2. The `plugins` array in `.claude-plugin/marketplace.json` (`name` + `source: ./skills/<name>` + `description`).
 3. The "Available Skills" table **and** the Repository Structure layout tree in `README.md`.
+
+## Contribution requirements (external PRs)
+
+`CONTRIBUTING.md` is the source of truth; the parts an agent preparing a PR must know:
+
+- **Agent-authored PRs are accepted** and expected — but a human must own the PR, and agent involvement should be disclosed in the description.
+- **Harness evidence is required** for any PR that adds or substantively changes a skill: run the same representative prompt(s) on a frontier model without and with the skill (fresh sessions, same model and harness), and include the comparison plus transcript links in the PR description. The `.github/PULL_REQUEST_TEMPLATE.md` has a section for this.
+- **Spec conformance**: validate with `skills-ref validate skills/<skill-name>` ([agentskills.io spec](https://agentskills.io/specification)).
+- **CLA**: first-time contributors sign the OllyGarden CLA (`CLA.md`) via the CLA bot on the PR (`.github/workflows/cla.yml`).
 
 ## Conventions
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,6 +1,6 @@
 # OllyGarden Individual Contributor License Agreement
 
-Thank you for your interest in contributing to open source projects published by OllyGarden, Inc. ("OllyGarden"). This Contributor License Agreement ("Agreement") documents the rights granted by contributors to OllyGarden. It is based on the Apache Software Foundation's Individual Contributor License Agreement.
+Thank you for your interest in contributing to open-source projects published by OllyGarden, Inc. ("OllyGarden"). This Contributor License Agreement ("Agreement") documents the rights granted by contributors to OllyGarden. It is based on the Apache Software Foundation's Individual Contributor License Agreement.
 
 You accept and agree to the following terms and conditions for Your present and future Contributions submitted to OllyGarden. Except for the license granted herein to OllyGarden and recipients of software distributed by OllyGarden, You reserve all right, title, and interest in and to Your Contributions.
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,43 @@
+# OllyGarden Individual Contributor License Agreement
+
+Thank you for your interest in contributing to open source projects published by OllyGarden, Inc. ("OllyGarden"). This Contributor License Agreement ("Agreement") documents the rights granted by contributors to OllyGarden. It is based on the Apache Software Foundation's Individual Contributor License Agreement.
+
+You accept and agree to the following terms and conditions for Your present and future Contributions submitted to OllyGarden. Except for the license granted herein to OllyGarden and recipients of software distributed by OllyGarden, You reserve all right, title, and interest in and to Your Contributions.
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) shall mean the copyright owner or legal entity authorized by the copyright owner that is making this Agreement with OllyGarden. For legal entities, the entity making a Contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single Contributor.
+
+**"Contribution"** shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to OllyGarden for inclusion in, or documentation of, any of the products owned or managed by OllyGarden (the "Work"). For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to OllyGarden or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, OllyGarden for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to OllyGarden and to recipients of software distributed by OllyGarden a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to OllyGarden and to recipients of software distributed by OllyGarden a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted. If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that Your Contribution, or the Work to which You have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Work shall terminate as of the date such litigation is filed.
+
+## 4. Authority
+
+You represent that You are legally entitled to grant the above license. If Your employer(s) has rights to intellectual property that You create that includes Your Contributions, You represent that You have received permission to make Contributions on behalf of that employer, that Your employer has waived such rights for Your Contributions to OllyGarden, or that Your employer has executed a separate corporate CLA with OllyGarden.
+
+## 5. Original Work
+
+You represent that each of Your Contributions is Your original creation (see section 7 for submissions on behalf of others). Contributions authored or implemented with the assistance of AI coding tools are accepted; by submitting such a Contribution, You represent that You have reviewed it and that You have the right to submit it under this Agreement. You represent that Your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which You are personally aware and which are associated with any part of Your Contributions.
+
+## 6. Support
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Submissions on Behalf of Others
+
+Should You wish to submit work that is not Your original creation, You may submit it to OllyGarden separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which You are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]".
+
+## 8. Notification
+
+You agree to notify OllyGarden of any facts or circumstances of which You become aware that would make these representations inaccurate in any respect.
+
+---
+
+Signing is handled electronically via the CLA bot on your first pull request to this repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,16 @@
 
 Thank you for your interest in contributing!
 
+## Contributions from AI coding agents
+
+We accept — and encourage — pull requests that were authored and implemented by AI coding agents (Claude Code, Codex, Cursor, etc.). This repository is itself a set of Agent Skills, and most of it was built that way.
+
+Agent-authored PRs are held to the same bar as any other PR:
+
+- A human contributor must open the PR (or take ownership of it), review the agent's output before submitting, and be able to respond to review feedback. You are responsible for what you submit.
+- Disclose agent involvement in the PR description (e.g. a `Co-Authored-By` trailer or a short note). This is for transparency, not gatekeeping — it will not count against the PR.
+- The evaluation requirement below applies regardless of who or what wrote the change.
+
 ## Getting Started
 
 1. Fork and clone the repository
@@ -15,11 +25,30 @@ Prefer using the [`skill-creator`](https://github.com/anthropics/skills/tree/mai
 
 Skills live under `skills/<skill-name>/` and must follow the [Agent Skills specification](https://agentskills.io/specification). Each must include a `SKILL.md` with YAML frontmatter (`name` and `description`), where the directory name matches the `name` field. Optional subdirectories: `references/`, `scripts/`, `assets/`.
 
+Validate spec conformance locally with the [`skills-ref`](https://github.com/agentskills/agentskills/tree/main/skills-ref) reference tool before opening a PR:
+
+```bash
+skills-ref validate skills/<skill-name>
+```
+
 These skills are **non-opinionated and vendor neutral by design** — they describe how OpenTelemetry works, not how you should use it. Keep them DRY and token efficient: prefer linking to official docs, examples, and source code that are already maintained over copying large amounts of knowledge into a skill, and prefer a targeted lookup or small generated artifact over dumping broad context. OllyGarden's opinionated guidance lives in the companion [`skills`](https://github.com/ollygarden/skills) repo.
 
-Validate your skill locally before opening a pull request to confirm it conforms to the spec and activates as intended.
-
 When you add or rename a skill, keep all three registration points in sync: the `skills/<skill-name>/SKILL.md` directory, the `plugins` entry in `.claude-plugin/marketplace.json`, and the "Available Skills" table and Repository Structure layout tree in `README.md`.
+
+## Proving the skill helps: harness results
+
+Every PR that adds a skill or substantively changes one must include evaluation results demonstrating that the skill actually improves agent output. A skill that doesn't measurably help is context-window cost with no benefit.
+
+The required evidence is an A/B comparison from an agent harness (Claude Code, or a comparable harness driving a frontier model):
+
+1. Pick one or more representative prompts a user would realistically ask — ideally prompts that exercise the part of the skill you added or changed.
+2. Run each prompt **without** the skill installed, on a frontier model (e.g. the current Claude Opus/Sonnet generation), in a fresh session.
+3. Run the **same prompt, same model, same harness** with the skill installed, in a fresh session.
+4. Include the results in the PR description: the prompts used, the model and harness versions, and a summary of how the outputs differed — where the baseline was wrong, outdated, or wasteful, and what the skill fixed. Attach or link the transcripts (a gist is fine) so reviewers can verify.
+
+What we look for: the baseline getting facts wrong (stale versions, renamed packages, invalid config keys) that the skill corrects; the skill reaching the right answer with fewer tokens or fewer wrong turns; and no regressions on prompts the skill shouldn't affect. If the comparison shows no meaningful difference, that's a signal the skill (or the change) isn't earning its place — rework it rather than submitting the results anyway.
+
+The [`skill-creator`](https://github.com/anthropics/skills/tree/main/skill-creator) skill can help you set up and run these evals.
 
 ## The `otel-agent-tools` Module
 
@@ -56,4 +85,9 @@ Common types:
 
 - Keep PRs focused on a single change
 - Include a summary and test plan in the PR description
-- Update `README.md` if adding or removing a skill
+- For skill additions or substantive skill changes, include the harness comparison results described above
+- Update `README.md` and `.claude-plugin/marketplace.json` if adding, renaming, or removing a skill
+
+## Contributor License Agreement
+
+Before we can merge your first pull request, you must sign the OllyGarden [Contributor License Agreement](CLA.md). Signing is handled automatically in the PR: the CLA bot will comment with instructions, and you sign by replying with the requested confirmation. You only need to sign once; the signature covers all your future contributions to this repository.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ skills/
     references/        # setup-sdk, instrumentation, performance
   otel-collector/
     SKILL.md
-    components/        # one file per Collector component (log_dedup, interval, …)
+    components/        # one directory per Collector component (log_dedup, interval, …)
   otel-declarative-config/
   otel-ottl/
   otel-sdk-versions/
@@ -108,8 +108,11 @@ Language-specific skills:
 
 ## Contributing
 
-Contributions are welcome. When adding or updating skills, please follow these guidelines:
+Contributions are welcome — including pull requests authored and implemented by AI coding agents. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. The essentials:
 
 - Keep skills DRY. Prefer referencing official docs, examples, and source code that are already maintained instead of copying large amounts of additional knowledge into the skill. There will be exceptions, but the default should be to link or point to the maintained source of truth.
 - Design skills to be token efficient. Avoid dumping large files or broad context into a skill when a targeted lookup, focused reference, or small generated artifact will do.
 - Stay vendor neutral.
+- Skills must conform to the [Agent Skills specification](https://agentskills.io/specification).
+- PRs that add or substantively change a skill must include harness results: the same prompt run on a frontier model without and with the skill, showing the skill helps.
+- Contributors sign the [OllyGarden CLA](CLA.md) on their first pull request.


### PR DESCRIPTION
## Summary

Prepares the repository for external contributors:

- **CONTRIBUTING.md**: explicitly states we accept PRs authored and implemented by AI coding agents (with human ownership + disclosure); requires **harness results** for skill additions/changes — the same prompt run on a frontier model without and with the skill, with transcripts, proving the skill helps; adds `skills-ref validate` step per the [Agent Skills spec](https://agentskills.io/specification); adds a CLA section.
- **CLA.md**: new individual CLA (Apache ICLA-based, adapted for OllyGarden, with an explicit AI-assisted-contribution clause).
- **.github/workflows/cla.yml**: CLA-assistant (contributor-assistant v2.6.1, SHA-pinned) gating PRs on signature; signatures stored on a `cla-signatures` branch; maintainer + bots allowlisted.
- **.github/PULL_REQUEST_TEMPLATE.md**: template with agent-involvement disclosure, harness-results section, and checklist.
- **AGENTS.md**: new "Contribution requirements" section; fixed stale collector `components/` layout description (now one directory per component).
- **README.md**: Contributing section points at CONTRIBUTING.md and summarizes agent PRs, spec conformance, harness evidence, and CLA.
- **marketplace.json**: fixed stale `otel-collector` description ("currently covers log_dedup and interval" → 22 components exist).

## Verification

- All 14 skills validated against the spec: directory name == `name:` field, only spec-allowed frontmatter fields.
- `marketplace.json` still parses as valid JSON.
- `contributor-assistant/github-action` SHA verified against upstream tag v2.6.1.

## Agent involvement

Authored and implemented by Claude Code; reviewed by @jpkroehling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw6ArwSeoPuM44omUuuxaK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the `otel-collector` skill’s component documentation structure and progressive-disclosure approach.
  - Expanded contribution guidance, including validation, harness evidence, skill registration, and contributor agreement requirements.
  - Updated README guidance for repository structure and AI-assisted contributions.

- **Contributor Experience**
  - Added a standardized pull request template with required checks and submission details.
  - Added automated contributor license agreement verification for pull requests.
  - Added a contributor license agreement document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->