### PR TITLE
docs(otel-ottl): refresh released language guidance

### DIFF
--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -142,6 +142,14 @@ processors:
     log_conditions:
       - 'log.severity_number < SEVERITY_NUMBER_WARN'
 
+  tail_sampling:
+    policies:
+      - name: errors
+        type: ottl_condition
+        ottl_condition:
+          span:
+            - 'span.status.code == STATUS_CODE_ERROR'
+
 connectors:
   routing:
     error_mode: ignore
@@ -151,14 +159,6 @@ connectors:
         pipelines: [traces/prod]
       - condition: 'span.status.code == STATUS_CODE_ERROR'
         pipelines: [traces/errors]
-
-  tail_sampling:
-    policies:
-      - name: errors
-        type: ottl_condition
-        ottl_condition:
-          span:
-            - 'span.status.code == STATUS_CODE_ERROR'
 ```
 
 ## Common gotchas

--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -35,7 +35,7 @@ OTTL paths are scoped by signal. Higher levels are reachable from lower ones (e.
 
 | Context | Common paths |
 |---------|--------------|
-| Resource | `resource.attributes["service.name"]`, `resource.metadata["X-Tenant-ID"]` |
+| Resource | `resource.attributes["service.name"]`, `resource.schema_url` |
 | Scope | `scope.name`, `scope.version`, `scope.attributes["…"]` |
 | Span | `span.name`, `span.kind`, `span.status.code`, `span.attributes["…"]`, `span.flags` |
 | Span Event | `spanevent.name`, `spanevent.attributes["…"]`, `spanevent.event_index` |
@@ -68,12 +68,12 @@ Split(s, ",")
 ToLowerCase(s) / ToUpperCase(s)
 IsMatch(s, "pattern")                 # bool
 String(v) / Int(v) / Double(v) / Bool(v)
-ParseJSON(s) / ParseKeyValue(s, "&", "=")
+ParseJSON(s) / ParseKeyValue(s, "=", "&")
 URL(s)                                # parse URL components (v0.127+)
 ExtractPatterns(s, "(?P<name>…)")     # named captures → map
 ExtractGrokPatterns(s, "%{IP:client}") # Grok (v0.130+)
 IsInCIDR(ip, ["10.0.0.0/8"])          # CIDR membership (v0.146+)
-SHA256(v) / Murmur3Hash(v) / XXH3(v)  # hashing
+SHA256(s) / Murmur3Hash(s) / XXH3(s)  # hexadecimal string hashes
 UUID() / UUIDv7()
 ```
 
@@ -210,7 +210,7 @@ In routing connector configs, use `otelcol.client.metadata["key"][0]` for HTTP/c
 
 ### `Bool` converter coercion is loose
 
-`Bool("true")`, `Bool("1")`, `Bool(1)` all return `true`; `Bool("false")`, `Bool("0")`, `Bool(0)`, `Bool(0.0)` return `false`. Anything else errors. Don't assume Python-like truthiness for arbitrary strings.
+`Bool` preserves booleans, treats any non-zero integer or double as `true`, and uses Go boolean parsing for strings (`1`, `t`, `T`, `TRUE`, `true`, `True`, and their false equivalents). Invalid strings and unsupported types error; `nil` returns `nil`. Don't assume Python-like truthiness for arbitrary strings.
 
 ### Verify before publishing
 
@@ -241,8 +241,8 @@ Recently added (still useful to know which release introduced them when supporti
 | Cache paths require context prefix; `spanevent` rename | v0.120 (breaking) |
 | `delete_index` editor | v0.145 |
 | `span.flags` path | v0.145 |
-| `<context>.metadata` for client request metadata | v0.147 |
 | `truncate_all` UTF-8 safe default (`utf8_safe` parameter) | v0.148 (behavior change) |
+| `Substring` optional `utf8_safe` parameter (default `false`) | v0.156 |
 | `SpanID` / `TraceID` accept hex strings | v0.142 |
 | `flatten` `resolveConflicts` parameter | v0.139 |
 | `Base64Encode` | v0.147 |

--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -86,6 +86,11 @@ set(log.attributes["selected"], ParseJSON(log.body.string)[log.attributes["field
 
 Full catalog with signatures in `references/functions.md`.
 
+The `transform` processor also provides 17 signal-specific functions that are not
+part of the common `pkg/ottl/ottlfuncs` catalog. See the
+[transform-only function table](references/functions.md#transform-processor-only-functions)
+for their contexts, signatures, and released-source links.
+
 ## Common patterns
 
 ```ottl

--- a/skills/otel-ottl/references/contexts.md
+++ b/skills/otel-ottl/references/contexts.md
@@ -21,9 +21,9 @@ OTelCol (Collector request/client metadata; read-only)
 resource.attributes                    # map
 resource.attributes["service.name"]
 resource.dropped_attributes_count
+resource.schema_url
 resource.cache                         # transformation-scope scratchpad
 resource.cache["key"]
-resource.metadata["key"]               # client request metadata (v0.147+)
 ```
 
 ```ottl
@@ -42,6 +42,7 @@ scope.version
 scope.attributes
 scope.attributes["key"]
 scope.dropped_attributes_count
+scope.schema_url
 scope.cache
 scope.cache["key"]
 ```
@@ -97,7 +98,6 @@ span.links                       # collection
 span.dropped_attributes_count
 span.dropped_events_count
 span.dropped_links_count
-span.metadata["key"]             # client request metadata (v0.147+)
 span.cache["key"]                # transformation cache
 ```
 
@@ -158,12 +158,12 @@ metric.type                          # int64 (use METRIC_DATA_TYPE_* enums)
 metric.aggregation_temporality       # int64
 metric.is_monotonic                  # bool
 metric.data_points                   # collection
-metric.metadata
+metric.metadata                       # metadata carried by the metric
 ```
 
 ```ottl
 # Normalize metric names to safe characters
-set(metric.name, replace_pattern(metric.name, "[^a-zA-Z0-9_]", "_"))
+replace_pattern(metric.name, "[^a-zA-Z0-9_]", "_")
 
 # Normalize legacy units
 set(metric.unit, "s") where metric.unit == "seconds"
@@ -236,7 +236,6 @@ log.body[0]                          # if body is a list
 log.attributes
 log.attributes["key"]
 log.dropped_attributes_count
-log.metadata["key"]                  # client request metadata (v0.147+)
 log.flags
 log.trace_id / log.trace_id.string
 log.span_id  / log.span_id.string
@@ -299,19 +298,6 @@ profilesample.timestamps              # []time.Time
 profilesample.attribute_indices
 cache["key"]
 ```
-
-## Client request metadata (v0.147+)
-
-All contexts expose a `metadata` map for reading metadata attached to the inbound request (gRPC metadata, HTTP headers). It is *not* part of the telemetry payload — values come from the receiver. Keys are case-sensitive and the available set depends on the receiver and transport.
-
-```ottl
-span.metadata["X-Tenant-ID"]
-log.metadata["X-Scope-OrgID"]
-resource.metadata["Authorization"]
-datapoint.metadata["X-Custom-Header"]
-```
-
-Common uses: tenant routing, request-level enrichment, conditional drop based on caller identity.
 
 ## OTelCol context (v0.147+, enabled by default feature gate)
 

--- a/skills/otel-ottl/references/functions.md
+++ b/skills/otel-ottl/references/functions.md
@@ -132,10 +132,11 @@ set(attributes["db.statement"], Substring(attributes["db.statement"], 0, 1024))
 
 ### `Concat`, `Split`, `Substring`
 ```ottl
-Concat(["user", user_id, "action"], "-")     # "user-123-action"
-Split(path, "/")                              # ["", "api", "v1", "users"]
-Split(path, "/")[1]                           # "api"
+Concat(["user", span.attributes["user.id"], "action"], "-")
+Split(span.name, "/")                         # ["", "api", "v1", "users"]
+Split(span.name, "/")[1]                      # "api"
 Substring(span.span_id.string, 0, 8)          # first 8 chars
+Substring(target, start, length, utf8_safe?)  # utf8_safe defaults to false; added v0.156
 ```
 
 ### Case
@@ -159,15 +160,9 @@ HasSuffix(s, suffix)         # bool
 where HasPrefix(span.name, "internal.")
 ```
 
-### `Replace` (literal, non-regex)
-```ottl
-Replace(target, old, new, count?)
-Replace(log.body.string, "ERROR", "ERR", 1)
-```
-
 ### `Format`
 ```ottl
-Format("user=%s req=%d", [user, count])      # printf-style
+Format("user=%s req=%d", [span.attributes["user.id"], span.attributes["request.count"]])
 ```
 
 ---
@@ -183,7 +178,7 @@ ParseInt(s, base)        # ParseInt("ff", 16) -> 255
 Hex(bytes)               # bytes -> hex string
 ```
 
-**`Bool` coercion is loose, not Pythonic.** `Bool("true")`, `Bool("1")`, `Bool(1)` → `true`; `Bool("false")`, `Bool("0")`, `Bool(0)`, `Bool(0.0)` → `false`. Other values error. Don't assume `Bool("yes")` or `Bool("anything-non-empty")` returns true.
+**`Bool` coercion is loose, not Pythonic.** Booleans pass through; any non-zero integer or double is `true`; zero is `false`; strings use Go boolean parsing (`1`, `t`, `T`, `TRUE`, `true`, `True`, and false equivalents). Invalid strings and unsupported types error, while `nil` returns `nil`.
 
 ---
 
@@ -233,10 +228,10 @@ Built-in pattern library covers HTTP, syslog, paths, IPs, dates, etc. Cheaper th
 ```ottl
 ParseJSON(s)                                  # JSON string -> map | list
 ParseCSV(s, headers, delimiter?, headerDelim?, mode?)
-ParseKeyValue(s, pair_delim?, kv_delim?)      # ParseKeyValue("a=1&b=2", "&", "=")
+ParseKeyValue(s, kv_delim?, pair_delim?)      # ParseKeyValue("a=1&b=2", "=", "&")
 ParseXML(s) / ParseSimplifiedXML(s)
 ParseSeverity(value, mapping)                 # map values -> SEVERITY_NUMBER_*
-URL(s)                                        # v0.127+; { scheme, domain, port, path, query, fragment, … }
+URL(s)                                        # v0.127+; { url.scheme, url.domain, url.port, url.path, … }
 UserAgent(s)                                  # v0.134+; { user_agent.name, .version, os.name, os.version, … }
 ```
 
@@ -246,7 +241,12 @@ set(log.attributes, ParseJSON(log.body.string))
     where IsString(log.body) and IsMatch(log.body.string, "^\\s*\\{.*\\}\\s*$")
 
 # URL parsing
-set(span.attributes["http.host"], URL(span.attributes["http.url"])["domain"])
+set(span.attributes["http.host"], URL(span.attributes["http.url"])["url.domain"])
+```
+
+### Fallback values
+```ottl
+Coalesce([span.attributes["user.id"], resource.attributes["user.id"], "fallback"])
 ```
 
 ---
@@ -300,14 +300,14 @@ Hours(d) / Minutes(d) / Seconds(d) / Milliseconds(d) / Microseconds(d) / Nanosec
 ## Hashing & encoding
 
 ```ottl
-SHA256(v) / SHA512(v)
-SHA1(v) / MD5(v)                              # cryptographically weak; avoid for security
-FNV(v)                                        # int64
-Murmur3Hash(v) / Murmur3Hash128(v)            # v0.129+
-XXH3(v) / XXH128(v)                           # v0.135+; very fast
+SHA256(s) / SHA512(s)
+SHA1(s) / MD5(s)                              # cryptographically weak; avoid for security
+FNV(s)                                        # int64
+Murmur3Hash(s) / Murmur3Hash128(s)            # v0.129+; hexadecimal string
+XXH3(s) / XXH128(s)                           # v0.135+; hexadecimal string
 Decode(value, encoding)                       # v0.141+; "base64", "base64-raw", "base64-url", "base64-raw-url", IANA charsets
-Base64Encode(v, variant?)                     # v0.147+; default base64
-Base64Decode(v)                               # DEPRECATED — use Decode(v, "base64")
+Base64Encode(s, variant?)                     # v0.147+; default base64
+Base64Decode(s)                               # DEPRECATED — use Decode(s, "base64")
 Hex(bytes)
 ```
 
@@ -382,6 +382,5 @@ Then read from `log.cache["parsed"]` in subsequent statements without paying the
 ### Hash-based sampling
 ```ottl
 set(span.attributes["sampled"], true)
-    where FNV(span.trace_id.string) % 100 < 10        # 10%
-# Murmur3Hash or XXH3 work too and are faster on long inputs.
+    where IsMatch(XXH3(span.trace_id.string), "^(0[0-9a-f]|1[0-9])")  # ~10.2%
 ```

--- a/skills/otel-ottl/references/functions.md
+++ b/skills/otel-ottl/references/functions.md
@@ -136,8 +136,10 @@ Concat(["user", span.attributes["user.id"], "action"], "-")
 Split(span.name, "/")                         # ["", "api", "v1", "users"]
 Split(span.name, "/")[1]                      # "api"
 Substring(span.span_id.string, 0, 8)          # first 8 chars
-Substring(target, start, length, utf8_safe?)  # utf8_safe defaults to false; added v0.156
+Substring(target, start, length, utf8_safe?)  # byte offsets; utf8_safe defaults false; added v0.156
 ```
+
+With `utf8_safe=true`, a start inside a multi-byte character advances to the next UTF-8 boundary and an end inside one backs up to the previous boundary. The result stays valid UTF-8 but can be shorter than `length` bytes.
 
 ### Case
 ```ottl

--- a/skills/otel-ottl/references/functions.md
+++ b/skills/otel-ottl/references/functions.md
@@ -132,7 +132,7 @@ set(attributes["db.statement"], Substring(attributes["db.statement"], 0, 1024))
 
 ### `Concat`, `Split`, `Substring`
 ```ottl
-Concat(["user", span.attributes["user.id"], "action"], "-")
+Concat(["user", span.attributes["user.id"], "action"], "-")  # "user-123-action" when user.id == "123"
 Split(span.name, "/")                         # ["", "api", "v1", "users"]
 Split(span.name, "/")[1]                      # "api"
 Substring(span.span_id.string, 0, 8)          # first 8 chars

--- a/skills/otel-ottl/references/functions.md
+++ b/skills/otel-ottl/references/functions.md
@@ -2,6 +2,42 @@
 
 Editor and converter reference for collector-contrib **v0.156.0**. Editors mutate telemetry; converters return values for use in expressions. See the upstream `pkg/ottl/ottlfuncs/README.md` for the authoritative source.
 
+## Transform-processor-only functions
+
+The `transform` processor adds the following functions to the common OTTL
+catalog. They are not generally available in other OTTL-consuming components.
+The contexts and signatures below are pinned to the released
+[v0.156.0 transform processor source](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#supported-functions).
+
+| Context | Signature | Behavior and limits |
+|---------|-----------|---------------------|
+| `metric` | `convert_sum_to_gauge()` | Sum to Gauge; other metric types are unchanged. The conversion can violate Gauge semantics. |
+| `metric` | `convert_gauge_to_sum(aggregation_temporality, is_monotonic)` | Gauge to Sum; temporality is `"delta"` or `"cumulative"`; other metric types are unchanged. The caller owns the resulting Sum semantics. |
+| `metric` | `extract_count_metric(is_monotonic, suffix?)` | Creates a Sum from Histogram, ExponentialHistogram, or Summary counts; default suffix `_count`; only creates output when datapoints exist. |
+| `metric` | `extract_percentile_metric(percentile, suffix?)` | Creates a Gauge from Histogram or ExponentialHistogram buckets; `0 < percentile < 100`; default suffix `_p{percentile}`; the result is an interpolated estimate. |
+| `metric` | `extract_sum_metric(is_monotonic, suffix?)` | Creates a Sum from Histogram, ExponentialHistogram, or Summary sums; default suffix `_sum`; skips datapoints whose sum is absent. |
+| `datapoint` | `convert_summary_count_val_to_sum(aggregation_temporality, is_monotonic, suffix?)` | Creates a Sum from a Summary count; temporality is `"delta"` or `"cumulative"`; default suffix `_count`. |
+| `metric` | `convert_summary_quantile_val_to_gauge(attribute_key?, suffix?)` | Creates one Gauge datapoint per Summary quantile; defaults are attribute `quantile` and suffix `.quantiles`. |
+| `datapoint` | `convert_summary_sum_val_to_sum(aggregation_temporality, is_monotonic, suffix?)` | Creates a Sum from a Summary sum; temporality is `"delta"` or `"cumulative"`; default suffix `_sum`. |
+| `metric` | `copy_metric(name?, description?, unit?)` | Appends a full copy, optionally overriding metadata. The copy runs through later metric statements, so guard it with a condition that excludes the copy. |
+| `metric` | `scale_metric(factor, unit?)` | Scales Gauge, Sum, Histogram, and Summary values; optionally changes the unit. |
+| `metric` | `aggregate_on_attributes(function, attributes?)` | Aggregates Sum, Gauge, Histogram, or ExponentialHistogram datapoints. Functions are `sum`, `max`, `min`, `mean`, `median`, or `count`; histogram types support only `sum`. Omitted attributes retain all keys, while `[]` drops all keys. |
+| `metric` | `convert_exponential_histogram_to_histogram(distribution, explicit_bounds)` | Converts ExponentialHistogram to explicit Histogram using `upper`, `midpoint`, `uniform`, or `random`; bounds must be non-empty. This lossy conversion is not specified by OpenTelemetry. |
+| `metric` | `aggregate_on_attribute_value(function, attribute, values, new_value)` | Aggregates selected attribute values for Sum, Gauge, Histogram, or ExponentialHistogram datapoints; histogram types support only `sum`. |
+| `datapoint` | `merge_histogram_buckets(target_value, method?)` | Explicit Histograms only. Default `remove_explicit_bound` removes a matching bound; `limit_buckets` requires a positive integer target and reduces resolution. Other metric types are unchanged. |
+| `log` | `ParseCLF(target, format?)` | Parses CLF (`"clf"`, default) or NCSA combined (`"combined"`) text into a map; malformed or empty input errors. |
+| `log` | `ParseLEEF(target)` | Parses LEEF 1.0/2.0 into a map; malformed or empty input errors; attribute values remain strings. |
+| `span` | `set_semconv_span_name(semconv_version, original_span_name_attribute?)` | Derives low-cardinality HTTP, RPC, messaging, or database span names. v0.156 accepts semantic-convention versions 1.37.0 through 1.40.0; unrelated spans are unchanged. |
+
+For full behavior, examples, and edge cases, follow the tag-pinned
+[metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#metrics-only-functions),
+[logs](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#logs-only-functions), and
+[traces](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#traces-only-functions)
+sections. The registrations that constrain the contexts are also tag-pinned:
+[metric/datapoint](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/internal/metrics/functions.go),
+[log](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/internal/logs/functions.go), and
+[span](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/internal/traces/functions.go).
+
 ## Editors (data manipulation)
 
 Editors are lowercase. Every OTTL statement contains exactly one.

--- a/skills/otel-ottl/references/quick-reference.md
+++ b/skills/otel-ottl/references/quick-reference.md
@@ -47,10 +47,10 @@ set(log.attributes, ParseJSON(log.body.string))
 
 # Query string -> map
 set(span.attributes["params"],
-    ParseKeyValue(span.attributes["http.query"], "&", "="))
+    ParseKeyValue(span.attributes["http.query"], "=", "&"))
 
 # URL parts (v0.127+)
-set(span.attributes["http.host"], URL(span.attributes["http.url"])["domain"])
+set(span.attributes["http.host"], URL(span.attributes["http.url"])["url.domain"])
 
 # User agent (v0.134+)
 set(span.attributes["client.os"],
@@ -100,9 +100,9 @@ where IsInCIDR(span.attributes["client.address"],
 ### Sampling
 
 ```ottl
-# Hash-based 10% — XXH3 is faster than FNV on long inputs
+# Hash-based ~10.2%; 26 of 256 possible first-byte values match
 set(span.attributes["sampled"], true)
-    where XXH3(span.trace_id.string) % 100 < 10
+    where IsMatch(XXH3(span.trace_id.string), "^(0[0-9a-f]|1[0-9])")
 
 # Always-sample errors
 set(span.attributes["sampled"], true)
@@ -276,9 +276,9 @@ service:
 set(span.attributes["ottl.processed"], true)
 set(span.attributes["ottl.timestamp"], Now())
 
-# 0.1% sampled debug snapshot
+# ~0.1% sampled debug snapshot (4 of 4096 three-hex-digit prefixes)
 set(span.attributes["debug.original_name"], span.name)
-    where XXH3(span.trace_id.string) % 1000 == 0
+    where IsMatch(XXH3(span.trace_id.string), "^00[0-3]")
 ```
 
 ### Validate before transforming
@@ -336,7 +336,7 @@ where span.kind == SPAN_KIND_SERVER and IsMatch(span.name, "expensive.*")
 | Backreferences appear literal | YAML ate the `$` | Use `$${1}` in YAML for OTTL `${1}` |
 | `attributes` processor doesn't touch resource | Wrong processor | Use `resource` processor or `transform` with `context: resource` |
 | `cache["x"]` errors in span context | Cache requires a context prefix since v0.120 | Write `span.cache["x"]` |
-| `Bool("yes")` errors | `Bool` only accepts true/false/1/0 inputs | Use `IsMatch` with an explicit pattern, or check with `where` |
+| `Bool("yes")` errors | String inputs use Go boolean parsing; arbitrary non-empty strings are not truthy | Use `IsMatch` with an explicit pattern, or check with `where` |
 | `Base64Decode` deprecation warning | v0.141+ moved to generic decoder | Use `Decode(value, "base64")` |
 
 ### Checklist before shipping


### PR DESCRIPTION
## Summary

- correct released OTTL context paths and function signatures
- remove nonexistent converters and invalid arithmetic/editor examples
- add released `Coalesce` and schema URL paths within the existing scope
- clarify the v0.156 `Substring` UTF-8 boundary behavior confirmed against the released Collector
- catalog all 17 released transform-processor-only functions with their actual metric,
  datapoint, log, and span contexts

## Verification

- source-checked OpenTelemetry Collector Contrib v0.156.0 and every referenced upstream path
- `/private/tmp/skills-ref-venv/bin/skills-ref validate skills/otel-ottl`
- `python3 .github/scripts/check-skill-registration.py`
- `git diff --check`
- `otel/opentelemetry-collector-contrib:0.156.0 validate` for the complete changed-example transform configuration
- end-to-end traces, metrics, and logs through `otel/opentelemetry-collector-contrib:0.156.0`, generated by `telemetrygen:v0.156.0`, with assertions covering schema URLs, `ParseKeyValue`, `URL`, `Coalesce`, `Substring`, `Bool`, `Format`, hashes, regex sampling, and metric-name replacement
- end-to-end routing-connector test proving `otelcol.grpc.metadata["x-tenant"][0]` routes a real OTLP/gRPC request carrying `x-tenant: acme`, with a no-header control routed to the default pipeline
- negative validation proving `Bool("yes")` is rejected with `strconv.ParseBool: parsing "yes": invalid syntax`
- exact `otel/opentelemetry-collector-contrib:0.156.0 validate` coverage proving all
  17 transform-only functions parse in their documented contexts
- end-to-end OTLP runtime coverage for all 17 functions: 14 metric-family functions
  produced the expected 16 metrics / 17 datapoints, `ParseCLF` and `ParseLEEF`
  produced the expected maps, and `set_semconv_span_name` rewrote the span while
  preserving its original name

Released images used:

- Collector v0.156.0: `sha256:125bdbeb7590cc1952c5b3430ecf14063568980c2c93d5b38676cc0446ed8108`
- telemetrygen v0.156.0: `sha256:0d2936509ffd2a68b3fe6f4f299a3ec87653dc37676df4313e628a8413e1d2f2`

## Deliberately excluded

- post-v0.156.0 functions and feature-gate promotions

Agent-authored refresh; human-owned PR.
