### PR TITLE
docs(otel-ottl): refresh collector OTTL guidance

### DIFF
--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: otel-ottl
-description: OpenTelemetry Transformation Language (OTTL) expert for writing and debugging telemetry transformations in the OpenTelemetry Collector. Use when authoring or reviewing `transform`, `filter`, `routing`, or `tail_sampling` processor configs, debugging OTTL syntax or semantics, transforming traces, metrics, logs, or profiles, or converting data-processing requirements into OTTL statements.
+description: OpenTelemetry Transformation Language (OTTL) expert for writing and debugging telemetry transformations in the OpenTelemetry Collector. Use when authoring or reviewing `transform`, `filter`, `tail_sampling` processor configs or `routing` connector configs, debugging OTTL syntax or semantics, transforming traces, metrics, logs, or profiles, or converting data-processing requirements into OTTL statements.
 ---
 
 # OpenTelemetry Transformation Language (OTTL)
 
-OTTL is a domain-specific language for transforming telemetry inside the OpenTelemetry Collector. It is consumed by the `transform`, `filter`, `routing`, and `tail_sampling` processors (and a few others) in [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl).
+OTTL is a domain-specific language for transforming telemetry inside the OpenTelemetry Collector. It is consumed by the `transform`, `filter`, and `tail_sampling` processors, the `routing` connector, and a few other components in [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl).
 
 This skill targets `pkg/ottl` as of collector-contrib **v0.156.0**. Function and path availability differs across Collector releases; check the upstream `pkg/ottl/ottlfuncs/README.md` and `pkg/ottl/contexts/*/README.md` for the exact set in older or newer releases.
 
@@ -23,11 +23,11 @@ set(span.attributes["env"], "prod") where resource.attributes["env"] == nil
 
 ## Workflow
 
-1. **Pick the processor.** `transform` rewrites; `filter` drops; `routing` fans out by pipeline; `tail_sampling` keeps/drops traces. The processor decides which contexts and function set are usable.
-2. **Pick the context.** `resource`, `scope`, `span`, `spanevent`, `metric`, `datapoint`, `exemplar`, `log`, `profile`, `profilesample`. Operate at the lowest level that gives you the data — using `datapoint` to set attributes is much cheaper than walking through `metric.data_points` from the metric context.
+1. **Pick the component.** `transform` rewrites; `filter` drops; the `routing` connector fans out by pipeline; `tail_sampling` keeps/drops traces. The component decides which contexts and function set are usable.
+2. **Pick the context.** `resource`, `scope`, `span`, `spanevent`, `metric`, `datapoint`, `exemplar`, `log`, `profile`, `profilesample`, or `otelcol` for Collector request/client metadata. Operate at the lowest level that gives you the data — using `datapoint` to set attributes is much cheaper than walking through `metric.data_points` from the metric context.
 3. **Write statements.** Reach for `references/quick-reference.md` for common recipes; `references/contexts.md` for paths/enums; `references/functions.md` for the editor and converter catalog.
-4. **Set `error_mode`.** `ignore` (default) keeps the pipeline running and logs errors; `silent` does the same but quietly; `propagate` aborts on first failure (use only when you want a bad config to fail loud in tests).
-5. **Verify.** OTTL gotchas are the kind that pass the eye test (see [Common gotchas](#common-gotchas)). Use the [telemetrygen verification recipe](../telemetrygen/SKILL.md#verifying-a-collector-config) — `otelcol-contrib` + file exporter + telemetrygen — to confirm the snippet does what the prose claims before shipping.
+4. **Set `error_mode`.** `ignore` keeps the pipeline running and logs errors; `silent` does the same but quietly; `propagate` aborts on first failure. In v0.156, `transform` and `filter` default to `ignore` through enabled beta feature gates; `routing` defaults to `propagate` unless `connector.routing.defaultErrorModeIgnore` is enabled; lower-level OTTL sequences default to `propagate`.
+5. **Verify.** OTTL gotchas are the kind that pass the eye test (see [Common gotchas](#common-gotchas)). Use the [telemetrygen verification recipe](../otel-telemetrygen/SKILL.md#verifying-a-collector-config) — `otelcol-contrib` + file exporter + telemetrygen — to confirm the snippet does what the prose claims before shipping.
 
 ## Contexts at a glance
 
@@ -44,6 +44,7 @@ OTTL paths are scoped by signal. Higher levels are reachable from lower ones (e.
 | Exemplar | `exemplar.double_value`, `exemplar.int_value`, `exemplar.filtered_attributes["…"]` (transform `metric_statements` only, v0.156+) |
 | Log | `log.body`, `log.body.string`, `log.severity_number`, `log.attributes["…"]` |
 | Profile | `profile.profile_id`, `profile.attributes["…"]` (Development) |
+| OTelCol | `otelcol.client.metadata["x-tenant"][0]`, `otelcol.grpc.metadata["x-tenant"][0]` (read-only, enabled by default feature gate) |
 
 Full path inventory plus enums in `references/contexts.md`.
 
@@ -54,7 +55,7 @@ Full path inventory plus enums in `references/contexts.md`.
 set(target, value)
 delete_key(target, key)               # delete by exact key
 delete_matching_keys(target, regex)   # delete by regex
-delete_index(target, index)           # remove from a slice (v0.145+)
+delete_index(target, start, end?)     # remove one slice item or range (v0.145+)
 keep_keys(target, [k1, k2])           # keep only these keys
 merge_maps(target, source, "upsert")  # "insert" | "update" | "upsert"
 truncate_all(target, max_len)         # UTF-8 safe by default in v0.148+
@@ -136,19 +137,19 @@ processors:
 
   filter:
     error_mode: ignore
-    traces:
-      span:
-        - 'IsMatch(span.name, "^/health.*")'
-    logs:
-      log_record:
-        - 'log.severity_number < SEVERITY_NUMBER_WARN'
+    trace_conditions:
+      - 'IsMatch(span.name, "^/health.*")'
+    log_conditions:
+      - 'log.severity_number < SEVERITY_NUMBER_WARN'
 
+connectors:
   routing:
+    error_mode: ignore
     default_pipelines: [traces/default]
     table:
-      - statement: 'route() where resource.attributes["env"] == "prod"'
+      - condition: 'resource.attributes["env"] == "prod"'
         pipelines: [traces/prod]
-      - statement: 'route() where span.status.code == STATUS_CODE_ERROR'
+      - condition: 'span.status.code == STATUS_CODE_ERROR'
         pipelines: [traces/errors]
 
   tail_sampling:
@@ -203,13 +204,17 @@ In older configs you may see `span_event.*` — current syntax is `spanevent.*`.
 
 Use `Decode(value, "base64")` instead. The same `Decode` converter handles `base64-raw`, `base64-url`, `base64-raw-url`, and IANA character set encodings. Keep `Base64Decode` only if pinned to a pre-v0.141 collector.
 
+### `routing` request context is deprecated
+
+In routing connector configs, use `otelcol.client.metadata["key"][0]` for HTTP/client metadata or `otelcol.grpc.metadata["key"][0]` for gRPC metadata. The old `context: request` plus `request["key"] == "value"` form is deprecated in v0.156.
+
 ### `Bool` converter coercion is loose
 
 `Bool("true")`, `Bool("1")`, `Bool(1)` all return `true`; `Bool("false")`, `Bool("0")`, `Bool(0)`, `Bool(0.0)` return `false`. Anything else errors. Don't assume Python-like truthiness for arbitrary strings.
 
 ### Verify before publishing
 
-YAML/OTTL gotchas like the above pass the eye test. Use the [telemetrygen verification recipe](../telemetrygen/SKILL.md#verifying-a-collector-config) (otelcol-contrib + file exporter + telemetrygen) to confirm the snippet does what the surrounding prose claims, especially before shipping to a customer or production.
+YAML/OTTL gotchas like the above pass the eye test. Use the [telemetrygen verification recipe](../otel-telemetrygen/SKILL.md#verifying-a-collector-config) (otelcol-contrib + file exporter + telemetrygen) to confirm the snippet does what the surrounding prose claims, especially before shipping to a customer or production.
 
 ## Best practices
 
@@ -227,6 +232,11 @@ Recently added (still useful to know which release introduced them when supporti
 | Feature | Since |
 |---------|-------|
 | Exemplar context (transform `metric_statements` only) | v0.156 |
+| Routing connector context inference (`condition` with context-qualified paths) | v0.156 |
+| Routing connector `request` context deprecated; use `otelcol.*` metadata paths | v0.156 |
+| `connector.routing.defaultErrorModeIgnore` feature gate | v0.155 |
+| `otelcol.*` context via enabled-by-default `ottl.contexts.enableOTelColContext` feature gate | v0.147 |
+| Filter processor top-level `trace_conditions`, `metric_conditions`, `log_conditions` | v0.146 |
 | Profile / ProfileSample contexts | v0.124 / v0.132 (Development) |
 | Cache paths require context prefix; `spanevent` rename | v0.120 (breaking) |
 | `delete_index` editor | v0.145 |

--- a/skills/otel-ottl/references/contexts.md
+++ b/skills/otel-ottl/references/contexts.md
@@ -11,6 +11,8 @@ Resource
       ├── Metric → DataPoint → Exemplar
       ├── Log
       └── Profile → Profile Sample
+
+OTelCol (Collector request/client metadata; read-only)
 ```
 
 ## Resource context
@@ -310,6 +312,19 @@ datapoint.metadata["X-Custom-Header"]
 ```
 
 Common uses: tenant routing, request-level enrichment, conditional drop based on caller identity.
+
+## OTelCol context (v0.147+, enabled by default feature gate)
+
+The `otelcol` context exposes Collector-side client and request data that is not part of the telemetry payload. It is read-only. In v0.156, the routing connector deprecated its old `request` context in favor of these paths.
+
+```ottl
+otelcol.client.addr
+otelcol.client.metadata["x-tenant-id"][0]   # first HTTP/client metadata value
+otelcol.client.auth.attributes["subject"]   # auth extension attributes
+otelcol.grpc.metadata["x-tenant-id"][0]     # incoming gRPC metadata value
+```
+
+Prefer `otelcol.*` paths for routing/filtering conditions. If copying values into telemetry, only copy allowlisted, non-sensitive keys; metadata often includes authorization headers, cookies, or API keys.
 
 ## Enums
 

--- a/skills/otel-ottl/references/functions.md
+++ b/skills/otel-ottl/references/functions.md
@@ -26,7 +26,8 @@ If `target` is a scalar, it is converted to a slice first.
 ```ottl
 delete_key(span.attributes, "internal.debug")
 delete_matching_keys(span.attributes, "(?i).*password.*")
-delete_index(log.attributes["tags"], 0)        # v0.145+, slice index
+delete_index(log.attributes["tags"], 0)        # v0.145+, one slice index
+delete_index(log.attributes["tags"], 0, 3)     # delete indices 0, 1, 2
 ```
 
 ### `keep_keys` / `keep_matching_keys`
@@ -305,7 +306,7 @@ FNV(v)                                        # int64
 Murmur3Hash(v) / Murmur3Hash128(v)            # v0.129+
 XXH3(v) / XXH128(v)                           # v0.135+; very fast
 Decode(value, encoding)                       # v0.141+; "base64", "base64-raw", "base64-url", "base64-raw-url", IANA charsets
-Base64Encode(v)                               # v0.147+
+Base64Encode(v, variant?)                     # v0.147+; default base64
 Base64Decode(v)                               # DEPRECATED — use Decode(v, "base64")
 Hex(bytes)
 ```

--- a/skills/otel-ottl/references/quick-reference.md
+++ b/skills/otel-ottl/references/quick-reference.md
@@ -181,25 +181,24 @@ processors:
 processors:
   filter:
     error_mode: ignore
-    traces:
-      span:
-        - 'IsMatch(span.name, "^/health.*")'
-        - 'span.kind == SPAN_KIND_INTERNAL'
-    logs:
-      log_record:
-        - 'log.severity_number < SEVERITY_NUMBER_WARN'
+    trace_conditions:
+      - 'IsMatch(span.name, "^/health.*")'
+      - 'span.kind == SPAN_KIND_INTERNAL'
+    log_conditions:
+      - 'log.severity_number < SEVERITY_NUMBER_WARN'
 ```
 
-### `routing`
+### `routing` connector
 
 ```yaml
-processors:
+connectors:
   routing:
+    error_mode: ignore
     default_pipelines: [traces/default]
     table:
-      - statement: 'route() where resource.attributes["env"] == "prod"'
+      - condition: 'resource.attributes["env"] == "prod"'
         pipelines: [traces/prod]
-      - statement: 'route() where span.status.code == STATUS_CODE_ERROR'
+      - condition: 'span.status.code == STATUS_CODE_ERROR'
         pipelines: [traces/errors]
 ```
 
@@ -345,7 +344,7 @@ where span.kind == SPAN_KIND_SERVER and IsMatch(span.name, "expensive.*")
 1. Syntax: parens balanced, strings closed, regex escapes doubled.
 2. Types: type-check before conversion (`IsString`, `IsInt`).
 3. Existence: nil-guard paths that may be absent.
-4. Logic: dry-run with the [telemetrygen verification recipe](../../telemetrygen/SKILL.md#verifying-a-collector-config) — generate a known input, capture the file-exporter output, confirm the transformation. The eye test misses too many gotchas.
+4. Logic: dry-run with the [telemetrygen verification recipe](../../otel-telemetrygen/SKILL.md#verifying-a-collector-config) — generate a known input, capture the file-exporter output, confirm the transformation. The eye test misses too many gotchas.
 5. Performance: most-selective `where` clause first.
 
 ### Safe transformation skeletons


### PR DESCRIPTION
## Summary
- Updates routing guidance from the old processor shape to current routing connector configuration.
- Adds current `otelcol.*` context guidance and v0.156 routing request-context migration notes.
- Corrects `error_mode` defaults, filter `*_conditions`, routing `condition`, and OTTL function signatures.

## Verification
- Synced `opentelemetry-collector-contrib` from upstream/main on 2026-07-12; it was already up to date.
- Targeted released collector-contrib tag `v0.156.0` for source checks.
- Verified upstream paths for `pkg/ottl`, OTTL contexts/functions, transform/filter/tail-sampling processors, and routing connector exist locally.
- `otelcol-contrib validate` passed for transform/filter examples and tail-sampling validation configs using the locally installed collector.
- `git diff --check -- skills/otel-ottl` passed.
- `skills-ref validate skills/otel-ottl` not run: `skills-ref` is not installed locally.

## Deliberately excluded
- Unreleased main-only OTTL functions (`Any`, `All`, `MapEach`, `Filter`, `When`).
- Unreleased README-only wording around deprecated nested filter config.
- Full v0.156 runtime validation for routing/exemplar behavior: local `otelcol-contrib` is `0.155.0`, so those were source-verified.