### PR TITLE
docs(otel-java): refresh declarative config tags

### DIFF
--- a/skills/otel-java/SKILL.md
+++ b/skills/otel-java/SKILL.md
@@ -23,9 +23,11 @@ For Java-specific facts:
 |---|---|
 | Latest BOM (`opentelemetry-bom`) | `gh api repos/open-telemetry/opentelemetry-java/releases/latest -q '.tag_name'` |
 | Latest Javaagent | `gh api repos/open-telemetry/opentelemetry-java-instrumentation/releases/latest -q '.tag_name'` |
+| SDK declarative-config expected `file_format` for a selected BOM tag | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java/<selected-sdk-tag>/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactory.java` |
 | Javaagent declarative-config docs (current activation flag, supported `file_format`) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/configuration/` |
-| Javaagent declarative-config smoke fixture (parser truth for current main) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/smoke-tests/src/test/resources/declarative-config.yaml` |
+| Javaagent declarative-config smoke fixture (parser truth for selected agent tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests/src/test/resources/declarative-config.yaml` |
 | Javaagent CHANGELOG (when each schema rc landed) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/CHANGELOG.md` |
+| Spring Boot Starter declarative-config fixture (selected starter tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests-otel-starter/spring-boot-2/src/testDeclarativeConfig/resources/application.yaml` |
 | Spring Boot starter docs | `WebFetch https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/` |
 
 ## Cross-References

--- a/skills/otel-java/SKILL.md
+++ b/skills/otel-java/SKILL.md
@@ -24,7 +24,7 @@ For Java-specific facts:
 | Latest BOM (`opentelemetry-bom`) | `gh api repos/open-telemetry/opentelemetry-java/releases/latest -q '.tag_name'` |
 | Latest Javaagent | `gh api repos/open-telemetry/opentelemetry-java-instrumentation/releases/latest -q '.tag_name'` |
 | SDK declarative-config expected `file_format` for a selected BOM tag | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java/<selected-sdk-tag>/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactory.java` |
-| Javaagent declarative-config docs (current activation flag, supported `file_format`) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/configuration/` |
+| Javaagent declarative-config docs (current activation flag, supported `file_format`) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/declarative-configuration/` |
 | Javaagent declarative-config smoke fixture (parser truth for selected agent tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests/src/test/resources/declarative-config.yaml` |
 | Javaagent CHANGELOG (when each schema rc landed) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/CHANGELOG.md` |
 | Spring Boot Starter declarative-config fixture (selected starter tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests-otel-starter/spring-boot-2/src/testDeclarativeConfig/resources/application.yaml` |

--- a/skills/otel-java/references/declarative-setup.md
+++ b/skills/otel-java/references/declarative-setup.md
@@ -18,7 +18,7 @@ skill. For Java-specific facts:
 | Latest BOM (`opentelemetry-bom`) | `gh api repos/open-telemetry/opentelemetry-java/releases/latest -q '.tag_name'` |
 | Latest Javaagent | `gh api repos/open-telemetry/opentelemetry-java-instrumentation/releases/latest -q '.tag_name'` |
 | SDK declarative-config expected `file_format` for a selected BOM tag | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java/<selected-sdk-tag>/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactory.java` |
-| Javaagent declarative-config docs (current activation flag, supported `file_format`) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/configuration/` |
+| Javaagent declarative-config docs (current activation flag, supported `file_format`) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/declarative-configuration/` |
 | Javaagent declarative-config smoke fixture (parser truth for selected agent tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests/src/test/resources/declarative-config.yaml` |
 | Javaagent CHANGELOG (when each schema rc landed) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/CHANGELOG.md` |
 | Spring Boot Starter declarative-config fixture (selected starter tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests-otel-starter/spring-boot-2/src/testDeclarativeConfig/resources/application.yaml` |

--- a/skills/otel-java/references/declarative-setup.md
+++ b/skills/otel-java/references/declarative-setup.md
@@ -17,9 +17,11 @@ skill. For Java-specific facts:
 |---|---|
 | Latest BOM (`opentelemetry-bom`) | `gh api repos/open-telemetry/opentelemetry-java/releases/latest -q '.tag_name'` |
 | Latest Javaagent | `gh api repos/open-telemetry/opentelemetry-java-instrumentation/releases/latest -q '.tag_name'` |
+| SDK declarative-config expected `file_format` for a selected BOM tag | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java/<selected-sdk-tag>/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactory.java` |
 | Javaagent declarative-config docs (current activation flag, supported `file_format`) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/configuration/` |
-| Javaagent declarative-config smoke fixture (parser truth for current main) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/smoke-tests/src/test/resources/declarative-config.yaml` |
+| Javaagent declarative-config smoke fixture (parser truth for selected agent tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests/src/test/resources/declarative-config.yaml` |
 | Javaagent CHANGELOG (when each schema rc landed) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/CHANGELOG.md` |
+| Spring Boot Starter declarative-config fixture (selected starter tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests-otel-starter/spring-boot-2/src/testDeclarativeConfig/resources/application.yaml` |
 | Spring Boot starter docs | `WebFetch https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/` |
 
 ## Javaagent Download
@@ -43,8 +45,11 @@ java -javaagent:opentelemetry-javaagent.jar \
 Declarative config has been supported since Javaagent 2.9.0; the property is now the stable
 `otel.config.file` (the experimental `otel.experimental.config.file` alias was removed in the
 SDK 1.63.0 bundled with Javaagent 2.29.0). Newer agent versions track newer schema versions.
-Confirm the exact `file_format` literal from the Javaagent docs or test fixtures for the
-selected agent version, not from the generic language support matrix alone.
+Confirm the exact `file_format` literal from the tag-matched Javaagent or Spring Boot Starter
+fixture for the selected release, not from `main` or the generic language support matrix alone.
+For example, as of 2026-07-12, the latest released SDK BOM is 1.64.0 and expects
+`file_format: "1.1"`, but the latest released Javaagent/Spring Boot Starter is 2.29.0, targets
+SDK 1.63.0, and its released fixtures use `file_format: "1.0"`.
 
 When `-Dotel.config.file` is set, all other `-Dotel.*` properties are ignored except
 agent-only properties (see Key API Facts).
@@ -99,7 +104,8 @@ AutoConfiguredOpenTelemetrySdk sdk = AutoConfiguredOpenTelemetrySdk.builder().bu
 - **Spring Boot Starter activation**: unlike the Javaagent/autoconfigure, the starter does
   not load an external file. Embed the declarative config inline under the `otel:` key in
   `application.yaml` (or as `otel.*` properties in `application.properties`) and opt in by
-  setting `otel.file_format` (e.g. `file_format: "1.1"`). The presence of `otel.file_format`
-  is what switches the starter into declarative-config mode.
+  setting `otel.file_format` (for example, `file_format: "1.0"` for starter 2.29.0; verify the
+  selected release fixture). The presence of `otel.file_format` is what switches the starter into
+  declarative-config mode.
 - **Shutdown hook**: The Javaagent and autoconfigure both register a JVM shutdown hook automatically — no manual `sdk.close()` needed.
 - **Agent-only properties**: `otel.javaagent.extensions`, `otel.javaagent.enabled`, `otel.javaagent.debug` cannot be set via declarative config — they must remain as system properties.


### PR DESCRIPTION
## Summary
- Adds tag-matched source-of-truth pointers for Java SDK declarative config and Javaagent/Spring Boot Starter fixtures.
- Clarifies that SDK BOM `v1.64.0` expects `file_format: "1.1"`, while Javaagent/Spring Boot Starter `v2.29.0` targets SDK `1.63.0` and released fixtures use `file_format: "1.0"`.
- Updates Spring Boot Starter guidance to verify `otel.file_format` against the selected release fixture.

## Verification
- Synced `opentelemetry-java`, `opentelemetry-java-instrumentation`, and `opentelemetry-java-contrib` from upstream/main on 2026-07-12; all were already up to date.
- Verified `opentelemetry-java` tag `v1.64.0` has `EXPECTED_FILE_FORMAT = "1.1"` in `OpenTelemetryConfigurationFactory.java`.
- Verified `opentelemetry-java-instrumentation` tag `v2.29.0` Javaagent and Spring Boot Starter declarative-config fixtures use `file_format: 1.0` / `"1.0"`.
- `git diff --check -- skills/otel-java` passed.
- `skills-ref validate skills/otel-java` not run: `skills-ref` is not installed locally.

## Deliberately excluded
- No unreleased main behavior beyond release-tag source pointers.
- No broad Java instrumentation module audit; this PR is limited to the stale declarative-config tag guidance found in the skill-level refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated OpenTelemetry Java “Sources of Truth” to use tag-selected upstream SDK, Javaagent smoke-test, and Spring Boot Starter fixtures instead of generic references.
  - Added a version-aware SDK declarative-config `file_format` “expected” reference and updated the Javaagent documentation link to the correct declarative-configuration page.
  - Clarified Activation guidance to confirm the exact `file_format` literal from the selected release’s fixtures/docs (not the generic matrix).
  - Refined Spring Boot Starter examples and wording with release-specific `file_format` values, including an updated BOM vs latest release example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->