### PR TITLE
docs(otel-js): refresh current upstream guidance

### DIFF
--- a/skills/otel-js/SKILL.md
+++ b/skills/otel-js/SKILL.md
@@ -24,8 +24,10 @@ For Node.js-specific facts:
 | Latest `@opentelemetry/configuration` | `npm view @opentelemetry/configuration version` |
 | Latest `@opentelemetry/sdk-node` | `npm view @opentelemetry/sdk-node version` |
 | Latest `@opentelemetry/auto-instrumentations-node` | `npm view @opentelemetry/auto-instrumentations-node version` |
-| Package status / breaking changes | `WebFetch https://www.npmjs.com/package/@opentelemetry/configuration` |
+| Package status / breaking changes | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/configuration/README.md` and `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/opentelemetry-sdk-node/README.md` |
 | `sdk-node` CHANGELOG (experimental packages) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/CHANGELOG.md` |
+| ESM / CJS preload mechanics | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/doc/esm-support.md` |
+| Auto-instrumentations register entry point | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js-contrib/main/packages/auto-instrumentations-node/README.md` |
 | Node.js getting-started docs | `WebFetch https://opentelemetry.io/docs/languages/js/getting-started/nodejs/` |
 
 ## Cross-References

--- a/skills/otel-js/references/declarative-setup.md
+++ b/skills/otel-js/references/declarative-setup.md
@@ -1,7 +1,8 @@
 # JavaScript/Node.js SDK Setup with Declarative Configuration
 
 Configure the OpenTelemetry SDK in Node.js via declarative YAML. The
-`@opentelemetry/configuration` package loads SDK settings from a YAML file at startup.
+`@opentelemetry/configuration` package parses YAML or environment-derived SDK settings;
+`@opentelemetry/sdk-node` applies them during startup.
 
 For the YAML configuration schema, load the `otel-declarative-config` skill.
 
@@ -18,48 +19,68 @@ skill. For JS-specific facts:
 | Latest `@opentelemetry/configuration` | `npm view @opentelemetry/configuration version` |
 | Latest `@opentelemetry/sdk-node` | `npm view @opentelemetry/sdk-node version` |
 | Latest `@opentelemetry/auto-instrumentations-node` | `npm view @opentelemetry/auto-instrumentations-node version` |
-| Package status / breaking changes | `WebFetch https://www.npmjs.com/package/@opentelemetry/configuration` |
+| Package status / breaking changes | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/configuration/README.md` and `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/opentelemetry-sdk-node/README.md` |
+| SDK declarative startup helper | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/opentelemetry-sdk-node/src/start.ts` |
 | File config parser for current source (`file_format` acceptance) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/configuration/src/FileConfigFactory.ts` |
 | File config fixtures for current source | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/configuration/test/fixtures/sdk-config.yaml` |
 | `sdk-node` CHANGELOG (experimental packages) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/CHANGELOG.md` |
+| ESM / CJS preload mechanics | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/doc/esm-support.md` |
+| Auto-instrumentations register entry point | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js-contrib/main/packages/auto-instrumentations-node/README.md` |
 | Node.js getting-started docs | `WebFetch https://opentelemetry.io/docs/languages/js/getting-started/nodejs/` |
 
 ## Activation
 
-Set the `OTEL_CONFIG_FILE` environment variable pointing to a YAML config file:
+Set `OTEL_CONFIG_FILE` to a YAML config file, then preload a telemetry startup module
+before application code:
+
+```typescript
+// instrumentation.ts
+import { startNodeSDK } from '@opentelemetry/sdk-node';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+
+startNodeSDK({
+  instrumentations: [getNodeAutoInstrumentations()],
+});
+```
 
 ```bash
 export OTEL_CONFIG_FILE=configs/otel.yaml
 node --import ./dist/instrumentation.js ./dist/index.js
 ```
 
-When `OTEL_CONFIG_FILE` is set, the `@opentelemetry/configuration` package reads the file
-at startup and configures all providers. The `createConfigFactory()` function auto-detects
-the config source: if a valid YAML file exists at the `OTEL_CONFIG_FILE` path, it uses file
-config; otherwise it falls back to environment variables.
+When `OTEL_CONFIG_FILE` is set, `@opentelemetry/configuration` reads that path as YAML.
+`@opentelemetry/sdk-node`'s experimental `startNodeSDK()` helper uses the resulting model
+to configure providers. If `OTEL_CONFIG_FILE` is unset, `createConfigFactory()` falls back
+to environment variables. If it is set but unreadable or invalid, `startNodeSDK()` logs a
+diagnostic error and returns a no-op SDK rather than falling back to env vars.
 
-The config file must have a `.yaml` or `.yml` extension.
+Use `.yaml` or `.yml` filenames in examples and docs; verify extension enforcement against
+the current `FileConfigFactory.ts` source before claiming the parser rejects other suffixes.
 
 ## YAML Config
 
 For the canonical structure, fetch `examples/otel-sdk-config.yaml` (see the
-`otel-declarative-config` skill's Sources of Truth). For the correct `file_format` string,
-inspect the installed `@opentelemetry/configuration` package or its matching source/fixtures.
-Package releases may accept a different literal than the generic language support matrix.
+`otel-declarative-config` skill's Sources of Truth), then check the installed
+`@opentelemetry/configuration` package or its matching source/fixtures for runtime support.
+Current released JS packages generated config types from schema v1.1.0, use
+`file_format: "1.1"` in examples, accept schema major `1` including `1.0`, warn on newer
+minor versions, and reject other major versions.
 
 ```yaml
-# file_format: use the exact literal accepted by the installed @opentelemetry/configuration parser
+file_format: "1.1"
 resource:
   attributes:
     - name: service.name
       value: "${SERVICE_NAME:-my-node-service}"
+      type: string
     - name: service.version
       value: "${SERVICE_VERSION:-0.1.0}"
+      type: string
     - name: deployment.environment.name
       value: "${NODE_ENV:-development}"
+      type: string
 
 # Tracer/meter/logger provider blocks: structure per the canonical example.
-# JS-specific quirk: the config file must have a .yaml or .yml extension.
 ```
 
 ## Using Tracers and Meters
@@ -84,8 +105,20 @@ OTEL_CONFIG_FILE=configs/otel.yaml node --import ./dist/instrumentation.js ./dis
 OTEL_CONFIG_FILE=configs/otel.yaml node --require ./dist/instrumentation.js ./dist/index.js
 ```
 
+If the service relies on auto-instrumentation patching ESM imports, include the current
+OpenTelemetry loader hook as described in `doc/esm-support.md`:
+
+```bash
+node --experimental-loader=@opentelemetry/instrumentation/hook.mjs --import ./dist/instrumentation.js ./dist/index.js
+```
+
+The zero-code `@opentelemetry/auto-instrumentations-node/register` entry point starts
+`NodeSDK` from environment variables; use `startNodeSDK()` when the task specifically needs
+declarative YAML via `OTEL_CONFIG_FILE`.
+
 ## Key API Facts
 
 - **Import order matters**: Telemetry setup must be imported and started before any other application imports. Auto-instrumentation patches modules at require/import time.
 - **`@opentelemetry/sdk-node` is experimental** but is the recommended way to set up OTel in Node.js. It handles context manager, propagator, and provider registration automatically.
 - **v2.0 migration**: `Resource` class is no longer exported. Use `resourceFromAttributes()`, `defaultResource()`, `emptyResource()` instead.
+- **2.9.0 / 0.220.0 migration note**: `@opentelemetry/sdk-node` now uses `@opentelemetry/sdk-trace`; the `node` and `tracing` namespace re-exports are deprecated. Import trace SDK types/classes directly from their packages.


### PR DESCRIPTION
## Summary
- Refreshes JS package source-of-truth pointers from npm-only status to upstream README/changelog/source paths.
- Updates declarative setup guidance for current `startNodeSDK()` behavior, `file_format: "1.1"`, invalid-file handling, ESM loader usage, and SDK trace migration notes.

## Verification
- Synced `opentelemetry-js` and `opentelemetry-js-contrib` from upstream/main on 2026-07-12; both were already up to date.
- Verified relevant local release tags reported by the audit: `opentelemetry-js` `v2.9.0`, experimental packages `0.220.0`, and `auto-instrumentations-node-v0.78.0`.
- `git diff --check -- skills/otel-js` passed in the audit agent.
- `skills-ref validate skills/otel-js` not run: `skills-ref` is not installed locally.

## Deliberately excluded
- No unreleased CHANGELOG items.
- No scope expansion beyond current JS skill content.
- No npm/web repo-content fetches; audit used synced local OpenTelemetry checkouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenTelemetry JavaScript setup guidance with current upstream references.
  * Clarified YAML and environment-based configuration behavior, including startup activation and error handling.
  * Added guidance for configuration file formats, schema versions, and ESM loader-based auto-instrumentation.
  * Documented current SDK package usage and migration considerations, including deprecated re-exports.
  * Expanded references for experimental package status, SDK changes, module loading, and auto-instrumentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->