### PR TITLE
fix(otel-telemetrygen): use v-prefixed GHCR tags

### DIFF
--- a/skills/otel-telemetrygen/SKILL.md
+++ b/skills/otel-telemetrygen/SKILL.md
@@ -182,7 +182,7 @@ telemetrygen traces --mtls \
 ```bash
 # Docker with host networking
 docker run --rm --network host \
-  ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:0.156.0 \
+  ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.156.0 \
   traces --otlp-insecure --traces 100
 
 # Kubernetes Job
@@ -274,5 +274,5 @@ These are the mistakes that cause real problems -- review before running against
 go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@v0.156.0
 
 # Container
-docker pull ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:0.156.0
+docker pull ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.156.0
 ```

--- a/skills/otel-telemetrygen/references/flags.md
+++ b/skills/otel-telemetrygen/references/flags.md
@@ -144,7 +144,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:0.156.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.156.0
         args:
         - traces
         - --otlp-insecure


### PR DESCRIPTION
## Summary

- add the required `v` prefix to every versioned GHCR telemetrygen image reference
- preserve the unprefixed Docker Hub `otel/opentelemetry-collector-contrib` tag
- fix the Docker, Kubernetes Job, and installation examples

Closes [E-2456](https://linear.app/ollygarden/issue/E-2456/fix-telemetrygen-container-image-tag-in-otel-telemetrygen-skill).

## Agent involvement

Implemented by an AI coding agent. Human review is still required before merge.

## Harness results

Not run: this is a narrowly scoped image-tag correction rather than a substantive skill behavior change.

## Validation

- `rg` repository-wide check confirms every versioned GHCR telemetrygen tag uses the `v` prefix
- `rg` confirms the Docker Hub collector-contrib tag remains unprefixed
- `git diff --check`
- `skills-ref validate skills/otel-telemetrygen` not run because `skills-ref` is not installed in the environment

## Checklist

- [x] I read and agree to follow the [Code of Conduct](https://github.com/ollygarden/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] `skills-ref validate skills/otel-telemetrygen` passes (validator unavailable locally)
- [ ] `python .github/scripts/check-skill-registration.py` passes (not applicable; no registration changes)
- [ ] Skill registered in all three places (not applicable; no skill added or renamed)
- [x] Content is vendor-neutral, non-opinionated, DRY, and token-efficient
- [ ] Harness comparison results included above (not applicable; targeted typo-level correction)
- [x] Commit messages follow Conventional Commits
- [x] I have signed (or will sign via the CLA bot on this PR) the [OllyGarden CLA](https://github.com/ollygarden/.github/blob/main/CLA.md)
