### PR TITLE
docs(otel-weaver): refresh released CLI guidance

### DIFF
--- a/skills/otel-weaver/SKILL.md
+++ b/skills/otel-weaver/SKILL.md
@@ -21,7 +21,7 @@ If a companion skill is unavailable:
 
 Three moving parts:
 
-1. **Registry** — directory of YAML files. `manifest.yaml` is required; its `schema_url` (OTel schema URL format, `http[s]://host/path/<version>`) both names the registry and carries its version in the final path segment. The rest declare `attributes`, `metrics`, `spans`, `events`, `entities`. The version segment of `schema_url` is yours to manage; bump it on changes. (`semconv_version` and `schema_base_url` are deprecated in favor of `schema_url`.)
+1. **Registry** — directory of YAML files. `manifest.yaml` is required; its `schema_url` (OTel schema URL format, `http[s]://host/path/<version>`) both names the registry and carries its version in the final path segment. Dependency entries also use `schema_url` plus optional `registry_path`. The rest declare `attributes`, `metrics`, `spans`, `events`, `entities`. The version segment of `schema_url` is yours to manage; bump it on changes. (`name`, `semconv_version`, and `schema_base_url` are legacy/deprecated in favor of `schema_url`.)
 2. **Templates** — directory of Jinja2 files plus a `weaver.yaml` per target language describing which templates to run, with what filter, in what `application_mode`, and with what output filename.
 3. **Policies** — Rego rules. Built-in OTel policies are the floor; custom policies layer on org rules.
 
@@ -52,7 +52,7 @@ These cost time and are not obvious from the upstream docs:
 2. Generated output is not formatter-clean. Always run the language formatter after `weaver registry generate`.
 3. Resolved field names differ from input. Attribute input `key` → resolved `name`. Metric input `name` → resolved `metric_name`. Span input `type` → resolved `id` of the form `span.<type>`, with a flat `name` string equal to the input `name.note`. Always resolve and inspect before writing a template.
 4. The `comment` Jinja filter takes a keyword argument: `attr.brief | comment(format="go")`. It already emits the `// ` prefix; do not add another.
-5. Spans, events, and entities have prebuilt grouped jq filters — `semconv_grouped_spans`, `semconv_grouped_events`, `semconv_grouped_entities` — alongside `semconv_grouped_attributes` and `semconv_grouped_metrics`. Use `semconv_grouped_spans` (a bareword, like the others). Only a raw multi-clause jq expression needs single-quoting in `weaver.yaml`, because the colons collide with YAML mapping rules.
+5. Spans and events have prebuilt grouped jq filters — `semconv_grouped_spans` and `semconv_grouped_events` — alongside `semconv_grouped_attributes` and `semconv_grouped_metrics`. Use `semconv_grouped_spans` (a bareword, like the others). Only a raw multi-clause jq expression needs single-quoting in `weaver.yaml`, because the colons collide with YAML mapping rules.
 6. `weaver registry check` emits "File format `definition/2` is not yet stable" (a warning) on every run as of 0.24.2. This is normal; do not treat it as a failure.
 7. `--future` is opt-in but breaks today on `definition/2`. Note this in CI guidance and re-enable once the format goes stable.
 8. CLI argument ordering for `generate`: target directory name is positional **after** `--registry` and `--templates`; the output directory follows. `--templates` points at the **parent** that contains target dirs, not at the language-specific subdir.

--- a/skills/otel-weaver/references/ci-integration.md
+++ b/skills/otel-weaver/references/ci-integration.md
@@ -64,7 +64,7 @@ jobs:
             registry diff \
               --baseline-registry /baseline/telemetry/registry/ \
               --registry /work/telemetry/registry/ \
-              --diff-format markdown
+              --format markdown
 ```
 
 ## Notes

--- a/skills/otel-weaver/references/registry-authoring.md
+++ b/skills/otel-weaver/references/registry-authoring.md
@@ -25,7 +25,7 @@ description: "Telemetry conventions for the ecommerce monolith"
 stability: development
 ```
 
-`schema_url` is required and must follow the OTel schema URL format `http[s]://host/path/<version>`. The registry name is derived from the path (`example.com/schemas/ecommerce`) and the version from the final segment (`0.1.0`) — bump that segment on any schema change. Pick a stable URL even if it does not yet resolve. `description`, `stability`, and `dependencies` are optional. (The older `name` and `semconv_version`/`schema_base_url` fields are deprecated in favor of `schema_url`.)
+`schema_url` is required and must follow the OTel schema URL format `http[s]://host/path/<version>`. The registry name is derived from the path (`example.com/schemas/ecommerce`) and the version from the final segment (`0.1.0`) — bump that segment on any schema change. Pick a stable URL even if it does not yet resolve. `description`, `stability`, and `dependencies` are optional. Dependency entries require `schema_url` and may add `registry_path` for the local, archive, or Git location. (The older `name` and `semconv_version`/`schema_base_url` fields are legacy/deprecated in favor of `schema_url`.)
 
 ## Attributes
 

--- a/skills/otel-weaver/references/template-authoring.md
+++ b/skills/otel-weaver/references/template-authoring.md
@@ -27,7 +27,7 @@ Field names as they appear in the template `ctx` after the `semconv_grouped_*` f
 | span `type`            | `id` of the form `span.<type>`, plus flat `name` (= input `name.note`) |
 | span `kind`            | `span_kind`                                           |
 
-The `semconv_grouped_*` helpers wrap each signal list in `[{ root_namespace, <attributes|metrics|spans|events|entities> }]`. Other fields are mostly verbatim (`brief`, `stability`, `unit`, `instrument`, `attributes`, ...).
+The `semconv_grouped_*` helpers wrap each signal list in `[{ root_namespace, <attributes|metrics|spans|events> }]`. Other fields are mostly verbatim (`brief`, `stability`, `unit`, `instrument`, `attributes`, ...).
 
 ## Layout
 
@@ -81,7 +81,7 @@ templates:
 
 Notes:
 - `application_mode: single` renders the template once with the filter result bound to `ctx`.
-- Bundled jq filters live in [`defaults/jq/semconv.jq`](https://github.com/open-telemetry/weaver/blob/main/defaults/jq/semconv.jq) in the Weaver repo. Each signal has a grouped helper: `semconv_grouped_attributes`, `semconv_grouped_metrics`, `semconv_grouped_spans`, `semconv_grouped_events`, `semconv_grouped_entities` (all barewords).
+- Bundled jq filters live in [`defaults/jq/semconv.jq`](https://github.com/open-telemetry/weaver/blob/main/defaults/jq/semconv.jq) in the Weaver repo. In v0.24.2, released grouped helpers are `semconv_grouped_attributes`, `semconv_grouped_metrics`, `semconv_grouped_spans`, and `semconv_grouped_events` (all barewords).
 - **Single-quote only raw jq expressions.** The `semconv_grouped_*` helpers are barewords and need no quoting. If you write a custom multi-clause jq expression, single-quote it — colons in jq syntax otherwise collide with YAML mapping rules (`mapping values are not allowed in this context`).
 - `acronyms` shapes how `pascal_case_const` and similar filters split words.
 - `comment_formats` lets `comment(format="go")` know what comment prefix to emit.


### PR DESCRIPTION
## Summary
- Refreshes registry manifest dependency guidance for current `schema_url` plus optional `registry_path`.
- Removes unreleased `semconv_grouped_entities` from the released helper list for Weaver `v0.24.2`.
- Updates CI diff command guidance to use `weaver registry diff --format markdown`.

## Verification
- Synced `weaver` and `semantic-conventions` from upstream/main on 2026-07-12; both were already up to date.
- Verified released Weaver tag `v0.24.2` docs, changelog, schemas, `defaults/jq/semconv.jq`, and GitHub Action docs locally.
- Confirmed `v0.24.2` has grouped helpers for attributes, metrics, spans, and events, and does not have released `semconv_grouped_entities`.
- `git diff --check -- skills/otel-weaver` passed.
- `inspect-resolved.sh` ran successfully against an older-compatible fixture with installed `weaver 0.23.0`.
- `skills-ref validate skills/otel-weaver` not run: `skills-ref` is not installed locally.

## Deliberately excluded
- Unreleased main features such as `live-check --fail-on`, `semconv_grouped_entities`, template `when`, `[template]` `.weaver.toml`, `SpanRefinement.name`, and `--advice-data`.
- Full validation with a `v0.24.2` live binary; installed local binary is `weaver 0.23.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that legacy registry manifest fields have been replaced by `schema_url`.
  * Documented optional manifest metadata and dependency requirements.
  * Updated grouped template helper guidance to cover attributes, metrics, spans, and events.
  * Corrected the CI example’s registry diff formatting option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->