### PR TITLE
docs(otel-go): refresh released SDK guidance

### DIFF
--- a/skills/otel-go/references/api.md
+++ b/skills/otel-go/references/api.md
@@ -258,7 +258,7 @@ if logger.Enabled(ctx, params) {
     logger.Emit(ctx, rec)
 }
 
-// Attach an error to a log record (v1.42.0+)
+// Attach an error to a log record (otel/log v0.18.0+; released with core v1.42.0)
 // The SDK automatically sets exception attributes (exception.type, exception.message)
 var rec log.Record
 rec.SetSeverity(log.SeverityError)
@@ -298,7 +298,7 @@ log.MapValue(log.String("key", "value"))
 
 Logging bridges connect existing logging libraries to OpenTelemetry.
 
-> **Note (contrib v1.35.0):** otelzap and otelslog emit `code.function` with the full package path-qualified function name (e.g., `github.com/user/pkg.MyFunc`). The `code.namespace` attribute is no longer emitted.
+> **Note (bridge v0.10.0):** otelzap and otelslog emit `code.function` with the full package path-qualified function name (e.g., `github.com/user/pkg.MyFunc`). The `code.namespace` attribute is no longer emitted.
 
 ```go
 import (

--- a/skills/otel-go/references/breaking-changes.md
+++ b/skills/otel-go/references/breaking-changes.md
@@ -6,19 +6,19 @@ version selection, fetch from the Sources of Truth table in the `otel-go` skill 
 
 ## API Deprecations
 
-- `go.opentelemetry.io/contrib/config` is deprecated (contrib v1.35.0). Use `go.opentelemetry.io/contrib/otelconf` instead. The API is identical.
-- `WithMetricAttributesFn` deprecated in otelhttp (contrib v1.41.0). Use `Labeler` instead.
-- otelgrpc: prefer stats handlers (`NewServerHandler` / `NewClientHandler`) over deprecated interceptors for new code.
+- `go.opentelemetry.io/contrib/config` was removed in contrib v1.35.0. Use `go.opentelemetry.io/contrib/otelconf` instead.
+- `WithMetricAttributesFn` deprecated in otelhttp v0.66.0 (contrib v1.41.0 release). Use `Labeler` instead.
+- otelgrpc's deprecated client/server interceptors were removed in v0.60.0. Use stats handlers (`NewServerHandler` / `NewClientHandler`).
 - `attribute.INVALID` deprecated (core v1.43.0) — an empty value is now valid; use `attribute.EMPTY` instead.
 - `attribute.Value.Emit` deprecated (core v1.44.0). Use `attribute.Value.String` instead.
 - `OTEL_EXPERIMENTAL_CONFIG_FILE` is no longer supported by root `otelconf` v0.23.0+ (contrib v1.43.0+). Use `OTEL_CONFIG_FILE`.
 
-## Removed APIs (contrib v1.40.0+)
+## Removed APIs (instrumentation v0.65.0; contrib v1.40.0 release)
 
 - otelhttp removed `DefaultClient`, `Get`, `Head`, `Post`, `PostForm`, `WithPublicEndpoint`, `WithRouteTag`. Always create a custom client with `otelhttp.NewTransport`.
 - HTTP instrumentation sets the `error.type` attribute instead of `exception` span events.
 
-## Semantic Convention Renames (contrib v1.40.0+)
+## Semantic Convention Renames (instrumentation v0.65.0; contrib v1.40.0 release)
 
 RPC attribute changes:
 
@@ -27,7 +27,7 @@ RPC attribute changes:
 - `rpc.client.duration` / `rpc.server.duration` → `rpc.client.call.duration` / `rpc.server.call.duration` (unit changed to seconds)
 - `rpc.grpc.status_code` → `rpc.response.status_code`
 
-## otelgrpc (contrib v1.42.0)
+## otelgrpc v0.67.0 (contrib v1.42.0 release)
 
 - No longer emits `rpc.message` span events, `rpc.*.request/response.size` metrics, or `network.*` attributes — even with `WithMessageEvents`.
 
@@ -43,18 +43,18 @@ RPC attribute changes:
 
 - The 8192-byte baggage size limit is now enforced during extraction/parsing (`otel/baggage`, `otel/propagation`): baggage strings over the limit are rejected outright, while malformed members are skipped — valid members are retained and an error is reported.
 
-## HTTP instrumentation behaviour (contrib v1.44.0)
+## HTTP instrumentation behaviour (instrumentation v0.69.0; contrib v1.44.0 release)
 
 - Unknown or empty HTTP methods now report `_OTHER` instead of `GET` across all HTTP instrumentations (otelhttp, otelmux).
 - The default server span name is now `{method} {route}` (e.g. `GET /foo/{id}`) when a route is available, or `{method}` otherwise — conforming to HTTP semconv.
 
-## Removed / renamed contrib APIs (contrib v1.43.0–v1.44.0)
+## Removed / renamed contrib APIs (v1.43.0–v1.44.0 release lines)
 
-- otelgrpc removed the deprecated `WithSpanOptions` option (v1.44.0).
-- `otelconf`: experimental config types moved from `otelconf` to the `otelconf/x` subpackage (v1.43.0). The `host` resource detector no longer sets `host.id` (v1.43.0).
-- otelgrpc added `OTEL_SEMCONV_STABILITY_OPT_IN` (values `rpc` default, `rpc/dup`, `rpc/old`) to stage RPC semconv migration (v1.43.0).
+- otelgrpc removed the deprecated `WithSpanOptions` option in v0.69.0.
+- `otelconf`: experimental config types moved from `otelconf` to the `otelconf/x` subpackage in v0.23.0. The `host` resource detector no longer sets `host.id` in v0.23.0.
+- otelgrpc added `OTEL_SEMCONV_STABILITY_OPT_IN` (values `rpc` default, `rpc/dup`, `rpc/old`) in v0.68.0 to stage RPC semconv migration.
 
-## Log bridges attach errors via SetErr (contrib v1.43.0–v1.44.0)
+## Log bridges attach errors via SetErr (bridge v0.18.0–v0.19.0)
 
 - otelslog, otelzap, otellogrus, and otellogr now record fields implementing `error` (e.g. `zap.Error`, `slog` error values) via `log.Record.SetErr` instead of emitting them as plain or `exception.*` attributes. The SDK then derives the `exception.*` attributes from the record error.
 
@@ -62,7 +62,7 @@ RPC attribute changes:
 
 - `trace.SpanFromContext()` never returns nil — no nil checks or `IsRecording()` guards needed.
 - `span.RecordError()` and `span.AddEvent()` are still present in the released tracing API; do not remove existing uses as deprecated APIs.
-- `log.Record.SetErr(err)` (v1.42.0) — the SDK automatically sets `exception.type` and `exception.message` attributes.
+- `log.Record.SetErr(err)` (`otel/log` v0.18.0; released with core v1.42.0) — the SDK automatically sets `exception.type` and `exception.message` attributes.
 
 ## Resolved Gotchas (historical reference)
 

--- a/skills/otel-go/references/declarative-setup.md
+++ b/skills/otel-go/references/declarative-setup.md
@@ -36,7 +36,7 @@ latest module tag supports.
 
 ## Migration notes
 
-- `go.opentelemetry.io/contrib/config` is deprecated. Use `go.opentelemetry.io/contrib/otelconf`.
+- `go.opentelemetry.io/contrib/config` was removed in contrib v1.35.0. Use `go.opentelemetry.io/contrib/otelconf`.
 - In the root package, use `OTEL_CONFIG_FILE`; `OTEL_EXPERIMENTAL_CONFIG_FILE` is rejected by
   current released `otelconf`.
 - If migrating from the schema-pinned `otelconf/v0.3.0` import, the YAML must also migrate to
@@ -72,8 +72,8 @@ resource:
       value: "${DEPLOY_ENV:-development}"
 
 # Tracer/meter/logger provider blocks: structure per the canonical example.
-# Go-specific quirk: os.ExpandEnv resolves ${VAR} substitutions before the YAML is
-# parsed, so any ${VAR} in this file works when the loader uses os.ExpandEnv.
+# The root otelconf parser resolves ${VAR}, ${env:VAR}, and ${VAR:-default}
+# before parsing YAML. Use $${VAR} when the literal text must be preserved.
 ```
 
 ## Key API Facts

--- a/skills/otel-go/references/instrumentation-libraries.md
+++ b/skills/otel-go/references/instrumentation-libraries.md
@@ -38,8 +38,7 @@ SERVER span living in `c.Request.Context()` (gin) or `r.Context()` (net/http) pa
 DB/client span **only if that exact context is passed into it**.
 
 > **Symptom:** DB or client spans show up as CLIENT-kind *roots* in their own traces, disconnected
-> from the request. OllyGarden flags this as "Root Client Span"; it means trace context was dropped
-> at an internal boundary.
+> from the request. This means trace context was dropped at an internal boundary.
 
 The usual cause is structural, not a missing option:
 
@@ -94,7 +93,7 @@ func setupHTTPServer() *http.Server {
 }
 
 // HTTP client with automatic instrumentation
-// Note: otelhttp.DefaultClient, Get, Head, Post, PostForm were removed in contrib v1.40.0
+// Note: otelhttp.DefaultClient, Get, Head, Post, PostForm were removed in v0.65.0
 // Always create a custom client with otelhttp.NewTransport instead
 func setupHTTPClient() *http.Client {
     return &http.Client{
@@ -124,7 +123,7 @@ func setupGRPCClient(target string) (*grpc.ClientConn, error) {
     )
 }
 
-// Override default span kind in gRPC (contrib v1.41.0+)
+// Override default span kind in gRPC (otelgrpc v0.66.0+)
 func setupGRPCServerWithSpanKind() *grpc.Server {
     return grpc.NewServer(
         grpc.StatsHandler(otelgrpc.NewServerHandler(
@@ -152,8 +151,8 @@ func setupGRPCServerWithSpanKind() *grpc.Server {
 > // db.query.text becomes: INSERT INTO "users" (...) VALUES (?, ?, ?)
 > ```
 >
-> Treat this as the default for any service that touches user data. The same trap applies to other
-> SQL instrumentation that captures full statement text; verify the selected package's option to
+> For services that handle user data, the same trap applies to other SQL instrumentation that
+> captures full statement text; verify the selected package's option to
 > disable or redact query text. Keep parameter values out of `db.query.text` before export. If the
 > selected instrumentation cannot sanitize or parameterize query text, disable query-text capture;
 > downstream redaction is defense-in-depth.
@@ -174,7 +173,7 @@ func setupGRPCServerWithSpanKind() *grpc.Server {
 | logrus | `go.opentelemetry.io/contrib/bridges/otellogrus` |
 | logr | `go.opentelemetry.io/contrib/bridges/otellogr` |
 
-> **Logging bridge change (contrib v1.35.0):** otelzap and otelslog now emit `code.function` with the full package path-qualified function name (e.g., `github.com/user/pkg.MyFunc`) instead of just the function name. The `code.namespace` attribute is no longer emitted.
+> **Logging bridge change (bridge v0.10.0):** otelzap and otelslog now emit `code.function` with the full package path-qualified function name (e.g., `github.com/user/pkg.MyFunc`) instead of just the function name. The `code.namespace` attribute is no longer emitted.
 
 ```go
 // zap bridge setup
@@ -233,7 +232,7 @@ func setupLogger() {
 
 | Cloud | Package |
 |-------|---------|
-| AWS EC2 | `go.opentelemetry.io/contrib/detectors/aws/ec2` |
+| AWS EC2 | `go.opentelemetry.io/contrib/detectors/aws/ec2/v2` |
 | AWS ECS | `go.opentelemetry.io/contrib/detectors/aws/ecs` |
 | AWS EKS | `go.opentelemetry.io/contrib/detectors/aws/eks` |
 | AWS Lambda | `go.opentelemetry.io/contrib/detectors/aws/lambda` |
@@ -244,7 +243,7 @@ func setupLogger() {
 
 | Propagator | Package |
 |------------|---------|
-| Environment carrier | `go.opentelemetry.io/contrib/propagators/envcar` (new in v1.42.0) |
+| Environment carrier | `go.opentelemetry.io/contrib/propagators/envcar` (new in v0.67.0) |
 
 ## Manual Instrumentation Patterns
 
@@ -261,7 +260,12 @@ func (c *CustomClient) CallExternalAPI(ctx context.Context, endpoint string) err
             semconv.URLFull(endpoint)))
     defer span.End()
 
-    resp, err := c.httpClient.Get(endpoint)
+    req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+    if err != nil {
+        return fmt.Errorf("creating request: %w", err)
+    }
+
+    resp, err := c.httpClient.Do(req)
     if err != nil {
         return fmt.Errorf("making request: %w", err)
     }

--- a/skills/otel-go/references/performance.md
+++ b/skills/otel-go/references/performance.md
@@ -32,7 +32,9 @@ Performance tuning reference for OpenTelemetry Go SDK. Covers sampling, batch pr
 
 ## Sampling
 
-Sampling is the single most impactful performance lever for traces. Unsampled spans create noop instances with virtually zero overhead -- no allocations for attributes, events, or links.
+Sampling is the single most impactful performance lever for traces. Dropped spans do not record
+attributes, events, or links, though the application still pays to construct values and options it
+passes to `Start`.
 
 ### Head Sampling Configuration
 
@@ -57,10 +59,14 @@ tp := sdktrace.NewTracerProvider(
 
 ### AlwaysRecord Sampler (v1.40.0+)
 
-The `AlwaysRecord` sampler wraps another sampler and ensures spans are always recorded (attributes, events, status are captured) even when the inner sampler decides not to sample (export). This is useful with tail sampling in a Collector: spans carry full data for the Collector to make sampling decisions, but unsampled spans are not exported by the SDK.
+The `AlwaysRecord` sampler wraps another sampler and ensures spans are always recorded (attributes,
+events, and status are captured) and passed to in-process span processors even when the inner
+sampler decides `Drop`. Standard `SimpleSpanProcessor` and `BatchSpanProcessor` exporters still
+skip `RecordOnly` spans, so this is useful for in-process processing such as span-to-metrics, not
+for sending unsampled spans to a Collector.
 
 ```go
-// Record all spans but only export 10% -- useful with Collector tail sampling
+// Record all spans in-process; standard processors export only the sampled 10%
 sampler := sdktrace.AlwaysRecord(sdktrace.TraceIDRatioBased(0.1))
 ```
 
@@ -68,14 +74,17 @@ sampler := sdktrace.AlwaysRecord(sdktrace.TraceIDRatioBased(0.1))
 
 ```
 AlwaysSample       -> Full span lifecycle: allocation + recording + export
-AlwaysRecord(0.1)  -> All spans recorded, 10% exported
+AlwaysRecord(0.1)  -> All spans recorded in-process, 10% exported by standard processors
 TraceIDRatioBased(0.1) -> 90% of spans become noop (near-zero cost)
 NeverSample        -> All spans noop (useful for load testing)
 ```
 
 `AlwaysSample` records and exports every span. `TraceIDRatioBased(0.1)` makes 90% of spans noop with near-zero cost. `ParentBased` wrapping respects upstream sampling decisions. `NeverSample` makes all spans noop, which is useful for benchmarking application-only performance.
 
-> **Tail sampling**: For decision-making based on complete traces (error status, latency thresholds), use the Collector's tail sampling processor instead of SDK-level sampling. SDK head sampling combined with Collector tail sampling is a common production pattern.
+> **Tail sampling**: For a Collector to decide from complete traces (error status, latency
+> thresholds), configure the SDK to sample and export all candidate spans, then use the Collector's
+> tail sampling processor. `AlwaysRecord` does not send its `RecordOnly` spans through the standard
+> SDK span processors.
 
 ---
 
@@ -125,7 +134,8 @@ When the queue fills, new spans are dropped silently by default. Telemetry loss 
 
 `WithBlockOnQueueFull()` changes this behavior to backpressure the application goroutine, blocking on `span.End()` until queue space is available.
 
-The SDK exposes internal metrics for monitoring queue depth.
+With experimental SDK self-observability enabled via `OTEL_GO_X_OBSERVABILITY=true`, the SDK
+exposes queue size/capacity and processed-span metrics. This feature may change incompatibly.
 
 ### SimpleSpanProcessor
 
@@ -219,28 +229,29 @@ Metric attribute cardinality is the product of unique values across all recorded
 
 ## Attribute Allocation Patterns
 
-Attributes are one of the primary sources of allocations in instrumented code.
+Attribute options can be a significant source of allocations in instrumented code.
 
 ### Pre-allocating Attribute Sets
 
-For attributes used across many measurements, construct them once:
+For attributes used across many measurements, construct an attribute set and measurement option
+once:
 
 ```go
 var (
-    methodGET  = attribute.String("http.request.method", "GET")
-    methodPOST = attribute.String("http.request.method", "POST")
-    status2xx  = attribute.Int("http.response.status_code", 200)
-    status4xx  = attribute.Int("http.response.status_code", 400)
-    status5xx  = attribute.Int("http.response.status_code", 500)
+    successfulGET = attribute.NewSet(
+        attribute.String("http.request.method", "GET"),
+        attribute.Int("http.response.status_code", 200),
+    )
+    successfulGETOption = metric.WithAttributeSet(successfulGET)
 )
 
 func handleRequest(ctx context.Context, method string, status int) {
-    // Reuse pre-allocated attributes -- no allocation per call
-    counter.Add(ctx, 1, metric.WithAttributes(methodGET, status2xx))
+    counter.Add(ctx, 1, successfulGETOption)
 }
 ```
 
-Constructing `attribute.String(...)` or `attribute.Int(...)` inline on every call allocates on every call.
+Reusing `metric.WithAttributeSet(...)` avoids rebuilding and deduplicating the same attribute set
+for every measurement. Benchmark dynamic cases before adding caches or pools.
 
 ### Slice Capacity
 
@@ -259,7 +270,8 @@ A `nil` slice (`var attrs []attribute.KeyValue`) reallocates on the first and su
 
 ### Span Attribute Limits
 
-The SDK enforces configurable limits on span attributes, events, and links. When limits are exceeded, the oldest items are evicted (FIFO):
+The SDK enforces configurable limits on span attributes, events, and links. New span attributes
+beyond the count limit are dropped; new events and links replace the oldest item (FIFO):
 
 ```go
 tp := sdktrace.NewTracerProvider(
@@ -274,7 +286,8 @@ tp := sdktrace.NewTracerProvider(
 )
 ```
 
-`AttributeValueLengthLimit` truncates string values (stack traces, SQL queries, request bodies) that would otherwise consume unbounded memory.
+`AttributeValueLengthLimit` truncates strings, string-slice elements, byte slices, and those values
+nested in slice attributes that would otherwise consume unbounded memory.
 
 ---
 
@@ -441,12 +454,14 @@ The OpenTelemetry SDK is designed so that telemetry failures do not crash or blo
 
 ## Monitoring the Pipeline
 
-The SDK exposes internal metrics about its own health:
+The released SDK and OTLP exporters expose experimental self-observability metrics when
+`OTEL_GO_X_OBSERVABILITY=true`. They use the global `MeterProvider` and may change incompatibly:
 
 | Metric | Meaning |
 |--------|---------|
-| `otel.sdk.trace.spans_exported` | Spans successfully exported |
-| `otel.sdk.trace.spans_dropped` | Spans dropped (queue full, export failure) |
+| `otel.sdk.processor.span.queue.size` | Current BatchSpanProcessor queue depth |
+| `otel.sdk.processor.span.processed` | Spans processed; `error.type=queue_full` identifies queue drops |
+| `otel.sdk.exporter.span.exported` | Spans whose export finished; `error.type` distinguishes failures |
 | Exporter errors in logs | Export failures with error details |
 
 ### ForceFlush


### PR DESCRIPTION
## Summary

- correct removed and independently versioned Go module APIs
- update released otelconf substitution and contrib detector guidance
- fix sampling, span-limit, allocation, and SDK self-observability behavior

## Verification

- checked released core v1.44.0, logs v0.20.0, contrib v0.69.0, bridges v0.19.0, and otelconf v0.24.0
- focused released-package tests passed for attributes, semconv v1.41.0, otelconf environment expansion, and otelhttp compile-only
- current checkout compile-only checks passed for sdk/trace and metric
- `git diff --check -- skills/otel-go`

The full otelhttp suite was sandbox-blocked by local IPv6 socket binding. `skills-ref` is unavailable.

## Deliberately excluded

- post-release upstream `main` changes
- uncovered net-new modules such as MongoDB driver v2 and the Hetzner detector

Agent-authored refresh; human-owned PR.
