### PR TITLE
docs(otel-semantic-conventions): refresh lookup workflow

### DIFF
--- a/skills/otel-semantic-conventions/SKILL.md
+++ b/skills/otel-semantic-conventions/SKILL.md
@@ -13,10 +13,12 @@ Use this skill when you need released semantic convention guidance for naming, a
 1. Start with released semantic conventions, not model memory.
 - do not load the full semantic convention spec into context
 - use the bundled lookup script to query only the needed released group or attribute
+- for local verification against a checked-out upstream repo, set `OTEL_SEMCONV_REPO=/path/to/semantic-conventions`
 
 2. Choose the closest released group before inventing custom keys.
 - identify the boundary type such as `http`, `db`, `messaging`, `rpc`, or `network`
 - pick one primary group first, then add related groups only when they add needed context
+- for `gen_ai.*`, OpenAI, or MCP conventions, use the dedicated OpenTelemetry GenAI semantic conventions repository; the core repository keeps only deprecated GenAI-era stubs after v1.42.0
 - see `references/semconv-selection.md`
 
 3. Query only the released guidance you need.

--- a/skills/otel-semantic-conventions/references/otel-semantic-conventions.md
+++ b/skills/otel-semantic-conventions/references/otel-semantic-conventions.md
@@ -9,13 +9,17 @@ Use:
 - list groups: `./scripts/query-otel-semantic-conventions.sh --groups`
 - group lookup: `./scripts/query-otel-semantic-conventions.sh http`
 - exact attribute: `./scripts/query-otel-semantic-conventions.sh http http.request.method`
+- local checkout mode: `OTEL_SEMCONV_REPO=/path/to/semantic-conventions ./scripts/query-otel-semantic-conventions.sh http`
 
 Rules:
 - use `--groups` first if you do not already know the right group
 - start with one group
 - use the one-argument form first to discover the current released attribute ids and available kinds
 - use the two-argument form only when you need the exact upstream definition block for one attribute
-- the script resolves the latest released semantic conventions version and reads `model/<group>/registry.yaml` from that tag
+- the script resolves the latest released semantic conventions version and reads released YAML model files under `model/<group>/` from that tag
+- deprecated model files and directories are excluded from lookup results
+- the core semantic-conventions repository added `model/manifest.yaml` in v1.43.0; use it as release metadata, not as a convention group
+- `gen_ai.*`, OpenAI, and MCP conventions moved to the dedicated OpenTelemetry GenAI semantic conventions repository in v1.42.0; do not treat deprecated stubs under the core repository as current guidance
 
 Common groups:
-`http`, `db`, `messaging`, `rpc`, `network`, `url`, `server`, `error`, `user-agent`
+`http`, `db`, `messaging`, `rpc`, `network`, `url`, `server`, `error`, `user-agent`, `service`, `cloud`, `k8s`, `process`, `otel`, `log`, `exceptions`

--- a/skills/otel-semantic-conventions/references/semconv-selection.md
+++ b/skills/otel-semantic-conventions/references/semconv-selection.md
@@ -13,6 +13,9 @@ Pick the closest released semantic convention group before inventing custom keys
 - `server` for server endpoint metadata
 - `error` for error classification
 - `user-agent` for client user-agent details
+- `service` and `cloud` for service and cloud resource metadata
+- `k8s` and `process` for Kubernetes and process entities or metrics
+- `otel`, `log`, and `exceptions` for OpenTelemetry SDK telemetry, log records, and exception telemetry
 
 ## Selection Rules
 
@@ -20,6 +23,7 @@ Pick the closest released semantic convention group before inventing custom keys
 2. Add related groups only when they add needed context.
 3. Prefer required and recommended attributes before optional ones.
 4. If no released key exists, use a stable custom namespace and keep values bounded.
+5. For `gen_ai.*`, OpenAI, or MCP conventions, use the dedicated OpenTelemetry GenAI semantic conventions repository; do not use deprecated GenAI-era stubs from the core repository as current guidance.
 
 ## Lookup Workflow
 
@@ -30,6 +34,7 @@ Use the bundled script instead of loading large spec files:
 3. `./scripts/query-otel-semantic-conventions.sh <group> <attribute-id>`
 
 Use the one-argument form first. Use the two-argument form only when you need the exact released upstream definition for a single attribute.
+To verify against a local upstream checkout, set `OTEL_SEMCONV_REPO=/path/to/semantic-conventions`.
 
 ## Typical Group Pairings
 
@@ -38,4 +43,5 @@ Use the one-argument form first. Use the two-argument form only when you need th
 - Database: `db`, then maybe `server`, `error`
 - Messaging: `messaging`, then maybe `network`, `server`, `error`
 - RPC: `rpc`, then maybe `server`, `network`, `error`
+
 If a domain is not listed by `./scripts/query-otel-semantic-conventions.sh --groups`, treat it as not available in the currently released semantic conventions and use a stable custom namespace.

--- a/skills/otel-semantic-conventions/scripts/query-otel-semantic-conventions.sh
+++ b/skills/otel-semantic-conventions/scripts/query-otel-semantic-conventions.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 readonly RELEASE_API_URL="https://api.github.com/repos/open-telemetry/semantic-conventions/releases/latest"
+readonly SEMCONV_REPO="${OTEL_SEMCONV_REPO:-}"
+readonly SEMCONV_TAG="${OTEL_SEMCONV_TAG:-}"
 
 blob_url() {
   local tag="$1"
@@ -43,7 +45,7 @@ require_bin() {
 normalize_group() {
   printf '%s' "$1" |
     tr '[:upper:]' '[:lower:]' |
-    tr ' _' '--' |
+    tr ' ' '-' |
     tr -d '.'
 }
 
@@ -55,14 +57,32 @@ is_supported_kind() {
 }
 
 fetch_latest_tag() {
+  if [[ -n "$SEMCONV_TAG" ]]; then
+    printf '%s\n' "$SEMCONV_TAG"
+    return 0
+  fi
+
+  if [[ -n "$SEMCONV_REPO" ]]; then
+    git -C "$SEMCONV_REPO" tag --list 'v[0-9]*' --sort=-version:refname | sed -n '1p'
+    return 0
+  fi
+
   curl -fsSL "$RELEASE_API_URL" | jq -er '.tag_name'
 }
 
-fetch_model_tree() {
+fetch_model_paths() {
   local tag="$1"
-  local url="https://api.github.com/repos/open-telemetry/semantic-conventions/git/trees/${tag}?recursive=1"
 
-  if ! curl -fsSL "$url" 2>/dev/null; then
+  if [[ -n "$SEMCONV_REPO" ]]; then
+    if ! git -C "$SEMCONV_REPO" ls-tree -r --name-only "$tag" model 2>/dev/null; then
+      echo "failed to read semantic convention model tree from ${SEMCONV_REPO} at ${tag}" >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  local url="https://api.github.com/repos/open-telemetry/semantic-conventions/git/trees/${tag}?recursive=1"
+  if ! curl -fsSL "$url" 2>/dev/null | jq -r '.tree[] | select(.type == "blob") | .path'; then
     echo "failed to fetch semantic convention model tree from ${url}" >&2
     return 1
   fi
@@ -71,8 +91,16 @@ fetch_model_tree() {
 fetch_group_file() {
   local tag="$1"
   local path="$2"
-  local url="https://raw.githubusercontent.com/open-telemetry/semantic-conventions/${tag}/${path}"
 
+  if [[ -n "$SEMCONV_REPO" ]]; then
+    if ! git -C "$SEMCONV_REPO" show "${tag}:${path}" 2>/dev/null; then
+      echo "failed to read semantic convention file ${path} from ${SEMCONV_REPO} at ${tag}" >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  local url="https://raw.githubusercontent.com/open-telemetry/semantic-conventions/${tag}/${path}"
   if ! curl -fsSL "$url" 2>/dev/null; then
     echo "failed to fetch semantic convention file from ${url}" >&2
     return 1
@@ -80,34 +108,31 @@ fetch_group_file() {
 }
 
 model_records() {
-  local tree_json="$1"
+  local model_paths="$1"
 
-  jq -r '
-    def kind_for_file($file):
-      if ($file | contains("registry")) then "registry"
-      elif ($file | contains("spans")) then "spans"
-      elif ($file | contains("events")) then "events"
-      elif ($file | contains("metrics")) then "metrics"
-      elif ($file | contains("entities")) then "entities"
-      elif ($file | contains("common")) then "common"
-      elif ($file | contains("logs")) then "logs"
-      else ""
-      end;
+  awk '
+    function kind_for_file(file) {
+      if (index(file, "registry")) return "registry"
+      if (index(file, "spans")) return "spans"
+      if (index(file, "events")) return "events"
+      if (index(file, "metrics")) return "metrics"
+      if (index(file, "entities")) return "entities"
+      if (index(file, "common")) return "common"
+      if (index(file, "logs")) return "logs"
+      return ""
+    }
 
-    .tree[]
-    | select(.type == "blob")
-    | .path
-    | select(test("^model/[^/]+/.+\\.ya?ml$"))
-    | select(contains("/deprecated/") | not)
-    | . as $path
-    | ($path | split("/")) as $parts
-    | ($parts[-1] | ascii_downcase) as $file
-    | select($file | contains("deprecated") | not)
-    | (kind_for_file($file)) as $kind
-    | select($kind != "")
-    | [$parts[1], $kind, $path, $parts[-1]]
-    | @tsv
-  ' <<<"$tree_json"
+    $0 ~ "^model/[^/]+/.+\\.ya?ml$" {
+      path = $0
+      if (path ~ /\/deprecated\//) next
+      count = split(path, parts, "/")
+      file = tolower(parts[count])
+      if (index(file, "deprecated")) next
+      kind = kind_for_file(file)
+      if (kind == "") next
+      printf "%s\t%s\t%s\t%s\n", parts[2], kind, path, parts[count]
+    }
+  ' <<<"$model_paths"
 }
 
 list_available_groups() {
@@ -118,7 +143,14 @@ list_available_groups() {
 group_records() {
   local records="$1"
   local normalized_group="$2"
-  awk -F '\t' -v group="$normalized_group" '$1 == group' <<<"$records"
+  awk -F '\t' -v group="$normalized_group" '
+    function comparable(value) {
+      gsub(/_/, "-", value)
+      return value
+    }
+
+    $1 == group || comparable($1) == comparable(group)
+  ' <<<"$records"
 }
 
 list_group_kinds() {
@@ -323,9 +355,13 @@ print_kind_listing() {
 }
 
 main() {
-  require_bin curl
-  require_bin jq
   require_bin awk
+  if [[ -n "$SEMCONV_REPO" ]]; then
+    require_bin git
+  else
+    require_bin curl
+    require_bin jq
+  fi
 
   case "${1:-}" in
     ""|-h|--help)
@@ -335,12 +371,12 @@ main() {
       ;;
   esac
 
-  local tag version tree_json records groups
+  local tag version model_paths records groups
 
   tag="$(fetch_latest_tag)"
   version="${tag#v}"
-  tree_json="$(fetch_model_tree "$tag")"
-  records="$(model_records "$tree_json")"
+  model_paths="$(fetch_model_paths "$tag")"
+  records="$(model_records "$model_paths")"
 
   case "${1:-}" in
     --groups)
@@ -355,7 +391,7 @@ main() {
 
   local requested_group="$1"
   local second_arg="${2:-}"
-  local normalized_group group_records_output kinds registry_path registry_content registry_entries source_url
+  local normalized_group resolved_group group_records_output kinds registry_path registry_content registry_entries source_url
   local requested_kind kind_files file_path file_content kind_entries matched_entry
 
   normalized_group="$(normalize_group "$requested_group")"
@@ -365,9 +401,10 @@ main() {
     return 1
   }
 
+  resolved_group="$(awk -F '\t' 'NR == 1 { print $1 }' <<<"$group_records_output")"
   kinds="$(list_group_kinds "$group_records_output")"
   registry_path="$(find_registry_path "$group_records_output")"
-  source_url="$(group_url "$tag" "$normalized_group")"
+  source_url="$(group_url "$tag" "$resolved_group")"
 
   if [[ -z "$second_arg" ]]; then
     if [[ -n "$registry_path" ]]; then
@@ -376,7 +413,7 @@ main() {
     else
       registry_entries=""
     fi
-    print_group_summary "$requested_group" "$version" "$kinds" "$source_url" "$registry_entries"
+    print_group_summary "$resolved_group" "$version" "$kinds" "$source_url" "$registry_entries"
     return 0
   fi
 
@@ -395,7 +432,7 @@ main() {
       }
       registry_content="$(fetch_group_file "$tag" "$registry_path")"
       registry_entries="$(extract_entries "$registry_content" "      - id: " "        " 32)"
-      print_kind_listing "$requested_group" "$version" "$kinds" "$source_url" "$requested_kind" "$registry_entries"
+      print_kind_listing "$resolved_group" "$version" "$kinds" "$source_url" "$requested_kind" "$registry_entries"
       return 0
     fi
 
@@ -406,7 +443,7 @@ main() {
       kind_entries+="$(extract_entries "$file_content" "  - id: " "    " 36)"$'\n'
     done <<<"$kind_files"
 
-    print_kind_listing "$requested_group" "$version" "$kinds" "$source_url" "$requested_kind" "$kind_entries"
+    print_kind_listing "$resolved_group" "$version" "$kinds" "$source_url" "$requested_kind" "$kind_entries"
     return 0
   fi
 

--- a/skills/otel-semantic-conventions/scripts/query-otel-semantic-conventions.sh
+++ b/skills/otel-semantic-conventions/scripts/query-otel-semantic-conventions.sh
@@ -63,7 +63,18 @@ fetch_latest_tag() {
   fi
 
   if [[ -n "$SEMCONV_REPO" ]]; then
-    git -C "$SEMCONV_REPO" tag --list 'v[0-9]*' --sort=-version:refname | sed -n '1p'
+    local tag
+    tag="$(
+      git -C "$SEMCONV_REPO" tag --list 'v[0-9]*' --sort=-version:refname |
+        grep -E '^v[0-9]+(\.[0-9]+)*$' |
+        sed -n '1p' ||
+        true
+    )"
+    if [[ -z "$tag" ]]; then
+      echo "failed to find a stable semantic conventions release tag in ${SEMCONV_REPO}" >&2
+      return 1
+    fi
+    printf '%s\n' "$tag"
     return 0
   fi
 


### PR DESCRIPTION
## Summary
- Adds local semantic-conventions checkout mode via `OTEL_SEMCONV_REPO` / `OTEL_SEMCONV_TAG` to the lookup script.
- Updates model lookup guidance for released YAML files under `model/<group>/`, `model/manifest.yaml`, and deprecated-file exclusion.
- Notes that GenAI/OpenAI/MCP conventions moved to the dedicated GenAI semantic conventions repository after v1.42.
- Fixes group normalization so groups like `onc_rpc` and `onc-rpc` both resolve.

## Verification
- Synced `semantic-conventions` from upstream/main on 2026-07-12; it was already up to date.
- Verified latest local release tag `v1.43.0` and upstream paths `model/README.md` / `model/manifest.yaml`.
- `bash -n skills/otel-semantic-conventions/scripts/query-otel-semantic-conventions.sh` passed.
- Local lookup checks with `OTEL_SEMCONV_REPO=/Users/jpkroehling/Projects/src/github.com/open-telemetry/semantic-conventions` passed for `--groups`, `http http.request.method`, `onc_rpc`, and `onc-rpc`.
- `git diff --check -- skills/otel-semantic-conventions` passed.
- `skills-ref validate skills/otel-semantic-conventions` not run: `skills-ref` is not installed locally.

## Deliberately excluded
- No GenAI repository query support; that would expand scope beyond this core semantic-conventions refresh.
- No remote curl/GitHub content mode validation in this pass; local checkout mode was the required source of truth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for verifying OpenTelemetry semantic conventions from a local repository checkout.
  * Improved semantic convention group matching and expanded supported common groups.
  * Updated guidance for GenAI, OpenAI, and MCP conventions to use the dedicated OpenTelemetry GenAI repository.
  * Enhanced semantic convention lookup and release metadata guidance.

* **Documentation**
  * Clarified released model locations, deprecated content handling, and local verification options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->