### PR TITLE
docs(otel-telemetrygen): correct released CLI guidance

### DIFF
--- a/skills/otel-telemetrygen/SKILL.md
+++ b/skills/otel-telemetrygen/SKILL.md
@@ -242,7 +242,13 @@ docker run -d --rm --name otelcol-verify \
   --config=/etc/otelcol-contrib/config.yaml
 
 # wait for the collector to be ready, then send the telemetry shape under test
-until ss -ltn | grep -q ':4317 '; do sleep 0.25; done
+until docker logs otelcol-verify 2>&1 | grep -q 'Everything is ready'; do
+  if [ "$(docker inspect -f '{{.State.Running}}' otelcol-verify 2>/dev/null)" != true ]; then
+    echo 'collector exited before becoming ready' >&2
+    exit 1
+  fi
+  sleep 0.25
+done
 telemetrygen logs --otlp-insecure --logs 1 --severity-text Info
 
 # stop the collector to flush, then inspect

--- a/skills/otel-telemetrygen/SKILL.md
+++ b/skills/otel-telemetrygen/SKILL.md
@@ -20,7 +20,7 @@ Every command needs at least a subcommand and typically `--otlp-insecure` for lo
 1. **Pick the signal** -- `traces`, `metrics`, or `logs`.
 2. **Set the endpoint** -- defaults to `localhost:4317` (gRPC) or `localhost:4318` (HTTP). Use `--otlp-endpoint` to override.
 3. **Choose count or duration** -- use `--traces`/`--metrics`/`--logs` for a fixed count per worker, or `--duration` for time-based generation. Duration overrides count when both are set.
-4. **Control throughput** -- total rate = `--workers` x `--rate`. `--rate` defaults to `1` item/sec/worker; set `--rate 0` for unbounded max-speed generation (dangerous against real backends).
+4. **Control throughput** -- for metrics and logs, total record rate = `--workers` x `--rate`. For traces, `--rate` applies to every span, so approximate trace rate = `workers x rate / (1 + max(1, child-spans))`. `--rate` defaults to `1` metric/span/log per second per worker; set `--rate 0` for unbounded max-speed generation (dangerous against real backends).
 5. **Add identity and attributes** -- `--service` sets the service name; `--otlp-attributes` adds resource-level attributes; `--telemetry-attributes` adds span/metric/log-level attributes.
 6. **Review the anti-patterns** below before running against shared or production infrastructure.
 
@@ -34,7 +34,7 @@ See `references/flags.md` for the full flag reference. Key flags:
 | `--otlp-http` | `false` | Switch to HTTP transport |
 | `--otlp-insecure` | `false` | Disable TLS |
 | `--workers` | `1` | Concurrent goroutines |
-| `--rate` | `1` | Items/sec/worker (`0` = unlimited) |
+| `--rate` | `1` | Metrics/spans/logs per sec/worker (`0` = unlimited) |
 | `--duration` | `0` | Time-based generation (`5s`, `1m`, `inf`) |
 | `--timeout` | `10s` | Max time to wait for signals to reach destination |
 | `--service` | `"telemetrygen"` | Service name |
@@ -60,7 +60,7 @@ Resource attributes (`--otlp-attributes`) attach to the Resource; telemetry attr
 telemetrygen traces --otlp-insecure --traces 100
 ```
 
-Key trace flags: `--child-spans` (default 1), `--span-duration` (default 123us), `--status-code` (Unset/Error/Ok), `--span-links`.
+Key trace flags: `--child-spans` (default and minimum effective value 1), `--span-duration` (default 123us), `--status-code` (Unset/Error/Ok), `--span-links`.
 
 ### Trace recipes
 
@@ -132,23 +132,24 @@ telemetrygen logs --otlp-insecure --duration inf --rate 10 \
 
 ## Load testing patterns
 
-Total throughput = `workers` x `rate`.
+For metrics and logs, total record rate = `workers` x `rate`. For traces, the limiter counts both the parent and every child span. With the default one child span, approximate trace rate = `workers x rate / 2`.
 
 ```bash
-# 100 traces/sec sustained
-telemetrygen traces --otlp-insecure --duration inf --workers 10 --rate 10
+# Approximately 100 traces/sec sustained (200 spans/sec, one child per trace)
+telemetrygen traces --otlp-insecure --duration inf --workers 10 --rate 20
 
-# 1000 traces/sec burst for 60s
-telemetrygen traces --otlp-insecure --duration 60s --workers 10 --rate 100
+# Approximately 1000 traces/sec for 60s (2000 spans/sec, one child per trace)
+telemetrygen traces --otlp-insecure --duration 60s --workers 10 --rate 200
 
-# Large payloads (~1MB per span) -- always pair --size with --rate
+# Large payloads (~1MB on each generated trace's parent span) -- always pair --size with --rate
 telemetrygen traces --otlp-insecure --duration 30s --size 1 --rate 1
 ```
 
 ## Multi-signal and multi-tenant
 
 ```bash
-# Correlated signals sharing a trace ID
+# Generate all three signals. Metrics exemplars and logs share the explicit IDs;
+# telemetrygen traces generates its own trace and span IDs.
 TRACE_ID="0af7651916cd43dd8448eb211c80319c"
 SPAN_ID="b7ad6b7169203331"
 
@@ -182,7 +183,7 @@ telemetrygen traces --mtls \
 ```bash
 # Docker with host networking
 docker run --rm --network host \
-  ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:0.156.0 \
+  ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.156.0 \
   traces --otlp-insecure --traces 100
 
 # Kubernetes Job
@@ -252,7 +253,7 @@ cat ./out/result.json | python3 -c 'import sys,json; print(json.load(sys.stdin))
 Two recipes worth knowing for this pattern:
 
 - **Verify a filter drops matching records**: send a matching record, expect output to be empty (file size 0). Then send a non-matching record, expect output to contain it. Both halves are needed: empty output alone could also mean the collector crashed.
-- **Verify a transform that needs specific attributes**: telemetrygen alone can set resource and telemetry attributes but cannot rename spans or change kind. To exercise rules that depend on those, prepend a `transform/setup` processor in the same pipeline that sets the input shape, then chain the processor under test after it.
+- **Verify a transform that needs a shape telemetrygen cannot generate directly**: telemetrygen can set resource and telemetry attributes but cannot rename spans, change span kind, or choose IDs for generated traces. To exercise rules that depend on those, prepend a `transform/setup` processor in the same pipeline that sets the input shape, then chain the processor under test after it.
 
 On SELinux systems (Fedora, RHEL), append `:z` to the bind mounts so they get relabeled. On rootless Podman, the `--user` flag may not be needed because the container already runs as the invoking user.
 
@@ -274,5 +275,5 @@ These are the mistakes that cause real problems -- review before running against
 go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@v0.156.0
 
 # Container
-docker pull ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:0.156.0
+docker pull ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.156.0
 ```

--- a/skills/otel-telemetrygen/references/flags.md
+++ b/skills/otel-telemetrygen/references/flags.md
@@ -37,9 +37,9 @@ These apply to all subcommands (`traces`, `metrics`, `logs`).
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--workers` | int | `1` | Concurrent worker goroutines |
-| `--rate` | float64 | `1` | Items/sec/worker. `0` = no throttling |
+| `--rate` | float64 | `1` | Metrics/spans/logs per sec/worker. `0` = no throttling |
 | `--duration` | duration | `0` | How long to generate. Go durations (`5s`, `1m`) or `inf`. Overrides count flags |
-| `--interval` | duration | `1s` | Progress reporting interval |
+| `--interval` | duration | `1s` | Registered reporting interval; not consumed by generation code in v0.156.0 |
 | `--timeout` | duration | `10s` | Maximum time to wait for the signals to reach destination |
 
 ### Batching
@@ -62,7 +62,7 @@ These apply to all subcommands (`traces`, `metrics`, `logs`).
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--size` | int | `0` | Minimum payload size in MB per record |
+| `--size` | int | `0` | Minimum string-data payload size in MB per generated record; for traces, it is added to the parent span |
 | `--allow-export-failures` | bool | `false` | Continue when exports fail |
 
 ### Attribute Value Format
@@ -79,10 +79,10 @@ key=123                    # Integer
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--traces` | int | `0` | Traces per worker. Ignored if `--duration` set |
-| `--child-spans` | int | `1` | Child spans per trace |
-| `--span-duration` | duration | `123us` | Duration of each span |
+| `--child-spans` | int | `1` | Child spans per trace; values below 1 still generate one child |
+| `--span-duration` | duration | `123us` | Duration of each child span; the parent covers the child-span sequence |
 | `--status-code` | string | `"0"` | `Unset`/`0`, `Error`/`1`, `Ok`/`2` |
-| `--span-links` | int | `0` | Span links per span |
+| `--span-links` | int | `0` | Links requested from previously generated span contexts; the first parent has none |
 | `--marshal` | bool | `false` | Marshal trace context via HTTP headers |
 | `--otlp-http-url-path` | string | `"/v1/traces"` | HTTP URL path |
 
@@ -96,7 +96,7 @@ key=123                    # Integer
 | `--aggregation-temporality` | string | `"cumulative"` | `cumulative` or `delta` |
 | `--trace-id` | string | `""` | Trace ID for exemplar linking |
 | `--span-id` | string | `""` | Span ID for exemplar linking |
-| `--unique-timeseries` | bool | `false` | Enforce unique timeseries (experimental) |
+| `--unique-timeseries` | bool | `false` | Enforce unique timeseries within the configured duration window |
 | `--unique-timeseries-duration` | duration | `1s` | Window for unique timeseries generation |
 | `--otlp-http-url-path` | string | `"/v1/metrics"` | HTTP URL path |
 
@@ -144,7 +144,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:0.156.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.156.0
         args:
         - traces
         - --otlp-insecure


### PR DESCRIPTION
## Summary

- correct trace rate, size, duration, child-span, and link semantics
- remove false cross-signal correlation and experimental-status claims
- fix released telemetrygen container tags to include the `v` prefix

## Verification

- built and tested telemetrygen from the local v0.156.0 tag archive
- compared documented flags with root and per-signal help
- ran representative attribute, header, metric, and log smoke commands
- `git diff --check -- skills/otel-telemetrygen`

`skills-ref` is unavailable. The package registry API returned 403 without `read:packages`; the released publish workflow verifies that the image tag is derived verbatim from v0.156.0.

## Deliberately excluded

- post-v0.156.0 dependency changes on `main`
- new signals or feature scope

Agent-authored refresh; human-owned PR.
