### PR TITLE
docs(otel-span-events-to-logs-migration): refresh migration status

### DIFF
--- a/skills/otel-span-events-to-logs-migration/SKILL.md
+++ b/skills/otel-span-events-to-logs-migration/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: otel-span-events-to-logs-migration
-description: Migrate OpenTelemetry Span Events (AddEvent, RecordException) to the Logs API following the OTEP 4430 deprecation plan. Use when migrating instrumentation from span events to log-based events, reviewing code that still uses AddEvent or RecordException, or planning a migration across a codebase.
+description: Migrate OpenTelemetry Span Events (AddEvent, RecordException, and language equivalents) to the Logs API following the accepted OTEP 4430 migration plan. Use when migrating instrumentation from span events to log-based events, reviewing code that still uses AddEvent or RecordException, or planning a codebase migration while preserving trace correlation.
 ---
 
 # Span Events to Logs Migration
 
-Use this skill to migrate instrumentation from the deprecated Span Event API (`AddEvent`, `RecordException`) to the Logs API, following the [OTEP 4430 deprecation plan](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4430-span-event-api-deprecation-plan.md).
+Use this skill to migrate instrumentation from the Span Event API (`AddEvent`, `RecordException`, and language equivalents) to the Logs API, following the accepted [OTEP 4430 deprecation plan](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4430-span-event-api-deprecation-plan.md).
 
 ## Background
 
-The OpenTelemetry project is deprecating `Span.AddEvent` and `Span.RecordException` in favor of emitting events and exceptions through the Logs API. Span Events as a concept remain valid -- they can be emitted via logs that correlate to the active span, and optionally bridged back into the span proto.
+The OpenTelemetry project accepted a plan to deprecate `Span.AddEvent` and `Span.RecordException` in favor of emitting events and exceptions through the Logs API. Span Events as a concept remain valid -- they can be emitted via logs that correlate to the active span, and optionally bridged back into the span proto.
 
-Status as of 2026-07: OTEP 4430 (the deprecation plan) is accepted, log-based event/exception emission is stabilized in the Logs API, and the SDK "event to span event bridge" is specified. The trace API methods `AddEvent`/`RecordException` are not yet formally marked Deprecated in the specification -- that step is still pending. Some language SDKs have already begun deprecating their equivalents (e.g., OpenTelemetry .NET's `RecordException` extension is `[Obsolete]`).
+Status as of 2026-07-12: OTEP 4430 is accepted, log-based event/exception emission is specified in the Logs API, and the SDK "event to span event bridge" is specified with Development status. The trace API methods `AddEvent`/`RecordException` are not yet formally marked Deprecated in the specification -- that step is still pending. Treat existing span-event calls as migration candidates, not automatically invalid code; some SDK-specific equivalents have already changed status (for example OpenTelemetry .NET's `Activity.RecordException` extension is `[Obsolete]` in favor of `Activity.AddException`, which is still a span-event API).
 
 See `references/deprecation-plan.md` for the full context.
 
@@ -23,7 +23,7 @@ See `references/deprecation-plan.md` for the full context.
 - determine if downstream consumers (backends, dashboards, alerts) depend on span events appearing in the span proto envelope
 
 1. Scan the codebase for span event usage.
-- search for `AddEvent`, `add_event`, `addEvent`, `RecordException`, `record_exception`, `recordException`, and language-specific variants
+- search for `AddEvent`, `add_event`, `addEvent`, `RecordException`, `record_exception`, `recordException`, `RecordError`, `AddException`, and language-specific variants
 - categorize each call site: general event, exception recording, or informational annotation
 - note the span context, attributes, and timestamp usage at each site
 
@@ -73,7 +73,7 @@ Include file references as evidence for every completed item.
 - `[ ]` Call sites classified as "convert to span attributes" now use span attributes instead.
 - `[ ]` Call sites classified as "remove" have been removed with justification.
 - `[ ]` Backward compatibility bridge is configured if downstream systems require span events in the span envelope.
-- `[ ]` No remaining references to the deprecated `AddEvent` or `RecordException` APIs unless intentionally kept for the current major version.
+- `[ ]` No remaining span-event API call sites are left unintentionally; any retained `AddEvent` / `RecordException` / equivalent call is justified for current-version compatibility.
 - `[ ]` The changed files were re-read after implementation to verify the final state.
 - `[ ]` The final answer includes this checklist, file evidence, and any remaining risks or gaps.
 

--- a/skills/otel-span-events-to-logs-migration/SKILL.md
+++ b/skills/otel-span-events-to-logs-migration/SKILL.md
@@ -64,8 +64,8 @@ For every item, report one of these statuses in the final answer:
 
 Include file references as evidence for every completed item.
 
-- `[ ]` All `AddEvent` / `add_event` / `addEvent` call sites identified and classified.
-- `[ ]` All `RecordException` / `record_exception` / `recordException` call sites identified and classified.
+- `[ ]` All general span-event call sites identified and classified, including `AddEvent` / `add_event` / `addEvent` and language equivalents such as .NET `ActivityEvent`.
+- `[ ]` All exception span-event call sites identified and classified, including `RecordException` / `record_exception` / `recordException` and language equivalents such as Go `RecordError`, Rust `record_error`, and .NET `AddException`.
 - `[ ]` A LoggerProvider is configured in the SDK setup (or already existed).
 - `[ ]` Each migrated event uses the Logs API with the correct event name and attributes.
 - `[ ]` Each migrated exception preserves the applicable semconv attributes: `exception.type` and `exception.message` (at least one is required), plus `exception.stacktrace` when the language/error type makes it meaningful.
@@ -73,7 +73,7 @@ Include file references as evidence for every completed item.
 - `[ ]` Call sites classified as "convert to span attributes" now use span attributes instead.
 - `[ ]` Call sites classified as "remove" have been removed with justification.
 - `[ ]` Backward compatibility bridge is configured if downstream systems require span events in the span envelope.
-- `[ ]` No remaining span-event API call sites are left unintentionally; any retained `AddEvent` / `RecordException` / equivalent call is justified for current-version compatibility.
+- `[ ]` No remaining span-event API call sites are left unintentionally; any retained `AddEvent` / `RecordException` / `RecordError` / `AddException` / `ActivityEvent` / equivalent call is justified for current-version compatibility.
 - `[ ]` The changed files were re-read after implementation to verify the final state.
 - `[ ]` The final answer includes this checklist, file evidence, and any remaining risks or gaps.
 

--- a/skills/otel-span-events-to-logs-migration/references/backward-compat.md
+++ b/skills/otel-span-events-to-logs-migration/references/backward-compat.md
@@ -28,7 +28,7 @@ Do NOT use the bridge when:
 
 ## How to Configure It
 
-### Via Declarative Configuration (preferred)
+### Via Declarative Configuration
 
 When available for the language SDK, add the bridge processor to the log pipeline in the declarative config. The processor key is defined in the [opentelemetry-configuration](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema/logger_provider.yaml) schema as `event_to_span_event_bridge/development` (the `/development` suffix marks it experimental):
 
@@ -43,37 +43,28 @@ logger_provider:
             endpoint: "http://collector:4318"
 ```
 
-### Via Code (when declarative config is not available)
+### Via Code
 
-The bridge is a log record processor. Add it to the LoggerProvider alongside the batch processor:
+The bridge is a log record processor. Add a bridge implementation provided by
+the target language SDK to the LoggerProvider alongside any export processors.
+Do not infer support from the specification alone: the specification says SDKs
+SHOULD provide the processor, and implementation availability varies by language.
 
-```go
-// Go example
-bridgeProcessor := eventbridge.NewSpanEventBridge()
-loggerProvider := log.NewLoggerProvider(
-    log.WithProcessor(bridgeProcessor),
-    log.WithProcessor(
-        log.NewBatchProcessor(otlpExporter),
-    ),
-)
-```
+For example, OpenTelemetry Java 1.64.0 provides the bridge in the incubator SDK
+extension:
 
 ```java
-// Java example -- see opentelemetry-java-contrib
-// processors module for EventToSpanEventBridge
+// Java example -- opentelemetry-sdk-extension-incubator
 SdkLoggerProvider loggerProvider = SdkLoggerProvider.builder()
     .addLogRecordProcessor(EventToSpanEventBridge.create())
     .addLogRecordProcessor(BatchLogRecordProcessor.builder(otlpExporter).build())
     .build();
 ```
 
-## Processor Ordering
-
-The bridge processor should be registered BEFORE the batch/export processor in the chain. This ensures:
-1. The log record is first converted to a span event and attached to the span
-2. Then the log record is batched and exported as a log (if desired)
-
-If you only want span events and do NOT want separate log export, omit the batch log exporter and only register the bridge.
+The specification does not require a particular ordering between the bridge and
+other processors. Follow the target SDK's processor-composition semantics. If
+you only want span events and do not want separate log export, configure only
+the bridge where the SDK permits that pipeline.
 
 ## Migration Path
 
@@ -82,6 +73,8 @@ If you only want span events and do NOT want separate log export, omit the batch
 3. Once all consumers are migrated, remove the bridge
 4. The bridge is a transitional tool, not a permanent fixture
 
-## Reference Implementation
+## Reference Implementations
 
-- Java: [opentelemetry-java-contrib processors](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/processors/README.md#event-to-spanevent-bridge)
+- Specification: [Event to span event bridge](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md#event-to-span-event-bridge)
+- Java: `io.opentelemetry.sdk.extension.incubator.logs.EventToSpanEventBridge` in `opentelemetry-sdk-extension-incubator`
+- Historical Java contrib bridge: [opentelemetry-java-contrib processors](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/processors/README.md#event-to-spanevent-bridge) is deprecated and points to the SDK incubator extension.

--- a/skills/otel-span-events-to-logs-migration/references/decision-tree.md
+++ b/skills/otel-span-events-to-logs-migration/references/decision-tree.md
@@ -7,7 +7,7 @@ For each `AddEvent` or `RecordException` call site, follow this tree to determin
 If the call uses `RecordException` (or `AddEvent` with `exception.*` attributes):
 - **Action: Migrate to log-based exception**
 - Use the Logs API to emit an event with name `exception`
-- Preserve `exception.type`, `exception.message`, `exception.stacktrace`
+- Preserve the applicable exception semantic-convention attributes. Use SDK exception support when available; otherwise set `exception.type` and `exception.message` when known, plus `exception.stacktrace` when the language/error object carries a meaningful stack.
 - The log record must carry the active span context
 
 ## Step 2: Is It a Timestamped Diagnostic Event?

--- a/skills/otel-span-events-to-logs-migration/references/deprecation-plan.md
+++ b/skills/otel-span-events-to-logs-migration/references/deprecation-plan.md
@@ -2,10 +2,12 @@
 
 This reference summarizes the [OTEP 4430](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4430-span-event-api-deprecation-plan.md) deprecation plan.
 
-## What Is Being Deprecated
+## Planned Deprecation Targets
 
 - `Span.AddEvent` -- the API method for attaching events to spans
 - `Span.RecordException` -- the API method for recording exceptions on spans
+
+As of 2026-07-12, these methods are planned deprecation targets from the accepted OTEP. They are not yet marked Deprecated in `specification/trace/api.md`.
 
 ## What Is NOT Being Deprecated
 
@@ -39,12 +41,26 @@ Stabilize log-based Events. (The `event_name` LogRecord field is part of the sta
 - Next major version: migrate to the Logs API; for span-detail-without-a-timestamp cases, record span attributes instead ([semantic-conventions#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010), [opentelemetry-specification#4446](https://github.com/open-telemetry/opentelemetry-specification/issues/4446))
 - Users opt into the SDK bridge if they need span events in the proto envelope
 
-## Current Status (2026-07)
+## Current Status (2026-07-12)
 
 - **Proto**: log-based Events are stable; `event_name` is a stable LogRecord field.
-- **Spec**: the Logs API is Stable, including the `event_name` field and the optional `Exception` parameter to Emit, so log-based exception/event emission is specified. The "event to span event bridge" `LogRecordProcessor` is now specified in `specification/logs/sdk.md` (Status: Development), with a matching `event_to_span_event_bridge/development` declarative-config key.
+- **Spec**: the Logs API is Stable, including the `event_name` field and the optional `Exception` parameter to Emit, so log-based exception/event emission is specified. The "event to span event bridge" `LogRecordProcessor` is specified in `specification/logs/sdk.md` (Status: Development), with a matching `event_to_span_event_bridge/development` declarative-config key.
 - **Not yet done in spec**: `Span.AddEvent` and `Span.RecordException` are **not** yet marked Deprecated in `specification/trace/api.md`. That step remains pending.
-- **SDKs**: some have started deprecating equivalents ahead of the spec (e.g., OpenTelemetry .NET's `Activity.RecordException` extension is `[Obsolete]`, pointing to `Activity.AddException`).
+- **SDKs**: implementation status varies. Do not claim all `AddEvent`/`RecordException` equivalents are deprecated unless that language SDK marks them so.
+
+## Language Status Snapshot
+
+Use current released source for the target language before editing user code.
+The snapshot below was verified against locally available releases on
+2026-07-12 (the local checkouts could not be refreshed from the network):
+
+| Language | Current migration-relevant status |
+|---|---|
+| Go 1.44.0 | `trace.Span.AddEvent` / `RecordError` are present and not marked deprecated; `log.Record.SetEventName` is available. No event-to-span-event bridge implementation was found in this release. |
+| Java 1.64.0 | `Span.addEvent` / `recordException` are present and not marked deprecated; `LogRecordBuilder.setEventName` is available since 1.50.0 and `setException(Throwable)` since 1.60.0. The bridge is available in `opentelemetry-sdk-extension-incubator`; the older Java contrib bridge is deprecated. |
+| JavaScript / TypeScript 2.9.0 / experimental 0.220.0 | `Span.addEvent` / `recordException` are present and not marked deprecated; `@opentelemetry/api-logs` / `@opentelemetry/sdk-logs` support `eventName`; the `exception` log-record field is marked experimental. No event-to-span-event bridge implementation was found in these releases. |
+| Python 1.43.0 | `span.add_event` / `record_exception` are present and not marked deprecated; `opentelemetry._logs.Logger.emit` accepts `event_name` and `exception`, and the SDK derives exception attributes. No event-to-span-event bridge implementation was found in this release. |
+| .NET 1.16.0 | `ActivityExtensions.RecordException` is `[Obsolete]` and points to `Activity.AddException`; both record span events. `TelemetrySpan.AddEvent` / `RecordException` are not marked obsolete. `ILogger` supplies an event name through `EventId.Name`; the lower-level Logs API is pre-release. No event-to-span-event bridge implementation was found in this release. |
 
 Treat the deprecation as the accepted direction, not a completed spec change; verify the current status of each step against the linked sources before making hard claims.
 

--- a/skills/otel-span-events-to-logs-migration/references/migration-patterns.md
+++ b/skills/otel-span-events-to-logs-migration/references/migration-patterns.md
@@ -135,7 +135,7 @@ span.setStatus(StatusCode.ERROR, exception.getMessage());
 
 After:
 ```java
-Logger logger = GlobalOpenTelemetry.getLogsBridge().loggerBuilder("my-class").build();
+Logger logger = GlobalOpenTelemetry.get().getLogsBridge().loggerBuilder("my-class").build();
 logger.logRecordBuilder()
     .setSeverity(Severity.ERROR)
     .setEventName("exception")
@@ -248,7 +248,7 @@ After:
 ```csharp
 logger.LogWarning(
     new EventId(0, "validation.failure"),
-    "validation.failure for field {Field} rule {Rule}",
+    "validation.failure for field {validation.field} rule {validation.rule}",
     fieldName,
     rule);
 ```
@@ -258,7 +258,8 @@ With the OpenTelemetry .NET OTLP exporter, `EventId.Name` is exported as the OTL
 ## Key Rules Across All Languages
 
 1. The event name replaces the name from `AddEvent`. Use the dedicated event-name API where available -- `record.SetEventName(...)` (Go), `.setEventName(...)` (Java `LogRecordBuilder`), `eventName:` (JS `logger.emit`), `event_name=` (Python `Logger.emit`), or `EventId.Name` (.NET `ILogger`) -- which maps to the `event_name` LogRecord field. Only set an `event.name` attribute when the target SDK/exporter has no dedicated event-name path.
-2. All original attributes transfer to the log record attributes.
+2. All original attributes transfer to the log record attributes, preserving the
+   original attribute keys unless an intentional mapping is documented and tested.
 3. The log record automatically inherits the active span context from `ctx` / the current context -- this is how trace correlation is maintained.
 4. `span.SetStatus` (or equivalent) is still set on the span for error cases -- the migration only moves event emission, not status.
 5. Timestamps are set automatically by the SDK if not specified explicitly.

--- a/skills/otel-span-events-to-logs-migration/references/migration-patterns.md
+++ b/skills/otel-span-events-to-logs-migration/references/migration-patterns.md
@@ -4,6 +4,8 @@ Language-specific patterns for migrating from `AddEvent` / `RecordException` to 
 
 When applying these patterns, always check the project's actual SDK imports and version. The examples below use idiomatic API calls; adapt to the project's style.
 
+Do not assume the span-event method is formally deprecated in the target SDK. The migration target comes from OTEP 4430 and per-language release status.
+
 ## Go
 
 ### Exception Recording
@@ -17,7 +19,7 @@ span.SetStatus(codes.Error, err.Error())
 After:
 ```go
 // Use the event logger to record the exception as a log-based event
-logger := otel.GetLoggerProvider().Logger("my-package")
+logger := global.Logger("my-package")
 record := log.Record{}
 record.SetTimestamp(time.Now())
 record.SetEventName("exception")
@@ -30,8 +32,8 @@ record.SetSeverity(log.SeverityError)
 // github.com/cockroachdb/errors), extract the stack from the error and
 // add an exception.stacktrace attribute. Do not call runtime.Stack here.
 record.AddAttributes(
-    log.String("exception.type", fmt.Sprintf("%T", err)),
-    log.String("exception.message", err.Error()),
+    attribute.String("exception.type", fmt.Sprintf("%T", err)),
+    attribute.String("exception.message", err.Error()),
 )
 logger.Emit(ctx, record)
 span.SetStatus(codes.Error, err.Error())
@@ -50,12 +52,12 @@ span.AddEvent("cache.miss", trace.WithAttributes(
 
 After:
 ```go
-logger := otel.GetLoggerProvider().Logger("my-package")
+logger := global.Logger("my-package")
 record := log.Record{}
 record.SetTimestamp(time.Now())
 record.SetEventName("cache.miss")
 record.AddAttributes(
-    log.String("cache.key", key),
+    attribute.String("cache.key", key),
 )
 logger.Emit(ctx, record)
 ```
@@ -88,13 +90,15 @@ span.set_status(Status(StatusCode.ERROR, str(exc)))
 
 After:
 ```python
-import logging
+from opentelemetry._logs import SeverityNumber, get_logger
 
-logger = logging.getLogger(__name__)
-# With the OTel logging bridge configured, this emits a log-based event
-logger.exception("exception", exc_info=exc, extra={
-    "event.name": "exception",
-})
+logger = get_logger(__name__)
+logger.emit(
+    event_name="exception",
+    severity_number=SeverityNumber.ERROR,
+    body="exception",
+    exception=exc,
+)
 span.set_status(Status(StatusCode.ERROR, str(exc)))
 ```
 
@@ -107,11 +111,17 @@ span.add_event("retry.attempt", attributes={"retry.count": count})
 
 After:
 ```python
-logger.info("retry.attempt", extra={
-    "event.name": "retry.attempt",
-    "retry.count": count,
-})
+from opentelemetry._logs import get_logger
+
+logger = get_logger(__name__)
+logger.emit(
+    event_name="retry.attempt",
+    body="retry.attempt",
+    attributes={"retry.count": count},
+)
 ```
+
+The Python SDK derives exception semantic-convention attributes when `exception=` is provided. If the project already uses stdlib `logging` with `LoggingHandler`, verify how that bridge maps event names before relying on it for `event_name`.
 
 ## Java
 
@@ -125,22 +135,19 @@ span.setStatus(StatusCode.ERROR, exception.getMessage());
 
 After:
 ```java
-// ExceptionAttributes lives in the io.opentelemetry.semconv artifact
-// (the old SemanticAttributes class was removed).
 Logger logger = GlobalOpenTelemetry.getLogsBridge().loggerBuilder("my-class").build();
 logger.logRecordBuilder()
     .setSeverity(Severity.ERROR)
     .setEventName("exception")
-    .setAttribute(ExceptionAttributes.EXCEPTION_TYPE, exception.getClass().getName())
-    .setAttribute(ExceptionAttributes.EXCEPTION_MESSAGE, exception.getMessage())
-    .setAttribute(ExceptionAttributes.EXCEPTION_STACKTRACE, getStackTrace(exception))
+    .setException(exception)
     .emit();
 span.setStatus(StatusCode.ERROR, exception.getMessage());
 ```
 
 `setEventName(...)` is a first-class method on the stable `LogRecordBuilder`
-(stabilized in opentelemetry-java 1.x); prefer it over setting an
-`event.name` attribute.
+(since 1.50.0); `setException(Throwable)` is available since 1.60.0. Prefer
+these over setting an `event.name` attribute or manually maintaining
+`exception.*` attributes when the project is on a current Java SDK.
 
 ### General Event
 
@@ -177,14 +184,13 @@ const logger = logs.getLogger('my-module');
 logger.emit({
   severityNumber: SeverityNumber.ERROR,
   eventName: 'exception',
-  attributes: {
-    'exception.type': error.name,
-    'exception.message': error.message,
-    'exception.stacktrace': error.stack,
-  },
+  body: 'exception',
+  exception: error,
 });
 span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
 ```
+
+The JS log-record `exception` field is present in current `@opentelemetry/api-logs` / `@opentelemetry/sdk-logs` source and marked experimental. If the project avoids experimental fields, set `exception.type`, `exception.message`, and `exception.stacktrace` attributes manually.
 
 ### General Event
 
@@ -223,7 +229,7 @@ activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
 After:
 ```csharp
 var logger = loggerFactory.CreateLogger("MyClass");
-logger.LogError(ex, "exception");
+logger.LogError(new EventId(0, "exception"), ex, "exception");
 activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
 ```
 
@@ -240,12 +246,18 @@ activity?.AddEvent(new ActivityEvent("validation.failure", default, new Activity
 
 After:
 ```csharp
-logger.LogWarning("validation.failure for field {Field} rule {Rule}", fieldName, rule);
+logger.LogWarning(
+    new EventId(0, "validation.failure"),
+    "validation.failure for field {Field} rule {Rule}",
+    fieldName,
+    rule);
 ```
+
+With the OpenTelemetry .NET OTLP exporter, `EventId.Name` is exported as the OTLP log `event_name` field. The lower-level `LogRecordData.EventName` / `Logger.EmitLog` bridge API exists in source but is experimental/pre-release-gated, so prefer stable `ILogger` patterns unless the project has opted into the bridge API.
 
 ## Key Rules Across All Languages
 
-1. The event name replaces the name from `AddEvent`. Use the dedicated event-name API where available -- `record.SetEventName(...)` (Go), `.setEventName(...)` (Java `LogRecordBuilder`), `eventName:` (JS `logger.emit`) -- which maps to the `event_name` LogRecord field. Only set an `event.name` attribute where the SDK has no dedicated field (e.g., the Python stdlib logging bridge).
+1. The event name replaces the name from `AddEvent`. Use the dedicated event-name API where available -- `record.SetEventName(...)` (Go), `.setEventName(...)` (Java `LogRecordBuilder`), `eventName:` (JS `logger.emit`), `event_name=` (Python `Logger.emit`), or `EventId.Name` (.NET `ILogger`) -- which maps to the `event_name` LogRecord field. Only set an `event.name` attribute when the target SDK/exporter has no dedicated event-name path.
 2. All original attributes transfer to the log record attributes.
 3. The log record automatically inherits the active span context from `ctx` / the current context -- this is how trace correlation is maintained.
 4. `span.SetStatus` (or equivalent) is still set on the span for error cases -- the migration only moves event emission, not status.

--- a/skills/otel-span-events-to-logs-migration/scripts/scan-span-events.sh
+++ b/skills/otel-span-events-to-logs-migration/scripts/scan-span-events.sh
@@ -10,8 +10,9 @@ Usage:
   ./scripts/scan-span-events.sh <directory>
   ./scripts/scan-span-events.sh .
 
-Scans for Span Event API calls (AddEvent, RecordException and
-their language-specific variants) and prints matches grouped by category.
+Scans for Span Event API calls (AddEvent, RecordException, RecordError,
+AddException, ActivityEvent, and language-specific variants) and prints matches
+grouped by category.
 EOF
 }
 

--- a/skills/otel-span-events-to-logs-migration/scripts/scan-span-events.sh
+++ b/skills/otel-span-events-to-logs-migration/scripts/scan-span-events.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Scans a directory for deprecated Span Event API usage across common languages.
+# Scans a directory for Span Event API usage targeted by the OTEP 4430 migration plan.
 # Outputs each match with file, line number, matched pattern, and a classification hint.
 
 usage() {
@@ -10,7 +10,7 @@ Usage:
   ./scripts/scan-span-events.sh <directory>
   ./scripts/scan-span-events.sh .
 
-Scans for deprecated Span Event API calls (AddEvent, RecordException and
+Scans for Span Event API calls (AddEvent, RecordException and
 their language-specific variants) and prints matches grouped by category.
 EOF
 }
@@ -84,7 +84,7 @@ main() {
   fi
 
   if [[ "$found" -eq 0 ]]; then
-    printf '\nNo deprecated Span Event API usage found.\n'
+    printf '\nNo Span Event API usage found.\n'
   else
     printf '\n---\n'
     printf 'total categories with matches: see sections above\n'


### PR DESCRIPTION
## Summary
- Reframes span-event migration guidance around accepted OTEP 4430 without falsely claiming all trace APIs are formally deprecated.
- Adds the current per-language status snapshot for Go, Java, JavaScript, Python, and .NET.
- Refreshes migration examples for Python `Logger.emit`, Java `setException`, JS `exception` caveats, and .NET `EventId.Name`.
- Updates backward-compat bridge guidance to prefer the Java SDK incubator bridge and mark the contrib bridge historical/deprecated.
- Updates the scan script wording from “deprecated usage” to “Span Event API usage targeted by OTEP 4430.”

## Verification
- Synced `opentelemetry-specification`, `opentelemetry-proto`, and language SDK checkouts from upstream/main on 2026-07-12; all were already up to date.
- Verified OTEP 4430 is accepted and `specification/trace/api.md` does not yet mark `AddEvent` / `RecordException` as Deprecated.
- Verified proto `LogRecord.event_name`, Logs API event/exception support, and Logs SDK bridge references exist in synced local upstream sources.
- `git diff --check -- skills/otel-span-events-to-logs-migration` passed.
- `bash -n skills/otel-span-events-to-logs-migration/scripts/scan-span-events.sh` passed.
- `skills/otel-span-events-to-logs-migration/scripts/scan-span-events.sh skills/otel-span-events-to-logs-migration` ran successfully.
- `skills-ref validate skills/otel-span-events-to-logs-migration` not run: `skills-ref` is not installed locally.

## Deliberately excluded
- No scope expansion outside the existing span-events-to-logs migration skill.
- Did not recommend .NET low-level `Logger.EmitLog`; it is experimental/pre-release-gated, so stable `ILogger` guidance remains preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated OpenTelemetry span-event migration guidance to reflect current OTEP 4430 status and language-specific SDK considerations.
  - Expanded migration examples for Go, Python, Java, JavaScript/TypeScript, and .NET.
  - Clarified exception attribute preservation and compatibility exceptions.
  - Revised deprecation timelines, reference links, and language status details.

- **Tools**
  - Updated the migration scan to identify all relevant span-event API usage, including additional naming variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->