### PR TITLE
ci: migrate CLA assistant to maintained fork

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,6 +16,10 @@ permissions:
   pull-requests: write
   statuses: write
 
+env:
+  # GitHub Actions is removing the Node 20 runtime in fall 2026.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   cla:
     runs-on: blacksmith
@@ -23,11 +27,9 @@ jobs:
     steps:
       - name: CLA Assistant
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        # contributor-assistant/github-action is archived (2026-03); upstream states all
-        # existing releases remain functional and recommends forking for future development.
-        # Accepted risk: pinned to an immutable SHA, so the code cannot change under us.
-        # If GitHub API changes ever break it, fork into the ollygarden org and repoint.
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        # Supported continuation of the archived contributor-assistant/github-action.
+        # Pinned to the immutable SHA for the v2.6.2 release.
+        uses: ribtoks/cla-github-action@f22feedd1f3f46f23fab3bc100081d349f9108af # v2.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

- replace the archived `contributor-assistant/github-action` v2.6.1 with the supported `ribtoks/cla-github-action` v2.6.2 continuation
- pin the replacement action to its immutable release SHA
- force JavaScript actions onto Node 24 ahead of GitHub's fall 2026 Node 20 removal
- preserve the existing public `cla-signatures` branch, signature file, events, permissions, signing phrase, and allowlist

This keeps the current simple repository-local signing model while moving away from an archived upstream action.

Linear: [OTEL-254](https://linear.app/ollygarden/issue/OTEL-254/modernize-cla-workflow-to-a-maintained-2026-action)

## Validation

- `yq eval '.' .github/workflows/cla.yml`
- `git diff --check`

## Agent involvement

Implemented with Codex. The approach and publication were reviewed and directed by @jpkrohling.

## Checklist

- [x] Commit message follows Conventional Commits
- [x] No skill content changed; harness evidence and skill registration checks are not applicable
- [x] Existing CLA signature storage and signing behavior remain unchanged
- [x] I have signed the OllyGarden CLA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the contribution agreement workflow to use the latest supported runtime.
  * Updated the pinned contribution agreement action for improved compatibility.
  * Simplified workflow comments and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->