### PR TITLE
docs(otel-java): sensitive-data capture reference — url.query is on by default, redaction and capture knobs

### DIFF
--- a/skills/otel-java/SKILL.md
+++ b/skills/otel-java/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: otel-java
-description: OpenTelemetry in Java — Javaagent zero-code instrumentation, Spring Boot Starter, manual autoconfigure SDK, declarative YAML configuration, BOM dependency management. Use when adding, reviewing, or configuring OpenTelemetry in a Java service. Triggers on "setup otel in java", "java telemetry", "javaagent", "Spring Boot otel", "GlobalOpenTelemetry", "AutoConfiguredOpenTelemetrySdk", "TracerProvider java", or any Java-related OTel question.
+description: OpenTelemetry in Java — Javaagent zero-code instrumentation, Spring Boot Starter, manual autoconfigure SDK, declarative YAML configuration, BOM dependency management, sensitive-data capture and redaction (url.query, headers, request parameters, SQL sanitization). Use when adding, reviewing, or configuring OpenTelemetry in a Java service. Triggers on "setup otel in java", "java telemetry", "javaagent", "Spring Boot otel", "GlobalOpenTelemetry", "AutoConfiguredOpenTelemetrySdk", "TracerProvider java", "url.query redaction", "capture request headers", or any Java-related OTel question.
 ---
 
 # OpenTelemetry in Java
@@ -13,6 +13,7 @@ the task; each reference is self-contained.
 | File | Use when |
 |---|---|
 | [`references/declarative-setup.md`](references/declarative-setup.md) | Configuring the SDK via declarative YAML: Javaagent activation, Spring Boot Starter, autoconfigure SDK, BOM, agent-only properties, manual instrumentation entry points. |
+| [`references/sensitive-data-capture.md`](references/sensitive-data-capture.md) | What HTTP instrumentation captures by default (query strings ON, headers/params OFF), query-parameter redaction (`sensitive-query-parameters`), header/servlet-parameter capture knobs, SQL sanitization. |
 
 ## Sources of Truth
 

--- a/skills/otel-java/references/sensitive-data-capture.md
+++ b/skills/otel-java/references/sensitive-data-capture.md
@@ -1,0 +1,76 @@
+# Sensitive-data capture in Java HTTP instrumentation
+
+What the Javaagent and Spring Boot Starter capture from HTTP traffic by default, and every
+knob that changes it. Applies to both distribution channels — they share the same
+instrumentation config properties (env-var form: upper-case, dots/dashes → underscores).
+
+## What is captured by default
+
+| Data | Attribute | Default |
+|---|---|---|
+| URL path | `url.path` (server) / inside `url.full` (client) | **captured** |
+| URL query string | `url.query` (server) / inside `url.full` (client) | **captured**, with only the sensitive-parameter list below redacted |
+| Request/response headers | `http.request.header.<name>` / `http.response.header.<name>` | not captured (opt-in) |
+| Servlet request parameters (form/query) | `servlet.request.parameter.<name>` | not captured (opt-in, experimental) |
+| SQL bound values | `db.query.text` | not captured (statements sanitized to `?` by default) |
+
+The asymmetry matters: headers, request parameters, and SQL values are **off** by default,
+but the raw query string is **on** — any user data in a query string
+(`GET /owners?lastName=Smith`, search terms, tokens in links) is exported verbatim unless
+its parameter name is in the redaction list.
+
+## Query-parameter redaction
+
+Values of listed parameter names are replaced with `REDACTED` in `url.query` and `url.full`
+(parameter names themselves are preserved, per semconv):
+
+```properties
+# default list — credential parameters only
+otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters=\
+  AWSAccessKeyId,Signature,sig,X-Goog-Signature
+```
+
+- Type: list of case-sensitive parameter names. Setting it **replaces** the default list
+  (full override, not additive) — re-list the credential defaults when extending it.
+- Declarative config: `general.sanitization.url.sensitive_query_parameters` under
+  `instrumentation/development`.
+- History: replaces `otel.instrumentation.http.client.experimental.redact-query-parameters`
+  (client-only; deprecated, then removed in 2026 releases —
+  [#18229](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18229)).
+
+**There is no property that drops the query string entirely.** To export URLs without query
+strings, post-process: overwrite `url.query`/`url.full` in a `SpanProcessor` (registered via
+the autoconfigure SPI, or an agent extension jar for the Javaagent), or delete/rewrite the
+attributes in a Collector processor (`transform`/`redaction`).
+
+## Opt-in capture knobs (off by default)
+
+```properties
+otel.instrumentation.http.server.capture-request-headers=<list>
+otel.instrumentation.http.server.capture-response-headers=<list>
+otel.instrumentation.http.client.capture-request-headers=<list>
+otel.instrumentation.http.client.capture-response-headers=<list>
+otel.instrumentation.servlet.experimental.capture-request-parameters=<list>
+```
+
+Captured headers land as `http.request.header.<lowercase-name>` /
+`http.response.header.<lowercase-name>` (list-valued); servlet parameters as
+`servlet.request.parameter.<name>`. Enabling any of these captures the raw values — there
+is no per-header/per-parameter redaction.
+
+## SQL sanitization
+
+Statement sanitization (bound values → `?`) is on by default; the current toggle is
+`db.query_sanitization.enabled` in declarative config. Older property spellings
+(`otel.instrumentation.common.db-statement-sanitizer.enabled` and per-instrumentation
+`*-statement-sanitizer.enabled` variants) are deprecated. Do not turn it off on request
+paths.
+
+## Sources of truth
+
+| Fact | Fetch |
+|---|---|
+| HTTP capture properties (headers, servlet params, known-methods) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/instrumentation/http/` |
+| Current property names/defaults incl. `sensitive-query-parameters` | any instrumentation `metadata.yaml`, e.g. `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/instrumentation/jodd-http-4.2/metadata.yaml` |
+| Renames/removals of capture & sanitization properties | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/CHANGELOG.md` |
+| Semconv redaction rules for `url.query`/`url.full` | `WebFetch https://opentelemetry.io/docs/specs/semconv/http/http-spans/` |


### PR DESCRIPTION
## Summary

Fills a factual gap surfaced while working ollygarden/skills#29: `otel-java` had nothing on what Java HTTP instrumentation captures from requests, so answering "does the agent export query strings, and how do I stop it?" required external research. These are vendor-neutral upstream facts and belong here.

New `references/sensitive-data-capture.md`, registered in the references table:

- The default-capture asymmetry: headers, servlet request parameters, and SQL bound values are **off** by default, but the raw query string (`url.query` / inside `url.full`) is **on**, with only four credential parameters redacted.
- `otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters`: list semantics, **full-override** (not additive) behavior, declarative-config name, and the removal of the old client-only `redact-query-parameters` property ([#18229](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18229)).
- The fact that **no property drops the query string entirely** — post-processing options (SpanProcessor via autoconfigure SPI / agent extension, or Collector `transform`/`redaction`).
- The opt-in capture knobs (header and servlet-parameter capture) and current SQL-sanitization toggles with the deprecated spellings.
- Sources-of-truth fetch table (upstream HTTP config docs, instrumentation `metadata.yaml`, CHANGELOG, semconv).

Every property name/default was verified against the upstream docs page, an instrumentation `metadata.yaml`, and the CHANGELOG (fetch commands are in the file's sources-of-truth table).

The companion opinion ("do not export query strings by default") lands in `ollygarden-otel-java-setup` via ollygarden/skills#29, which cross-references this file for mechanics — keeping opinions and upstream facts separated per contributing guidelines.

## Agent involvement

Authored by an AI coding agent (Claude Code); reviewed and owned by @jpkroehling.

## Harness results (required for new or substantively changed skills)

- **Prompt context:** Java showcase vibe run (2026-07-14, spring-petclinic, openai/gpt-5.6-sol via opencode, hermetic harness) — with the current `otel-java` skill installed and invoked, the agent shipped instrumentation exporting `lastName=Owner58_88584` in `url.query` (deterministic PII check FAIL, 2/40 Tempo traces); the skill offered no capture/redaction facts to consult.
- **With this reference (micro-test, 2026-07-15):** a fresh hermetic planning session with the updated skill set produced the `sensitive_query_parameters` configuration block and an explicit query-value redaction plan item, unprompted. Full A/B re-run (`t3-vibe-java-r2`) follows once the paired opinion PR merges.
- Transcripts live in the (remote-less) showcase meta-repo `results/`; available on request.

## Checklist

- [x] `skills-ref validate skills/otel-java` passes
- [x] Content is vendor-neutral upstream fact, verified against sources of truth
- [x] Harness comparison results included above
- [x] Commit messages follow Conventional Commits
- [x] I have signed the OllyGarden CLA
- [x] I have read and will follow the Code of Conduct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
