### PR TITLE
docs(otel-go): refresh current API guidance

### DIFF
--- a/skills/otel-go/SKILL.md
+++ b/skills/otel-go/SKILL.md
@@ -29,7 +29,7 @@ and version churn:
 | Stable signals (traces, metrics) | `go.opentelemetry.io/otel`, `otel/sdk`, `otel/trace`, `otel/metric`, OTLP trace/metric exporters | **v1.x** (e.g. v1.44.0) |
 | Logs | `otel/log`, `otel/sdk/log`, `otel/exporters/otlp/otlplog/otlploghttp` | **v0.x** (separate, lower line) |
 | Contrib instrumentation | `contrib/instrumentation/net/http/otelhttp`, `.../otelgrpc` | **v0.x** (separate line, e.g. v0.69.0) |
-| Contrib log bridges | `contrib/bridges/otelslog`, `otelzap`, `otelzerolog` | **v0.x** |
+| Contrib log bridges | `contrib/bridges/otelslog`, `otelzap`, `otellogrus`, `otellogr` | **v0.x** |
 
 **The trap:** pinning every module to the core version (e.g. `go get go.opentelemetry.io/otel/log@v1.44.0`)
 fails — log and bridge modules have no v1.x tag. Hand-picking and re-guessing each `@vX`

--- a/skills/otel-go/references/api.md
+++ b/skills/otel-go/references/api.md
@@ -165,7 +165,7 @@ _, _ = meter.Int64ObservableGauge("memory.usage",
 
 // Check if an instrument is enabled before expensive operations (v1.40.0+)
 // Available on all synchronous instruments: Counter, UpDownCounter, Histogram, Gauge
-if counter.Enabled(ctx, metric.WithAttributes(attribute.String("method", "GET"))) {
+if counter.Enabled(ctx) {
     // Only compute expensive value if the instrument will record
     value := computeExpensiveMetric()
     counter.Add(ctx, value, metric.WithAttributes(attribute.String("method", "GET")))
@@ -182,9 +182,11 @@ attribute.Int64("count", 42)
 attribute.Float64("ratio", 0.95)
 attribute.Bool("enabled", true)
 attribute.StringSlice("tags", []string{"a", "b"})
+attribute.ByteSlice("payload", []byte("data"))
 attribute.Int64Slice("ids", []int64{1, 2, 3})
 attribute.Float64Slice("values", []float64{1.1, 2.2})
 attribute.BoolSlice("flags", []bool{true, false})
+attribute.Slice("nested", attribute.StringValue("a"), attribute.Int64Value(1)) // v1.44.0+
 ```
 
 ### Attribute Sets
@@ -224,9 +226,9 @@ propagator.Inject(ctx, propagation.HeaderCarrier(w.Header()))
 
 The Logs API and SDK are versioned on a **separate v0.x line** (currently `otel/log` and
 `otel/sdk/log` v0.20.0, released alongside core v1.44.0) and are **not yet declared stable** —
-interfaces may still change without a major bump. They are production-usable and primarily
-provide a bridge for existing logging libraries. Track their version independently from the
-stable v1.x traces/metrics signals (see the module-versioning table in SKILL.md).
+interfaces may still change without a major bump. They primarily provide a bridge for existing
+logging libraries. Track their version independently from the stable v1.x traces/metrics
+signals (see the module-versioning table in SKILL.md).
 
 ### Core Types
 ```go
@@ -308,9 +310,6 @@ import (
 
     // For logrus logging
     "go.opentelemetry.io/contrib/bridges/otellogrus"
-
-    // For zerolog logging
-    "go.opentelemetry.io/contrib/bridges/otelzerolog"
 
     // For logr logging
     "go.opentelemetry.io/contrib/bridges/otellogr"

--- a/skills/otel-go/references/api.md
+++ b/skills/otel-go/references/api.md
@@ -182,7 +182,7 @@ attribute.Int64("count", 42)
 attribute.Float64("ratio", 0.95)
 attribute.Bool("enabled", true)
 attribute.StringSlice("tags", []string{"a", "b"})
-attribute.ByteSlice("payload", []byte("data"))
+attribute.ByteSlice("payload", []byte("data")) // v1.44.0+
 attribute.Int64Slice("ids", []int64{1, 2, 3})
 attribute.Float64Slice("values", []float64{1.1, 2.2})
 attribute.BoolSlice("flags", []bool{true, false})

--- a/skills/otel-go/references/breaking-changes.md
+++ b/skills/otel-go/references/breaking-changes.md
@@ -6,13 +6,12 @@ version selection, fetch from the Sources of Truth table in the `otel-go` skill 
 
 ## API Deprecations
 
-- `span.RecordError()` and `span.AddEvent()` are deprecated. Use the Logs API to emit events and record exceptions within the context of the active span.
 - `go.opentelemetry.io/contrib/config` is deprecated (contrib v1.35.0). Use `go.opentelemetry.io/contrib/otelconf` instead. The API is identical.
 - `WithMetricAttributesFn` deprecated in otelhttp (contrib v1.41.0). Use `Labeler` instead.
 - otelgrpc: prefer stats handlers (`NewServerHandler` / `NewClientHandler`) over deprecated interceptors for new code.
 - `attribute.INVALID` deprecated (core v1.43.0) — an empty value is now valid; use `attribute.EMPTY` instead.
 - `attribute.Value.Emit` deprecated (core v1.44.0). Use `attribute.Value.String` instead.
-- `OTEL_EXPERIMENTAL_CONFIG_FILE` deprecated in `otelconf` (contrib v1.43.0). Use `OTEL_CONFIG_FILE`.
+- `OTEL_EXPERIMENTAL_CONFIG_FILE` is no longer supported by root `otelconf` v0.23.0+ (contrib v1.43.0+). Use `OTEL_CONFIG_FILE`.
 
 ## Removed APIs (contrib v1.40.0+)
 
@@ -62,6 +61,7 @@ RPC attribute changes:
 ## Behavioural Notes
 
 - `trace.SpanFromContext()` never returns nil — no nil checks or `IsRecording()` guards needed.
+- `span.RecordError()` and `span.AddEvent()` are still present in the released tracing API; do not remove existing uses as deprecated APIs.
 - `log.Record.SetErr(err)` (v1.42.0) — the SDK automatically sets `exception.type` and `exception.message` attributes.
 
 ## Resolved Gotchas (historical reference)

--- a/skills/otel-go/references/declarative-setup.md
+++ b/skills/otel-go/references/declarative-setup.md
@@ -79,7 +79,7 @@ resource:
 ## Key API Facts
 
 - **`otelconf.ParseYAML([]byte) (*OpenTelemetryConfiguration, error)`** parses a YAML config file.
-- **`otelconf.NewSDK(opts ...) (SDK, error)`** builds the SDK from a parsed configuration. Options include `WithContext(ctx)` and `WithOpenTelemetryConfiguration(conf OpenTelemetryConfiguration)`; after `ParseYAML`, pass `*conf`.
+- **`otelconf.NewSDK(opts ...) (SDK, error)`** builds the SDK from a parsed configuration. Options include `WithContext(ctx)` and `WithOpenTelemetryConfiguration(conf OpenTelemetryConfiguration)`; after `ParseYAML`, pass `*conf` because `ParseYAML` returns `*OpenTelemetryConfiguration`.
 - **`sdk.TracerProvider()`, `sdk.MeterProvider()`, `sdk.LoggerProvider()`** return the configured providers.
 - **`sdk.Propagator()`** (root package, `otelconf v0.20.0+`, fixes [open-telemetry/opentelemetry-go-contrib#6712](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/6712)) returns the propagator built from the YAML `propagator:` block. Install it via `otel.SetTextMapPropagator(sdk.Propagator())`. Not available on the schema-pinned `otelconf/v0.3.0` subpackage.
 - **`sdk.Shutdown(ctx) error`** flushes and closes all providers.

--- a/skills/otel-go/references/declarative-setup.md
+++ b/skills/otel-go/references/declarative-setup.md
@@ -37,6 +37,8 @@ latest module tag supports.
 ## Migration notes
 
 - `go.opentelemetry.io/contrib/config` is deprecated. Use `go.opentelemetry.io/contrib/otelconf`.
+- In the root package, use `OTEL_CONFIG_FILE`; `OTEL_EXPERIMENTAL_CONFIG_FILE` is rejected by
+  current released `otelconf`.
 - If migrating from the schema-pinned `otelconf/v0.3.0` import, the YAML must also migrate to
   the new schema (fetch `examples/otel-sdk-migration-config.yaml` from the schema repo for
   before/after pairs).
@@ -77,7 +79,7 @@ resource:
 ## Key API Facts
 
 - **`otelconf.ParseYAML([]byte) (*OpenTelemetryConfiguration, error)`** parses a YAML config file.
-- **`otelconf.NewSDK(opts ...) (SDK, error)`** builds the SDK from a parsed configuration. Options include `WithContext(ctx)` and `WithOpenTelemetryConfiguration(*conf)`.
+- **`otelconf.NewSDK(opts ...) (SDK, error)`** builds the SDK from a parsed configuration. Options include `WithContext(ctx)` and `WithOpenTelemetryConfiguration(conf OpenTelemetryConfiguration)`; after `ParseYAML`, pass `*conf`.
 - **`sdk.TracerProvider()`, `sdk.MeterProvider()`, `sdk.LoggerProvider()`** return the configured providers.
 - **`sdk.Propagator()`** (root package, `otelconf v0.20.0+`, fixes [open-telemetry/opentelemetry-go-contrib#6712](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/6712)) returns the propagator built from the YAML `propagator:` block. Install it via `otel.SetTextMapPropagator(sdk.Propagator())`. Not available on the schema-pinned `otelconf/v0.3.0` subpackage.
 - **`sdk.Shutdown(ctx) error`** flushes and closes all providers.

--- a/skills/otel-go/references/instrumentation-libraries.md
+++ b/skills/otel-go/references/instrumentation-libraries.md
@@ -19,7 +19,6 @@ import (
     "go.opentelemetry.io/contrib/bridges/otelzap"
     "go.opentelemetry.io/contrib/bridges/otelslog"
     "go.opentelemetry.io/contrib/bridges/otellogrus"
-    "go.opentelemetry.io/contrib/bridges/otelzerolog"
 )
 ```
 
@@ -139,7 +138,7 @@ func setupGRPCServerWithSpanKind() *grpc.Server {
 
 | Library | Package |
 |---------|---------|
-| database/sql | `go.opentelemetry.io/contrib/instrumentation/database/sql/otelsql` |
+| database/sql | No package in current `go.opentelemetry.io/contrib`; check the OpenTelemetry registry for third-party instrumentation or instrument manually with `...Context` methods. |
 | MongoDB | `go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo` |
 | GORM | `gorm.io/plugin/opentelemetry/tracing` (registered via `db.Use(tracing.NewPlugin(...))`) |
 
@@ -154,9 +153,9 @@ func setupGRPCServerWithSpanKind() *grpc.Server {
 > ```
 >
 > Treat this as the default for any service that touches user data. The same trap applies to other
-> SQL instrumentation that captures full statement text — for `otelsql`, suppress it with
-> `otelsql.WithSpanOptions(otelsql.SpanOptions{DisableQuery: true})`. Keep parameter values out of
-> `db.query.text`, or redact them downstream.
+> SQL instrumentation that captures full statement text; verify the selected package's option to
+> disable or redact query text. Keep parameter values out of `db.query.text`, or redact them
+> downstream.
 
 ### AWS
 
@@ -172,7 +171,6 @@ func setupGRPCServerWithSpanKind() *grpc.Server {
 | zap | `go.opentelemetry.io/contrib/bridges/otelzap` |
 | slog | `go.opentelemetry.io/contrib/bridges/otelslog` |
 | logrus | `go.opentelemetry.io/contrib/bridges/otellogrus` |
-| zerolog | `go.opentelemetry.io/contrib/bridges/otelzerolog` |
 | logr | `go.opentelemetry.io/contrib/bridges/otellogr` |
 
 > **Logging bridge change (contrib v1.35.0):** otelzap and otelslog now emit `code.function` with the full package path-qualified function name (e.g., `github.com/user/pkg.MyFunc`) instead of just the function name. The `code.namespace` attribute is no longer emitted.

--- a/skills/otel-go/references/instrumentation-libraries.md
+++ b/skills/otel-go/references/instrumentation-libraries.md
@@ -154,8 +154,9 @@ func setupGRPCServerWithSpanKind() *grpc.Server {
 >
 > Treat this as the default for any service that touches user data. The same trap applies to other
 > SQL instrumentation that captures full statement text; verify the selected package's option to
-> disable or redact query text. Keep parameter values out of `db.query.text`, or redact them
-> downstream.
+> disable or redact query text. Keep parameter values out of `db.query.text` before export. If the
+> selected instrumentation cannot sanitize or parameterize query text, disable query-text capture;
+> downstream redaction is defense-in-depth.
 
 ### AWS
 

--- a/skills/otel-go/references/performance.md
+++ b/skills/otel-go/references/performance.md
@@ -473,7 +473,7 @@ As of v1.40.0, all synchronous metric instruments (`Int64Counter`, `Float64Count
 histogram, _ := meter.Float64Histogram("expensive.metric")
 
 attrs := metric.WithAttributes(attribute.String("region", region))
-if histogram.Enabled(ctx, attrs) {
+if histogram.Enabled(ctx) {
     value := computeExpensiveValue() // Only called when instrument is active
     histogram.Record(ctx, value, attrs)
 }


### PR DESCRIPTION
## Summary
- Updates contrib bridge references to the currently released Go log bridges.
- Fixes metric `Enabled(ctx)` examples and adds current v1.44.0 attribute helpers.
- Corrects stale deprecation guidance for `RecordError` / `AddEvent`, `OTEL_EXPERIMENTAL_CONFIG_FILE`, and `otelconf` setup signatures.
- Removes stale `otelsql` / `otelzerolog` package references.

## Verification
- Synced `opentelemetry-go` and `opentelemetry-go-contrib` from upstream/main on 2026-07-12; both were already up to date.
- Checked released local tags: core `v1.44.0`, logs `v0.20.0`, contrib instrumentation `v0.69.0`, bridges `v0.19.0`, and `otelconf/v0.24.0`.
- `go test ./...` passed in a disposable module for released core/log/metric/trace API shapes.
- `git diff --check -- skills/otel-go` passed.
- `skills-ref validate skills/otel-go` not run: `skills-ref` is not installed locally.

## Deliberately excluded
- No unreleased main changes, including semconv `v1.42.0` and unreleased log API changes.
- No `opentelemetry-go-instrumentation` content; it remains out of scope for this skill.
- No web repo-content fetches; audit used synced local OpenTelemetry checkouts and cached Go modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenTelemetry Go guidance for logging bridges, including current module recommendations.
  * Clarified configuration file requirements and SDK setup examples.
  * Corrected metric enablement examples and expanded attribute examples.
  * Updated API deprecation and behavioral notes for tracing methods.
  * Revised database instrumentation and SQL query-text privacy guidance.
  * Removed outdated zerolog references and clarified Logs API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->