### PR TITLE
fix: finalize CLA workflow rollout

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,6 +22,5 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    # Temporarily pinned to the reviewed head of ollygarden/.github#5.
-    # Replace with that PR's immutable squash-merge SHA after merge.
-    uses: ollygarden/.github/.github/workflows/cla.yml@d8fd829d25fb6d57ebc598cf495ab54a35e48ac1
+    # Pinned to the immutable squash-merge SHA of ollygarden/.github#6.
+    uses: ollygarden/.github/.github/workflows/cla.yml@f9fba8552bebbf8b9c01d20d6cfd30041065b4aa


### PR DESCRIPTION
## Summary

- replace the detached temporary reusable-workflow pin with the immutable squash-merge SHA of `ollygarden/.github#6`

## Why

The community-policy rollout was merged while both callers still referenced the deleted PR 5 head. GitHub could not resolve that reusable workflow, so CLA runs failed at startup with no jobs. The organization workflow now also contains the corrected maintainer allowlist.

The organization Actions policy intentionally permits any SHA of OllyGarden's internal reusable CLA workflow.

## Validation

- `git diff --check`
- parsed `.github/workflows/cla.yml` as YAML
- verified the pinned SHA resolves to the merged reusable workflow
- verified the two repository caller workflows are byte-for-byte identical

## Agent involvement

Codex implemented these changes. A human must review the result before merge.

Harness evidence is not applicable because no skill content changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated contribution agreement workflow to use a newer, securely pinned configuration.
  * Refreshed the associated workflow reference information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->