### PR TITLE
docs(otel-browser): refresh browser SDK guidance

### DIFF
--- a/skills/otel-browser/SKILL.md
+++ b/skills/otel-browser/SKILL.md
@@ -60,8 +60,8 @@ Browser SDK; the span-based packages still live in `opentelemetry-js` / `opentel
 
 These constraints drive most design decisions (detailed in the references):
 
-- **The process disappears** — no graceful shutdown. Flush on `visibilitychange`/`pagehide` with
-  `keepalive`, not `unload`.
+- **The process disappears** — no graceful shutdown. Flush on `visibilitychange`/`pagehide`;
+  browser exporters use `keepalive` when limits allow it. Do not rely on `unload`.
 - **No gRPC** — export is **OTLP/HTTP** only (protobuf or JSON).
 - **Cross-origin propagation is opt-in** — `traceparent` is not sent to other origins unless you set
   `propagateTraceHeaderCorsUrls` **and** the server allows the header via `Access-Control-Allow-Headers`.

--- a/skills/otel-browser/references/instrumentation.md
+++ b/skills/otel-browser/references/instrumentation.md
@@ -80,11 +80,13 @@ batches, captures resources loaded before it was enabled (buffered), and flushes
 | `maxProcessingTime` | `number` | `50` | Max ms spent per idle callback. |
 | `maxQueueSize` | `number` | `1000` | Queue size before forcing an immediate flush. |
 | `initiatorTypes` | `string[]` | (all) | Restrict to specific initiator types, e.g. `['xmlhttprequest', 'fetch']`. |
+| `ignoreUrls` | `(string \| RegExp)[]` | — | Drop resource entries whose URL matches. String matching is exact and case-sensitive; prefer RegExp for robust endpoint filters. |
 
 Captured data: URL, initiator type, total duration, timing phases, transfer/encoded/decoded sizes,
 HTTP protocol (h1/h2/h3), redirect timing, service-worker start, render-blocking status (Chromium).
 This is one of the **highest-volume** RUM signals — a content-heavy page can load hundreds of
-resources. Restrict `initiatorTypes` or sample aggressively (see
+resources. Restrict `initiatorTypes`, set `ignoreUrls` for known-noisy endpoints, or sample
+aggressively (see
 [performance.md](performance.md#telemetry-volume-and-cost)).
 
 ### Web Vitals (`browser.web_vital`)
@@ -106,8 +108,9 @@ INP and CLS finalize near the end of the page lifecycle — they depend on the S
 ### Console (`browser.console`)
 
 Captures console API calls (by default `log`, `warn`, `error`, `info`, `debug`); records carry
-`browser.console.method`. Capturing `log`/`info`/`debug` in production is typically noise and a PII
-risk — restrict it:
+`browser.console.method`. The `messageSerializer` option controls how console arguments become the
+record body (default: join arguments as strings). Capturing `log`/`info`/`debug` in production is
+typically noise and a PII risk — restrict it:
 
 ```typescript
 new ConsoleInstrumentation({ logMethods: ['error', 'warn'] });

--- a/skills/otel-browser/references/instrumentation.md
+++ b/skills/otel-browser/references/instrumentation.md
@@ -80,7 +80,7 @@ batches, captures resources loaded before it was enabled (buffered), and flushes
 | `maxProcessingTime` | `number` | `50` | Max ms spent per idle callback. |
 | `maxQueueSize` | `number` | `1000` | Queue size before forcing an immediate flush. |
 | `initiatorTypes` | `string[]` | (all) | Restrict to specific initiator types, e.g. `['xmlhttprequest', 'fetch']`. |
-| `ignoreUrls` | `(string \| RegExp)[]` | — | Drop resource entries whose URL matches. String matching is exact and case-sensitive; prefer RegExp for robust endpoint filters. |
+| `ignoreUrls` | `(string \| RegExp)[]` | — | Drop resource entries whose URL matches. String matching is exact and case-sensitive; prefer non-stateful RegExp filters (no `g`/`y` flags) for robust endpoint filters. |
 
 Captured data: URL, initiator type, total duration, timing phases, transfer/encoded/decoded sizes,
 HTTP protocol (h1/h2/h3), redirect timing, service-worker start, render-blocking status (Chromium).

--- a/skills/otel-browser/references/performance.md
+++ b/skills/otel-browser/references/performance.md
@@ -75,6 +75,10 @@ document.addEventListener('visibilitychange', () => {
     void tracerProvider.forceFlush();
   }
 });
+document.addEventListener('pagehide', () => {
+  void loggerProvider.forceFlush();
+  void tracerProvider.forceFlush();
+});
 ```
 
 ## Telemetry volume and cost

--- a/skills/otel-browser/references/performance.md
+++ b/skills/otel-browser/references/performance.md
@@ -43,7 +43,8 @@ The main thread renders the page; telemetry must stay off it.
   `Simple*` variants (one network request per record). Bound the queue and batch:
 
 ```typescript
-new BatchLogRecordProcessor(exporter, {
+new BatchLogRecordProcessor({
+  exporter,
   maxQueueSize: 100,        // illustrative — drop records past this rather than grow unbounded
   maxExportBatchSize: 50,
   scheduledDelayMillis: 5000,
@@ -58,9 +59,12 @@ A browser page can be closed, backgrounded, or frozen (bfcache) at any time with
 shutdown. Telemetry buffered in a batch processor is lost if you don't flush in time.
 
 - **Flush on `visibilitychange`/`pagehide`, not `unload`/`beforeunload`** — the latter are unreliable
-  (especially on mobile) and break bfcache.
-- The OTLP/HTTP browser exporter uses **`fetch` with `keepalive`** (the modern replacement for
-  `navigator.sendBeacon`) so in-flight exports survive the page going away.
+  (especially on mobile) and break bfcache. The browser `BatchSpanProcessor` and
+  `BatchLogRecordProcessor` install these flush handlers by default unless
+  `disableAutoFlushOnDocumentHide` is set.
+- The OTLP/HTTP browser exporter uses **`fetch` with `keepalive` when browser limits allow it** (the
+  modern replacement for `navigator.sendBeacon`) so in-flight exports can survive the page going
+  away.
 - Late-finalizing signals (INP, CLS, Web Vitals generally) are only known near the end of the page
   lifecycle — they depend on this flush actually happening.
 
@@ -81,8 +85,8 @@ resource-timing records.
 
 - **Enable a minimal set first** (e.g. Web Vitals + Errors + Navigation); add resource timing,
   console, and user actions deliberately once you understand their volume.
-- **Restrict resource timing** with `initiatorTypes` (e.g. `['xmlhttprequest', 'fetch']`) instead of
-  capturing every script/image/font.
+- **Restrict resource timing** with `initiatorTypes` (e.g. `['xmlhttprequest', 'fetch']`) and
+  `ignoreUrls` instead of capturing every script/image/font and known-noisy endpoints.
 - **Restrict console capture** to `['error', 'warn']` in production.
 - **Sample.** Apply head sampling in the SDK and/or sampling at the Collector edge. Because clients
   are untrusted and chatty, edge sampling and rate limiting protect both cost and your backend.
@@ -119,8 +123,10 @@ Controlling it is partly developer discipline and partly pipeline enforcement.
 - [ ] Subpath imports for instrumentations (no barrel import)
 - [ ] `zone.js`/`ZoneContextManager` included **only** if async span stitching is required
 - [ ] Batch processors with bounded queue/batch sizes (no `Simple*` processors)
-- [ ] `forceFlush()` wired to `visibilitychange`/`pagehide`; export uses `keepalive`
-- [ ] Minimal instrumentation set enabled; resource timing restricted by `initiatorTypes`
+- [ ] Browser batch processor auto-flush on document hide left enabled, or equivalent
+      `forceFlush()` wired to `visibilitychange`/`pagehide`; export uses `keepalive` when possible
+- [ ] Minimal instrumentation set enabled; resource timing restricted by `initiatorTypes` /
+      `ignoreUrls`
 - [ ] Console capture limited to `error`/`warn` in production
 - [ ] Sampling configured (SDK and/or Collector edge)
 - [ ] URL sanitization on; PII redaction enforced in the Collector

--- a/skills/otel-browser/references/setup-sdk.md
+++ b/skills/otel-browser/references/setup-sdk.md
@@ -204,8 +204,9 @@ session manager under `@opentelemetry/browser-sdk/session` (`createSessionManage
 
 > **Processor ordering**: register the session processor **before** the export (batch) processor so
 > `session.id` is stamped before export. If you call the per-signal `startLogsSdk` /
-> `startTracesSdk` with `processors` and no `exportConfig`, no default batch export processor is
-> added; include an export processor or set `exportConfig`.
+> `startTracesSdk` with `processors`, include the export processor in that list. If you want the
+> SDK to build the default batch export processor from `exportConfig` / `batchProcessorConfig`, omit
+> `processors`.
 
 `session.*` follows the
 [session semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/session.md).

--- a/skills/otel-browser/references/setup-sdk.md
+++ b/skills/otel-browser/references/setup-sdk.md
@@ -19,7 +19,8 @@ is no MeterProvider story in the browser yet.
 - **Export over OTLP/HTTP.** gRPC is not available in the browser. Use the OTLP/HTTP (protobuf or
   JSON) exporters.
 - **Flush before the page vanishes.** Pages can be closed, backgrounded, or frozen (bfcache) with no
-  graceful shutdown. Flush on `visibilitychange`/`pagehide` with `keepalive`, not `unload`. See
+  graceful shutdown. Flush on `visibilitychange`/`pagehide`; browser exporters use `keepalive` when
+  limits allow it. Do not rely on `unload`. See
   [performance.md](performance.md#page-lifecycle-flush-before-the-page-vanishes).
 
 ### A Collector (or vendor edge) in front of browsers
@@ -104,9 +105,9 @@ const loggerProvider = new LoggerProvider({
   // no `service.name` and cannot be correlated with the spans from the same app.
   resource,
   processors: [
-    new BatchLogRecordProcessor(
-      new OTLPLogExporter({ url: 'https://collector.example.com/v1/logs' }),
-    ),
+    new BatchLogRecordProcessor({
+      exporter: new OTLPLogExporter({ url: 'https://collector.example.com/v1/logs' }),
+    }),
   ],
 });
 logs.setGlobalLoggerProvider(loggerProvider);
@@ -175,9 +176,12 @@ const sdk = quickStartBrowserSdk({
 });
 ```
 
-`startBrowserSdk` exposes full control (`resourceAttributes`, `exportConfig`, per-signal `logs` /
-`traces` blocks with `spanLimits`/`logRecordLimits`, `contextManager`, `propagators`, `sampler`),
-and `await sdk.shutdown()` flushes and stops.
+`startBrowserSdk` exposes full control (`resourceAttributes`, `exportConfig`,
+`batchProcessorConfig`, per-signal `logs` / `traces` blocks with
+`spanLimits`/`logRecordLimits`, `contextManager`, and `propagators`), and `await sdk.shutdown()`
+flushes and stops. In the `0.1.0` release, the traces config type includes `sampler`, but
+`startTracesSdk` does not yet pass it to the provider — verify source before relying on SDK-level
+sampling there.
 
 ### Per-signal SDKs (tree-shaking)
 
@@ -194,12 +198,14 @@ Each takes the **full** URL (the signal path is not appended automatically).
 A **session** correlates the traces and events a single user produces over a time window, expressed
 as `session.*` attributes (e.g. `session.id`) attached to every span/log. The Browser SDK ships a
 session manager under `@opentelemetry/browser-sdk/session` (`createSessionManager`,
-`createLocalStorageSessionStore`, `createSessionSpanProcessor`, `createSessionLogRecordProcessor`),
-with configurable `maxDuration` and `inactivityTimeout`.
+`createDefaultSessionIdGenerator`, `createLocalStorageSessionStore`, `createSessionSpanProcessor`,
+`createSessionLogRecordProcessor`), with configurable `maxDuration` and `inactivityTimeout`
+(seconds).
 
 > **Processor ordering**: register the session processor **before** the export (batch) processor so
-> `session.id` is stamped before export. If you set `processors` explicitly you own the pipeline —
-> include both the session processor and an export processor.
+> `session.id` is stamped before export. If you call the per-signal `startLogsSdk` /
+> `startTracesSdk` with `processors` and no `exportConfig`, no default batch export processor is
+> added; include an export processor or set `exportConfig`.
 
 `session.*` follows the
 [session semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/session.md).
@@ -232,7 +238,7 @@ new FetchInstrumentation({
 - [ ] `BatchSpanProcessor` / `BatchLogRecordProcessor` (not `Simple*`) for export efficiency
 - [ ] Session processor registered **before** the export processor
 - [ ] `propagateTraceHeaderCorsUrls` set and server `Access-Control-Allow-Headers` includes `traceparent`
-- [ ] Telemetry flushed on `visibilitychange`/`pagehide` (keepalive), not `unload`
+- [ ] Telemetry flushed on `visibilitychange`/`pagehide`; export uses `keepalive` when possible, not `unload`
 - [ ] **Verified** each enabled instrumentation actually emits to the Collector (diag logging + `debug` exporter), not just assumed
 
 ## Anti-patterns
@@ -243,7 +249,7 @@ new FetchInstrumentation({
 | Exporting straight to a backend store from the browser | Leaks credentials, no CORS control, no edge sampling/redaction, unbounded cost | Export to a Collector / vendor edge endpoint |
 | Expecting `traceparent` on cross-origin calls by default | The browser only propagates same-origin unless told otherwise | Set `propagateTraceHeaderCorsUrls` **and** server `Access-Control-Allow-Headers` |
 | `SimpleSpanProcessor` / `SimpleLogRecordProcessor` in production | One network request per record | Use the Batch processors |
-| Flushing on `unload` | Unreliable on mobile/bfcache; blocks navigation | Flush on `visibilitychange`/`pagehide` with `keepalive` |
+| Flushing on `unload` | Unreliable on mobile/bfcache; blocks navigation | Flush on `visibilitychange`/`pagehide`; use browser OTLP export with `keepalive` when possible |
 | Session processor after the batch processor | Records exported before `session.id` is attached | Put the session processor first |
 | Shipping `sdk-trace-web` without a context manager | Async user interactions lose parent context | Register `ZoneContextManager` |
 | `resource: resourceFromAttributes({...})` as the whole resource | Replaces the default resource; drops `telemetry.sdk.*` and env-detected attributes | Merge: `defaultResource().merge(resourceFromAttributes({...}))` |


### PR DESCRIPTION
## Summary
- Updates browser lifecycle flush guidance to describe `keepalive` as conditional on browser limits.
- Refreshes Browser SDK setup facts for `batchProcessorConfig`, session helpers, exporter/processor behavior, and the 0.1.0 sampler caveat.
- Adds current `ResourceTimingInstrumentation.ignoreUrls` and `ConsoleInstrumentation.messageSerializer` guidance.

## Verification
- Synced `opentelemetry-browser`, `opentelemetry-js`, and `opentelemetry-js-contrib` from upstream/main on 2026-07-12; all were already up to date.
- Audited released ceilings locally: `browser-sdk-v0.1.0`, browser instrumentation `0.5.2`, JS `v2.9.0` / `0.220.0`, and `auto-instrumentations-web-v0.65.0`.
- Verified referenced local upstream paths exist.
- `git diff --check -- skills/otel-browser` passed.
- `skills-ref validate skills/otel-browser` not run: `skills-ref` is not installed locally.

## Deliberately excluded
- No unreleased post-tag changes from JS/browser/contrib.
- No scope expansion beyond current browser skill content.
- No web repo-content fetches; audit used synced local OpenTelemetry checkouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined browser RUM “process disappears” guidance to emphasize flushing on `visibilitychange`/`pagehide`, using OTLP/HTTP `keepalive` only when permitted, and avoiding blanket `unload` advice.
  * Improved Resource Timing (`browser.resource_timing`) filtering with `ignoreUrls` (case-sensitive, exact string matching guidance) alongside `initiatorTypes`.
  * Expanded `browser.console` signal docs with `messageSerializer` details and clearer production capture recommendations.
  * Updated setup/performance guidance for page-lifecycle auto-flush behavior and processor/exporter wiring examples (including per-signal SDK startup nuances).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->