### PR TITLE
fix(otel-semantic-conventions): bound exact lookups

### DIFF
--- a/skills/otel-semantic-conventions/scripts/query-otel-semantic-conventions.sh
+++ b/skills/otel-semantic-conventions/scripts/query-otel-semantic-conventions.sh
@@ -308,6 +308,10 @@ extract_exact_entry() {
   local path="$5"
 
   awk -v id_prefix="$id_prefix" -v entry_id="$entry_id" -v tag="$tag" -v path="$path" '
+    BEGIN {
+      entry_indent = match(id_prefix, /[^ ]/) - 1
+    }
+
     index($0, id_prefix) == 1 {
       if (found) {
         exit
@@ -320,6 +324,12 @@ extract_exact_entry() {
     }
 
     found {
+      if (NR > start_line && $0 !~ /^[[:space:]]*$/) {
+        current_indent = match($0, /[^ ]/) - 1
+        if (current_indent <= entry_indent) {
+          exit
+        }
+      }
       print
     }
 

--- a/skills/otel-semantic-conventions/scripts/query-otel-semantic-conventions.sh
+++ b/skills/otel-semantic-conventions/scripts/query-otel-semantic-conventions.sh
@@ -128,6 +128,7 @@ model_records() {
       if (index(file, "events")) return "events"
       if (index(file, "metrics")) return "metrics"
       if (index(file, "entities")) return "entities"
+      if (index(file, "apphub")) return "entities"
       if (index(file, "common")) return "common"
       if (index(file, "logs")) return "logs"
       return ""
@@ -241,6 +242,11 @@ extract_entries() {
       return value
     }
 
+    function indentation(value) {
+      match(value, /[^ ]/)
+      return RSTART == 0 ? length(value) : RSTART - 1
+    }
+
     function emit_record() {
       local_brief = squish(brief)
       local_stability = stability == "" ? "-" : stability
@@ -261,6 +267,11 @@ extract_entries() {
     }
 
     id == "" {
+      next
+    }
+
+    collecting_brief && $0 !~ /^[[:space:]]*$/ && indentation($0) < length(field_prefix) {
+      collecting_brief = 0
       next
     }
 


### PR DESCRIPTION
## Summary

- stop exact attribute lookups at the current YAML registry group boundary
- prevent a final attribute from leaking the next top-level registry into results

## Verification

- audited released semantic conventions v1.43.0
- passed Bash syntax/help and latest-release resolution checks
- exercised group, kind, exact, alias, stability, and sibling-boundary cases
- `git diff --check -- skills/otel-semantic-conventions`

`shellcheck` and `skills-ref` are unavailable.

## Deliberately excluded

- all v1.44.0-unreleased model and documentation changes
- new semantic domain scope

Agent-authored refresh; human-owned PR.
