### PR TITLE
docs(otel-telemetrygen): refresh flag examples

### DIFF
--- a/skills/otel-telemetrygen/SKILL.md
+++ b/skills/otel-telemetrygen/SKILL.md
@@ -7,6 +7,8 @@ description: Construct telemetrygen commands for generating synthetic OpenTeleme
 
 Generate synthetic OpenTelemetry telemetry with `telemetrygen` from [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/cmd/telemetrygen).
 
+Upstream metadata currently marks the traces, metrics, and logs subcommands as alpha.
+
 ## Quick orientation
 
 `telemetrygen` has three subcommands -- `traces`, `metrics`, `logs` -- each exporting via OTLP to a collector or backend. The default transport is gRPC on port 4317; add `--otlp-http` to switch to HTTP on port 4318.
@@ -44,10 +46,10 @@ See `references/flags.md` for the full flag reference. Key flags:
 ### Attribute value format
 
 ```
---otlp-attributes key="string-value"       # String (must be quoted)
---otlp-attributes key=true                  # Boolean
---otlp-attributes key=123                   # Integer
---otlp-attributes key=[val1,val2,val3]      # Slice
+--otlp-attributes 'key="string-value"'       # String (quotes must reach telemetrygen)
+--otlp-attributes key=true                   # Boolean
+--otlp-attributes key=123                    # Integer
+--otlp-attributes 'key=["val1","val2"]'      # Slice (all elements same type)
 ```
 
 Resource attributes (`--otlp-attributes`) attach to the Resource; telemetry attributes (`--telemetry-attributes`) attach to the individual span, data point, or log record. Mixing them up is a common mistake.
@@ -72,8 +74,8 @@ telemetrygen traces --otlp-insecure --traces 20 --child-spans 5
 # Custom service with attributes
 telemetrygen traces --otlp-insecure --traces 10 \
   --service "checkout-service" \
-  --otlp-attributes deployment.environment="staging" \
-  --telemetry-attributes http.method="POST"
+  --otlp-attributes 'deployment.environment="staging"' \
+  --telemetry-attributes 'http.method="POST"'
 ```
 
 ## Metrics
@@ -158,7 +160,7 @@ telemetrygen logs --otlp-insecure --logs 5 \
 
 # Multi-tenant via headers
 telemetrygen traces --otlp-insecure --traces 100 \
-  --otlp-header X-Scope-OrgID="tenant-a"
+  --otlp-header 'X-Scope-OrgID="tenant-a"'
 ```
 
 ## TLS and mTLS

--- a/skills/otel-telemetrygen/references/flags.md
+++ b/skills/otel-telemetrygen/references/flags.md
@@ -68,10 +68,10 @@ These apply to all subcommands (`traces`, `metrics`, `logs`).
 ### Attribute Value Format
 
 ```
-key="string-value"       # String (must be quoted)
-key=true                  # Boolean
-key=123                   # Integer
-key=[val1,val2,val3]      # Slice (all elements same type)
+'key="string-value"'       # String (quotes must reach telemetrygen)
+key=true                   # Boolean
+key=123                    # Integer
+'key=["val1","val2"]'      # Slice (all elements same type)
 ```
 
 ## Trace-Specific Flags


### PR DESCRIPTION
## Summary
- Adds the current upstream alpha status for telemetrygen traces, metrics, and logs subcommands.
- Quotes string attribute/header examples so shell quoting preserves values for telemetrygen parsing.
- Updates slice examples to match the current parser expectations.

## Verification
- Synced `opentelemetry-collector-contrib` from upstream/main on 2026-07-12; it was already up to date.
- Source-verified telemetrygen flags/defaults under `cmd/telemetrygen` for released `v0.156.0`.
- Installed telemetrygen smoke tests confirmed quoted attributes/headers parse before expected export failure to a closed endpoint.
- `git diff --check -- skills/otel-telemetrygen` passed.
- `skills-ref validate skills/otel-telemetrygen` not run: `skills-ref` is not installed locally.

## Deliberately excluded
- No post-tag dependency/module-only changes.
- Did not build a fresh telemetrygen binary because module download required network and was not available in the audit environment.
- No scope expansion beyond current telemetrygen skill content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified telemetrygen CLI input formatting requirements for attributes and headers.
  * Updated examples to show correct quoting, escaping, and slice syntax for string values.
  * Noted that the traces, metrics, and logs subcommands are currently alpha.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->