### PR TITLE
docs(otel-browser): refresh released browser guidance

### DIFF
--- a/skills/otel-browser/SKILL.md
+++ b/skills/otel-browser/SKILL.md
@@ -51,10 +51,10 @@ are the authoritative, current map. Summary:
 | `@opentelemetry/auto-instrumentations-web` | opentelemetry-js-contrib | bundle | experimental |
 | `instrumentation-document-load` / `-long-task` / `-user-interaction` | opentelemetry-js-contrib | spans | experimental |
 | `instrumentation-browser-navigation` / `-web-exception` | opentelemetry-js-contrib | events | experimental |
-| `plugin-react-load` | opentelemetry-js-contrib | spans | experimental |
+| `plugin-react-load` | opentelemetry-js-contrib | spans | **unmaintained** |
 
-`opentelemetry-browser` is the home of the event-based instrumentations and the future home of the
-Browser SDK; the span-based packages still live in `opentelemetry-js` / `opentelemetry-js-contrib`.
+`opentelemetry-browser` is the home of the event-based instrumentations and the experimental Browser
+SDK; the span-based packages still live in `opentelemetry-js` / `opentelemetry-js-contrib`.
 
 ## Why browser RUM is different
 

--- a/skills/otel-browser/references/instrumentation.md
+++ b/skills/otel-browser/references/instrumentation.md
@@ -99,7 +99,7 @@ conventions are **merged** (see the
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `includeRawAttribution` | `boolean` | `false` | Set the record body to the `web-vitals` attribution object (which element/event caused the metric). |
+| `includeRawAttribution` | `boolean` | `false` | Set the record body to the JSON-stringified `web-vitals` attribution object (which element/event caused the metric). |
 | `applyCustomLogRecordData` | `(logRecord) => void` | — | Mutate the record before emit. |
 
 INP and CLS finalize near the end of the page lifecycle — they depend on the SDK flushing on
@@ -121,12 +121,17 @@ new ConsoleInstrumentation({ logMethods: ['error', 'warn'] });
 An `exception` event for every uncaught error (`window` `error`) and unhandled promise rejection
 (`unhandledrejection`), reusing the existing `exception` event. Records carry `exception.type`,
 `exception.message`, `exception.stacktrace` (type/stacktrace omitted for non-`Error` throws).
-`applyCustomAttributes` can add fields (e.g. an app-level severity).
+When an `ErrorEvent` has no error object but has a non-empty message (as can happen for cross-origin
+scripts), the message is still emitted; rejections with a null/undefined reason are dropped.
+`applyCustomAttributes` can add fields (e.g. an app-level severity). Failures while extracting or
+emitting an exception are contained and reported through SDK diagnostics rather than escaping the
+global error handler.
 
 ### User Action (`browser.user_action`)
 
 Captures user input events (by default `click`). Any `data-otel-*` attribute on the clicked element
-is copied onto the record — a deliberate channel for **non-PII** business context.
+is copied into the `browser.element.attributes` map with the prefix removed — a deliberate channel
+for **non-PII** business context.
 
 ```typescript
 new UserActionInstrumentation({ autoCapturedActions: ['click'] }); // default
@@ -162,7 +167,7 @@ registerInstrumentations({
 | `instrumentation-long-task` | js-contrib | Spans for [Long Tasks](https://developer.mozilla.org/docs/Web/API/Long_Tasks_API) (>50 ms main-thread blocks). |
 | `instrumentation-browser-navigation` | js-contrib | Event-based SPA navigation (alternative to the one above). |
 | `instrumentation-web-exception` | js-contrib | Event-based unhandled exception capture. |
-| `plugin-react-load` | js-contrib | React component mount/load performance. |
+| `plugin-react-load` | js-contrib | React component mount/load performance; **unmaintained** upstream. |
 
 ### fetch / XHR cross-origin propagation
 

--- a/skills/otel-browser/references/instrumentation.md
+++ b/skills/otel-browser/references/instrumentation.md
@@ -17,6 +17,20 @@ with a real begin/end and parent/child relationship.
 > against the upstream READMEs and `package.json` `exports` (see
 > [SKILL.md Sources of Truth](../SKILL.md#sources-of-truth)).
 
+### Network context correlation proposal (0.6.0)
+
+Release 0.6.0 added `ContextRegistry` and `NetworkContextRegistry` as a proposal for sharing
+OpenTelemetry context between instrumentations that observe the same network operation from
+different angles. The network registry indexes a completed span by URL and its `performance.now()`
+window, then lets a consumer match that context to a `PerformanceResourceTiming` entry whose
+`fetchStart` and `responseEnd` fall inside the window. This is intended to let resource-timing
+telemetry retain the network span's trace context.
+
+This is **not yet a user-facing activation mechanism** in 0.6.0: the package does not expose the
+registry through its npm `exports`, and no released instrumentation registers or consumes it.
+Track it as released experimental groundwork; do not import internal source paths or claim
+resource-timing events are correlated automatically.
+
 ## Event-based instrumentations (`@opentelemetry/browser-instrumentation`)
 
 Entry points are subpath exports under `./experimental/*`; they emit through the global

--- a/skills/otel-browser/references/performance.md
+++ b/skills/otel-browser/references/performance.md
@@ -22,9 +22,9 @@ more so than for backend SDKs.
   [setup-sdk.md](setup-sdk.md#per-signal-sdks-tree-shaking).
 - **Prefer event-based over span-based** instrumentations where both exist — they pull in less SDK
   surface.
-- **Use subpath imports** for instrumentations
-  (`@opentelemetry/browser-instrumentation/experimental/web-vitals`) rather than a barrel import, so
-  unused instrumentations tree-shake away.
+- **Use the instrumentation subpath exports**
+  (`@opentelemetry/browser-instrumentation/experimental/web-vitals`). The package declares itself
+  side-effect-free so bundlers can remove unused instrumentation code.
 - **`zone.js` is ~1 MB.** `ZoneContextManager` is the only reliable way to propagate trace context
   across async boundaries, but it is heavy. A common trade-off is to relax in-browser async tracing
   and rely on **session correlation** instead, adding `zone.js` only when stitched async spans are


### PR DESCRIPTION
## Summary

- refresh the browser instrumentation catalog for the released 0.6.0 surface
- correct raw attribution and `data-otel-*` behavior
- document released error handling and tree-shaking behavior
- document the released network-context correlation proposal and its current public-API limits

## Verification

- checked source and changelogs at `browser-instrumentation-v0.6.0`
- checked Browser SDK 0.1.0, OpenTelemetry JS 2.9.0/0.220.0, and web auto-instrumentation 0.65.0
- verified referenced local upstream paths and Markdown anchors
- `git diff --check -- skills/otel-browser`

Upstream package tests were not run because the checkout has no installed dependencies and the available npm 11.12.1 does not satisfy the repository's `^11.16.0` requirement. `skills-ref` is unavailable in this environment.

## Deliberately excluded

- post-release changes on upstream `main`

Agent-authored refresh; human-owned PR.
