### PR TITLE
docs(otel-python): refresh released SDK guidance

### DIFF
--- a/skills/otel-python/SKILL.md
+++ b/skills/otel-python/SKILL.md
@@ -29,8 +29,8 @@ For Python-specific facts:
 | Latest `opentelemetry-distro` | `WebFetch https://pypi.org/pypi/opentelemetry-distro/json` |
 | Latest `opentelemetry-instrumentation-<pkg>` (contrib) | `WebFetch https://pypi.org/pypi/opentelemetry-instrumentation-<pkg>/json` |
 | Latest OTLP exporter | `WebFetch https://pypi.org/pypi/opentelemetry-exporter-otlp/json` |
-| Declarative config support (overview) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/main/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/README.md` |
-| Declarative config vendored schema (parser-accepted `file_format`) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/main/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/schema.json` |
+| Declarative config support (released 1.43.0 overview) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.43.0/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/README.md` |
+| Declarative config vendored schema (released 1.43.0 parser-accepted `file_format`) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.43.0/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/schema.json` |
 | SDK CHANGELOG | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/main/CHANGELOG.md` |
 | Contrib CHANGELOG | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python-contrib/main/CHANGELOG.md` |
 | Python getting-started docs | `WebFetch https://opentelemetry.io/docs/languages/python/getting-started/` |

--- a/skills/otel-python/references/api.md
+++ b/skills/otel-python/references/api.md
@@ -233,12 +233,15 @@ The handler automatically injects the active span's `trace_id` and `span_id` int
 
 > **Deprecated path:** `opentelemetry.sdk._logs.LoggingHandler` is deprecated as of SDK 1.40.0/0.61b0. Always import from `opentelemetry.instrumentation.logging.handler`.
 
-### `LoggingInstrumentor` is a different feature
+### `LoggingInstrumentor` behavior
 
-`LoggingInstrumentor().instrument()` (also reachable via the `opentelemetry-instrument` CLI) is **not** equivalent to the handler above. It only injects the active `otelTraceID` / `otelSpanID` into stdlib log *text* formatting (it calls `logging.basicConfig` with an enriched format) — it does **not** route log records through the `LoggerProvider` to the OTel logs pipeline. Use it for trace-context correlation in plain-text logs; use the `LoggingHandler` above to actually export logs as OTel log records.
+`LoggingInstrumentor().instrument()` (also reachable via the `opentelemetry-instrument` CLI when the logging instrumentation is installed) has two separate behaviors:
+
+- It installs the contrib `LoggingHandler` by default, routing stdlib log records through the global `LoggerProvider`. Disable that with `OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION=false` or `enable_log_auto_instrumentation=False`.
+- It can inject `otelTraceID`, `otelSpanID`, `otelTraceSampled`, and `otelServiceName` into stdlib `LogRecord`s for text log correlation. Use `inject_trace_context=True` to add those fields without changing the logging format, or `set_logging_format=True` / `OTEL_PYTHON_LOG_CORRELATION=true` to also call `logging.basicConfig` with a format that prints them.
 
 ```python
-# Trace-context injection into log TEXT only — does NOT export logs to OTLP
+# Add correlation fields to LogRecord without changing logging.basicConfig
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
-LoggingInstrumentor().instrument(set_logging_format=True)
+LoggingInstrumentor().instrument(inject_trace_context=True)
 ```

--- a/skills/otel-python/references/breaking-changes.md
+++ b/skills/otel-python/references/breaking-changes.md
@@ -96,10 +96,11 @@ release may rename the entry-point, change the schema, or remove the module with
 period.
 
 Before upgrading, fetch the README/schema for the release you are upgrading to. As of the
-latest released SDK (1.43.0), the declarative configuration README is:
+latest released SDK (1.43.0), the declarative configuration README and schema are:
 
-```
+```text
 WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.43.0/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/README.md
+WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.43.0/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/schema.json
 ```
 
 Upstream `main` has moved this code into an unreleased `opentelemetry-configuration`

--- a/skills/otel-python/references/breaking-changes.md
+++ b/skills/otel-python/references/breaking-changes.md
@@ -61,8 +61,9 @@ from opentelemetry.instrumentation.logging.handler import LoggingHandler
 ```
 Code using the old SDK handler keeps working until removal, but the deprecation entry marks the
 migration window. Add the contrib package to `requirements.txt`. See `references/api.md` for wiring
-details. (Note: `LoggingInstrumentor` is a separate feature for injecting trace context into log
-text formatting; it is not the deprecation replacement.)
+details. (Note: `LoggingInstrumentor` can install the contrib handler during instrumentation and can
+also inject trace context into text logs; check the current `opentelemetry-instrumentation-logging`
+behavior before treating it as only a formatting helper.)
 
 For each finding, grep the codebase for the old symbol before concluding impact:
 
@@ -94,11 +95,16 @@ experimental**. The leading underscore is intentional: the public API is not gua
 release may rename the entry-point, change the schema, or remove the module without a deprecation
 period.
 
-Before upgrading, fetch the current README for this module:
+Before upgrading, fetch the README/schema for the release you are upgrading to. As of the
+latest released SDK (1.43.0), the declarative configuration README is:
 
 ```
-WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/main/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/README.md
+WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.43.0/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/README.md
 ```
+
+Upstream `main` has moved this code into an unreleased `opentelemetry-configuration`
+package; do not apply that import-path change to released guidance until it appears in a
+release.
 
 Cross-reference the **`references/declarative-setup.md`** reference in this skill for the current
 YAML schema and activation API. If a release changes `_configuration`, that reference is the

--- a/skills/otel-python/references/declarative-setup.md
+++ b/skills/otel-python/references/declarative-setup.md
@@ -7,6 +7,11 @@ Configure the OpenTelemetry SDK in Python via a YAML file processed by
 > modules are private (leading underscore) and experimental. They may change
 > or be removed without a deprecation notice between SDK releases. Check the
 > SDK CHANGELOG (see Sources of Truth) before upgrading.
+>
+> **Main-branch note (post-1.43.0):** upstream `main` has moved the
+> declarative configuration implementation into an unreleased
+> `opentelemetry-configuration` package. Keep released guidance on
+> `opentelemetry.sdk._configuration.*` until that package is released.
 
 For the YAML configuration schema, load the `otel-declarative-config` skill.
 
@@ -20,7 +25,7 @@ For YAML schema details, fetch the upstream sources listed in the
 | Latest `opentelemetry-sdk` / `opentelemetry-api` | `WebFetch https://pypi.org/pypi/opentelemetry-sdk/json` (`.info.version`) |
 | Latest `opentelemetry-distro` | `WebFetch https://pypi.org/pypi/opentelemetry-distro/json` |
 | Latest OTLP exporter | `WebFetch https://pypi.org/pypi/opentelemetry-exporter-otlp/json` |
-| Declarative config support + vendored schema version | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/main/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/README.md` |
+| Declarative config support + vendored schema version (released 1.43.0) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.43.0/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/README.md` |
 | SDK CHANGELOG | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/main/CHANGELOG.md` |
 
 ## Install
@@ -99,8 +104,10 @@ imported (or before the CLI activates the config) uses no-op providers.
 
 ## YAML Config
 
-`file_format` must be the literal string `'1.0'`. Omitting it or using a
-different value causes the parser to reject the file.
+`file_format` is required and must be a string version. SDK 1.43.0 validates it
+per the configuration spec: unsupported major versions are rejected; newer minor
+versions with the same major version are accepted with a warning. Use `"1.0"`
+unless you have checked the currently vendored schema and SDK loader.
 
 Minimal verified skeleton (all three signals, console exporters):
 

--- a/skills/otel-python/references/instrumentation-libraries.md
+++ b/skills/otel-python/references/instrumentation-libraries.md
@@ -51,6 +51,9 @@ Configuration is entirely via environment variables (`OTEL_SERVICE_NAME`, `OTEL_
 | `OTEL_METRICS_EXPORTER` | `otlp` |
 | `OTEL_LOGS_EXPORTER` | `otlp` |
 | `OTEL_PROPAGATORS` | `tracecontext,baggage` |
+| `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` | `requests,logging` |
+| `OTEL_SEMCONV_STABILITY_OPT_IN` | `http,database` |
+| `OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION` | `false` |
 
 ## Per-App Instrumentation
 

--- a/skills/otel-python/references/performance.md
+++ b/skills/otel-python/references/performance.md
@@ -294,7 +294,7 @@ async def main():
         # Active span here is still "main" — the thread's mutations are gone
 ```
 
-`asyncio.loop.run_in_executor()` and manually spawned threads do **not** automatically copy the current context. Prefer `asyncio.to_thread()` when possible; otherwise pass the context explicitly:
+`loop.run_in_executor(...)` and manually spawned threads may not automatically copy the current context. Prefer `asyncio.to_thread()` when possible; otherwise pass the context explicitly for deterministic behavior:
 
 ```python
 import asyncio

--- a/skills/otel-python/references/performance.md
+++ b/skills/otel-python/references/performance.md
@@ -270,14 +270,13 @@ async def fetch_data():
         ...
 ```
 
-### Pitfall: Crossing into Threads via `run_in_executor`
+### Pitfall: Crossing into Threads
 
-`asyncio.loop.run_in_executor` runs a callable in a `ThreadPoolExecutor`. The `contextvars` context is **copied** into the thread, so the active span is available — but mutations to `ContextVar` inside the thread do not propagate back to the asyncio event loop:
+`asyncio.to_thread()` copies the current `contextvars` context into the worker thread, so the active span is available there. Mutations to `ContextVar` inside the thread do not propagate back to the asyncio event loop:
 
 ```python
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
-from opentelemetry import trace, context
+from opentelemetry import trace
 
 tracer = trace.get_tracer(__name__)
 
@@ -291,17 +290,25 @@ def blocking_work():
 
 async def main():
     with tracer.start_as_current_span("main"):
-        loop = asyncio.get_event_loop()
-        await loop.run_in_executor(None, blocking_work)
+        await asyncio.to_thread(blocking_work)
         # Active span here is still "main" — the thread's mutations are gone
 ```
 
-When spawning threads manually (not via `run_in_executor`), the context is **not** automatically copied. Pass it explicitly:
+`asyncio.loop.run_in_executor()` and manually spawned threads do **not** automatically copy the current context. Prefer `asyncio.to_thread()` when possible; otherwise pass the context explicitly:
 
 ```python
+import asyncio
 import threading
+from contextvars import copy_context
 from opentelemetry import context
 
+# run_in_executor: wrap the callable in the copied context
+async def main():
+    loop = asyncio.get_running_loop()
+    ctxvars = copy_context()
+    await loop.run_in_executor(None, ctxvars.run, blocking_work)
+
+# manual thread: attach the captured OTel context
 ctx = context.get_current()  # Capture context in the calling thread
 
 def worker():


### PR DESCRIPTION
## Summary
- Pins declarative-config source links to the released Python `v1.43.0` implementation and clarifies `file_format` version handling.
- Updates logging guidance for current `LoggingInstrumentor` / contrib `LoggingHandler` behavior.
- Adds current zero-code env knobs for disabled instrumentations, semconv opt-in, and logging auto-instrumentation.
- Corrects asyncio thread context guidance: `asyncio.to_thread()` copies context; `run_in_executor()` needs explicit copied context.

## Verification
- Synced `opentelemetry-python` and `opentelemetry-python-contrib` from upstream/main on 2026-07-12; both were already up to date.
- Verified released versions `opentelemetry-api/sdk 1.43.0` and contrib/distro `0.64b0`.
- Verified changed upstream tag paths and relative skill links exist locally.
- Confirmed stable semconv imports used by examples exist at `v1.43.0`.
- `git diff --check -- skills/otel-python` passed.
- `skills-ref validate skills/otel-python` not run: `skills-ref` is not installed locally.

## Deliberately excluded
- Unreleased main changes: declarative-config extraction, schema 1.1.0, file exporter config, structlog instrumentation, Elasticsearch removal, and other 1.44.0.dev / 0.65b0.dev work.
- No scope expansion beyond current Python skill content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OpenTelemetry Python guidance for the 1.43.0 release, including declarative configuration “sources of truth” and schema links pinned to the tagged release.
  * Rewrote logging instrumentation docs to reflect installed log handler behavior and added trace-context injection details (with updated examples).
  * Added new environment variables for controlling auto-instrumentation, semantic convention stability, and logging instrumentation.
  * Refreshed asyncio/thread context propagation recommendations and examples.
  * Updated the breaking-changes audit workflow guidance with release-pinned declarative configuration references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->