### PR TITLE
docs(otel-collector): refresh released component guidance

### DIFF
--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -11,7 +11,7 @@ It does **not** cover OTTL expressions (see `otel-ottl`), declarative SDK config
 
 ## Workflow
 
-1. **Identify the component.** Find the `type` in the user's config or question (`log_dedup`, `interval`, `otlp`, …). Note that several components were renamed to snake_case in v0.150.0–v0.151.0 with deprecated aliases preserved — see [Recent renames](#recent-renames).
+1. **Identify the component.** Find the `type` in the user's config or question (`log_dedup`, `interval`, `otlp`, …). Note that several components were renamed to snake_case across v0.146.0–v0.154.0 with deprecated aliases preserved — see [Recent renames](#recent-renames).
 2. **Load the component page.** If the component is in the [Component index](#component-index), read `components/<type>/README.md` first — it carries the metadata, description, main use-cases, and a **Details** index. Open the linked detail files (`configuration.md`, `verification.md`, `advanced.md`, `quirks.md`, …) only as the question requires; don't load files you don't need.
 3. **If the component is not indexed**, say so explicitly and fall back to the upstream README under `processor/<name>/`, `receiver/<name>/`, `exporter/<name>/`, `connector/<name>/`, or `extension/<name>/` in [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib). Don't invent config keys from memory — Collector components evolve quickly.
 4. **Apply Collector-wide conventions.** Named instances (`type/name`), stability levels, and pipeline placement rules in [Collector-wide conventions](#collector-wide-conventions) apply to every component.
@@ -40,7 +40,7 @@ Coverage is intentionally selective. If a component is not indexed here, fall ba
 | `memory_limiter` | `components/memory_limiter/README.md` | processor | traces, metrics, logs, profiles | Beta (traces/metrics/logs), Alpha (profiles) | Safety valve against OOM: refuses data with backpressure when Go heap exceeds a soft/hard limit, forcing GC above the hard limit. Belongs first in every pipeline; pairs with `GOMEMLIMIT`. |
 | `load_balancing` | `components/load_balancing/README.md` | exporter | traces, logs, metrics | Beta (traces/logs), Development (metrics) | Distributes telemetry across downstream Collectors via a consistent-hash ring keyed on trace ID / `service.name` (etc.), pinning related records to one backend. The standard way to scale `tail_sampling`/`span_metrics`. Renamed from `loadbalancing` in v0.153.0; alias preserved. |
 | `otlp` (receiver) | `components/otlp/README.md` | receiver | traces, metrics, logs, profiles | Stable (traces/metrics/logs), Alpha (profiles) | The canonical OTLP ingress over gRPC (`4317`) and/or HTTP (`4318`, protobuf + JSON). `protocols:` block, at least one required. Default endpoint is `localhost`, not `0.0.0.0` — must be set explicitly to receive containerized traffic. |
-| `otlp_grpc` (exporter) | `components/otlp_exporter/README.md` | exporter | traces, metrics, logs, profiles | Stable (traces/metrics/logs), Alpha (profiles) | Sends OTLP over gRPC to a downstream endpoint; gzip by default. Built-in `sending_queue.batch` (flush 200ms / 8192 items) replaces the `batch` processor, plus `retry_on_failure`. Renamed from `otlp` in core v1.50.0; alias preserved. |
+| `otlp_grpc` (exporter) | `components/otlp_exporter/README.md` | exporter | traces, metrics, logs, profiles | Stable (traces/metrics/logs), Alpha (profiles) | Sends OTLP over gRPC to a downstream endpoint; gzip by default. Built-in `sending_queue.batch` (flush 200ms / 8192 items) plus `retry_on_failure`; a separate `batch` processor remains supported but may be redundant. Renamed from `otlp` in core v1.50.0; alias preserved. |
 | `file_log` (receiver) | `components/file_log/README.md` | receiver | logs | Beta | Tails log files (glob `include`), turns each line/entry into a log record, and parses it via a stanza `operators` pipeline (json/regex/severity/timestamp/recombine). Fingerprint + offset tracking across rotation; `storage` for durable offsets. `start_at` defaults to `end` (existing files look empty). Renamed from `filelog` in v0.149.0; alias preserved. |
 | `resource_detection` | `components/resource_detection/README.md` | processor | traces, metrics, logs, profiles | Beta (traces/metrics/logs), Development (profiles) | Auto-detects resource attributes from the Collector's environment (host, cloud metadata services, k8s, `OTEL_RESOURCE_ATTRIBUTES`) via an ordered `detectors` list; `override` governs detected-vs-incoming. A failed detector stops startup. Renamed from `resourcedetection` in v0.153.0; alias preserved. |
 | `file_storage` | `components/file_storage/README.md` | extension | — (not pipeline-scoped) | Beta | Persists component state to local disk (bbolt) so it survives a Collector restart: receiver read offsets (`storage:`), exporter persistent send queues (`sending_queue.storage:`), and stateful-processor decision caches. One bbolt file per consumer; `directory` must exist unless `create_directory: true`. Not placed in a pipeline — listed under `service.extensions:` and referenced by other components. |
@@ -86,7 +86,7 @@ Stability now varies per component — and per signal for multi-signal component
 
 ### Recent renames
 
-Many components were renamed to snake_case in v0.150.0–v0.151.0. The legacy names remain as deprecated aliases — old configs keep working but new configs should use the new names. Check the upstream component README for the exact rename version before flagging a config as broken.
+Many components were renamed to snake_case across v0.146.0–v0.154.0. The legacy names remain as deprecated aliases — old configs keep working but new configs should use the new names. Check the upstream component README for the exact rename version before flagging a config as broken.
 
 Examples: `logdedup` → `log_dedup`, `hostmetrics` → `host_metrics`, `spanmetrics` → `span_metrics`, `servicegraph` → `service_graph`, `k8sattributes` → `k8s_attributes`, plus several `_log` and `_check` receivers.
 
@@ -95,7 +95,7 @@ Examples: `logdedup` → `log_dedup`, `hostmetrics` → `host_metrics`, `spanmet
 Two rules of thumb that apply across components:
 
 - `memory_limiter` belongs first in any processor list, before anything that allocates buffers (`log_dedup`, `transform`, `tail_sampling`, …).
-- Batching is now done by the exporter's `sending_queue.batch`, not by a separate `batch` processor. Don't add `batch` to new pipelines.
+- The `otlp_grpc` exporter's `sending_queue.batch` is enabled by default. The separate `batch` processor remains Beta and supported; use it when pipeline-level batching is needed, place it after data-dropping processors, and avoid unintentional double batching when an exporter already batches.
 
 ### Verification harness
 

--- a/skills/otel-collector/components/file_log/README.md
+++ b/skills/otel-collector/components/file_log/README.md
@@ -36,7 +36,7 @@ Avoid when:
 - [`k8s_attributes`](../k8s_attributes/README.md) — enrich tailed pod logs with Kubernetes metadata (namespace, pod, labels).
 - [`transform`](../transform/README.md) — OTTL-based post-processing once records are in the pipeline; the stanza `operators` do parsing at ingest, `transform` does mutation downstream.
 - [`memory_limiter`](../memory_limiter/README.md) — belongs **first** in the logs pipeline fed by this receiver.
-- `file_storage` extension — set `storage:` to it so read offsets survive collector restarts (not yet a page in this skill).
+- [`file_storage`](../file_storage/README.md) extension — set `storage:` to it so read offsets survive collector restarts.
 
 ## Details
 

--- a/skills/otel-collector/components/memory_limiter/configuration.md
+++ b/skills/otel-collector/components/memory_limiter/configuration.md
@@ -71,8 +71,8 @@ Startup fails (config error) when:
 
 ```yaml
 # Good — refuse before anything buffers
-processors: [memory_limiter, batch, tail_sampling]
+processors: [memory_limiter, tail_sampling, batch]
 
-# Bad — data is already batched and processed before refusal
-processors: [batch, tail_sampling, memory_limiter]
+# Bad — memory limiting and sampling happen after batching
+processors: [batch, memory_limiter, tail_sampling]
 ```

--- a/skills/otel-collector/components/otlp_exporter/README.md
+++ b/skills/otel-collector/components/otlp_exporter/README.md
@@ -14,7 +14,7 @@
 
 Sends telemetry in **OTLP over gRPC** to a downstream OTLP endpoint — another Collector's `otlp` receiver, or any OTLP/gRPC backend. It is the standard egress for a pipeline and supports traces, metrics, and logs at **Stable** stability (profiles are **Alpha**). The canonical type is now **`otlp_grpc`**, renamed from `otlp` in core v1.50.0 to disambiguate it from the separate `otlphttp` exporter (OTLP over HTTP). The old name **`otlp` still works** as a deprecated alias — and is what the vast majority of existing configs use — so both `exporters: { otlp: … }` and `exporters: { otlp_grpc: … }` configure this component. Only `endpoint` is required; gRPC requests are **gzip-compressed by default**.
 
-The exporter **batches on its own.** Its `sending_queue` is enabled by default with a `batch` sub-block that flushes at **200ms** or **8192 items**, whichever comes first. Because of this, you do **not** add a separate `batch` processor to a pipeline that ends in this exporter — that legacy processor is deprecated in favor of `sending_queue.batch`. The same `sending_queue` provides the buffering and back-pressure, and `retry_on_failure` provides exponential-backoff retries; together they are the resiliency knobs you tune for throughput vs. latency. See [configuration.md](configuration.md) and [quirks.md](quirks.md).
+The exporter **batches on its own.** Its `sending_queue` is enabled by default with a `batch` sub-block that flushes at **200ms** or **8192 items**, whichever comes first. The separate `batch` processor is still Beta and supported, but may be redundant in a pipeline that ends in this exporter; use it deliberately when batching must happen at pipeline level (for example, before fan-out to several exporters). The same `sending_queue` provides buffering and back-pressure, and `retry_on_failure` provides exponential-backoff retries; together they are the exporter-level resiliency knobs you tune for throughput vs. latency. See [configuration.md](configuration.md) and [quirks.md](quirks.md).
 
 ## Main use-cases
 
@@ -34,11 +34,11 @@ Avoid when:
 - `otlphttp` exporter — the sibling that speaks OTLP over **HTTP** instead of gRPC; pick it when the backend has no gRPC endpoint.
 - [`load_balancing`](../load_balancing/README.md) — wraps a per-backend `otlp` exporter under `protocol.otlp`; its queue/retry/TLS semantics are this exporter's.
 - [`memory_limiter`](../memory_limiter/README.md) — the back-pressure guard at the **front** of the pipeline this exporter terminates.
-- The deprecated **`batch` processor** — superseded by this exporter's `sending_queue.batch`; don't add it to new pipelines.
+- The **`batch` processor** — still supported for pipeline-level batching; often unnecessary when this exporter's default `sending_queue.batch` is sufficient.
 
 ## Details
 
 - [Configuration](configuration.md) — `endpoint`, `compression`, `tls`, `headers`, `timeout`, the `retry_on_failure` block, and the full `sending_queue` (+ `batch`) reference with every default and validation rule.
 - [Verification](verification.md) — a two-collector chain (A exports to B) proving spans sent to A arrive in B's `debug` log.
 - [Advanced use-cases](advanced.md) — tuning the queue for throughput vs. latency, the persistent queue via `storage`, `wait_for_result`, mTLS to a secure backend, named instances, and the relationship to `load_balancing`.
-- [Known quirks](quirks.md) — the `otlp`→`otlp_grpc` rename and `otlphttp` distinction (top item), "don't add a `batch` processor", default gzip, `insecure: true` for plaintext, `wait_for_result` vs. persistent `storage`, `min_size` ≤ `queue_size`, drop-after-`max_elapsed_time`, and per-signal stability.
+- [Known quirks](quirks.md) — the `otlp`→`otlp_grpc` rename and `otlphttp` distinction (top item), exporter batching vs. the `batch` processor, default gzip, `insecure: true` for plaintext, `wait_for_result` vs. persistent `storage`, `min_size` ≤ `queue_size`, drop-after-`max_elapsed_time`, and per-signal stability.

--- a/skills/otel-collector/components/otlp_exporter/configuration.md
+++ b/skills/otel-collector/components/otlp_exporter/configuration.md
@@ -70,7 +70,7 @@ The buffer between the pipeline and the gRPC sender. **Enabled by default**, and
 
 ### `sending_queue.batch`
 
-Present by default — flushes at `flush_timeout` or when `min_size` is reached, whichever comes first. **This is why you don't add a separate `batch` processor.**
+Present by default — flushes at `flush_timeout` or when `min_size` is reached, whichever comes first. This often makes a separate `batch` processor unnecessary, but that processor remains supported for pipeline-level batching.
 
 | Key | Type | Default | Meaning |
 |-----|------|---------|---------|

--- a/skills/otel-collector/components/otlp_exporter/quirks.md
+++ b/skills/otel-collector/components/otlp_exporter/quirks.md
@@ -4,9 +4,9 @@
 
 The canonical type was renamed from `otlp` to **`otlp_grpc`** in core **v1.50.0** (≈ contrib v0.144.0). The old name **`otlp` still works** as a deprecated alias (it emits a deprecation warning) and is what most existing configs use, so both `exporters: { otlp: … }` and `exporters: { otlp_grpc: … }` configure this same gRPC exporter. The rename disambiguates it from the **`otlphttp`** exporter, which is a *different* component speaking OTLP over **HTTP**. If your backend has no gRPC endpoint, you want `otlphttp`, not this one — they are not interchangeable.
 
-## Don't add a `batch` processor — batching is built in
+## Exporter batching vs. the `batch` processor
 
-This exporter's `sending_queue` is enabled by default with a `batch` sub-block that flushes at **200ms** or **8192 items**. So a pipeline ending in this exporter **already batches**. Adding the legacy `batch` processor (now deprecated) double-batches and just adds latency. Tune `sending_queue.batch` instead. This matches the skill-wide pipeline-placement rule.
+This exporter's `sending_queue` is enabled by default with a `batch` sub-block that flushes at **200ms** or **8192 items**, so a pipeline ending in this exporter already batches at the exporter boundary. The separate `batch` processor is still Beta and supported; use it when batching must happen at pipeline level (for example, once before fan-out to several exporters), and place it after processors that may drop data. If both layers are enabled, tune them deliberately because unintentional double batching can add latency.
 
 ## gzip compression is on by default
 

--- a/skills/otel-collector/components/resource/configuration.md
+++ b/skills/otel-collector/components/resource/configuration.md
@@ -73,7 +73,7 @@ processors:
 
 ## No include / exclude matching
 
-Unlike the [`attributes`](../attributes/README.md) processor, `resource` has **no `include`/`exclude` block**. There is no way to scope its actions to a subset of resources by service, attribute, or any other matcher — every resource that passes through the pipeline is processed. To apply resource-attribute edits only to matching telemetry, use the `attributes` processor (its match block supports `resources:` matchers) or `transform` (OTTL conditions).
+Unlike the [`attributes`](../attributes/README.md) processor, `resource` has **no `include`/`exclude` block**. There is no way to scope its actions to a subset of resources by service, attribute, or any other matcher — every resource that passes through the pipeline is processed. To apply resource-attribute edits only to matching telemetry, use `transform` with an OTTL condition. The `attributes` processor can match on resource attributes, but its actions still edit only span/log/datapoint attributes, not the resource.
 
 ## Context values
 

--- a/skills/otel-collector/components/resource/quirks.md
+++ b/skills/otel-collector/components/resource/quirks.md
@@ -16,7 +16,7 @@ For span/log/datapoint attributes use the [`attributes`](../attributes/README.md
 
 ## No include / exclude matching
 
-`resource` has **no `include`/`exclude` block**. Every resource flowing through the pipeline is processed — there's no way to scope its actions to a subset of resources. If you need conditional application (e.g. only rename a key for one service), use the `attributes` processor (its match block supports `resources:` matchers) or `transform` with an OTTL condition. Attempting to add an `include:` key to a `resource` config is a configuration error.
+`resource` has **no `include`/`exclude` block**. Every resource flowing through the pipeline is processed — there's no way to scope its actions to a subset of resources. If you need conditional application (e.g. only rename a key for one service), use `transform` with an OTTL condition. The `attributes` processor can match on resource attributes, but it cannot edit them; its actions still target span/log/datapoint attributes. Attempting to add an `include:` key to a `resource` config is a configuration error.
 
 ## Changes are wholesale across the batch
 

--- a/skills/otel-collector/components/tail_sampling/advanced.md
+++ b/skills/otel-collector/components/tail_sampling/advanced.md
@@ -85,7 +85,7 @@ A single tail-sampling instance only works while every span of a trace lands on 
 ```yaml
 # Layer 1 — routing collectors (any number of replicas)
 exporters:
-  loadbalancing:
+  load_balancing:
     routing_key: traceID
     protocol:
       otlp:
@@ -100,7 +100,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [loadbalancing]
+      exporters: [load_balancing]
 
 # Layer 2 — tail-sampling collectors (behind the DNS name above)
 processors:


### PR DESCRIPTION
## Summary

- correct released batch-processor support and processor ordering guidance
- update resource editing and renamed load-balancing references
- refresh five drifted component areas while preserving the existing component scope

## Verification

- audited all 22 indexed component directories at core v1.62.0 / contrib v0.156.0
- verified 33 referenced upstream paths
- checked relative Markdown links and skill frontmatter
- `git diff --check -- skills/otel-collector`

`skills-ref` is unavailable. Empirical verification dates were not restamped because the full Docker recipe suite was not rerun.

## Deliberately excluded

- all post-v0.156.0/v1.62.0 upstream `main` changes
- new components or other scope expansion

Agent-authored refresh; human-owned PR.
