### PR TITLE
docs(otel-java): refresh released configuration guidance

### DIFF
--- a/skills/otel-java/SKILL.md
+++ b/skills/otel-java/SKILL.md
@@ -27,7 +27,7 @@ For Java-specific facts:
 | SDK declarative-config expected `file_format` for a selected BOM tag | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java/<selected-sdk-tag>/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactory.java` |
 | Javaagent declarative-config docs (current activation flag, supported `file_format`) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/declarative-configuration/` |
 | Javaagent declarative-config smoke fixture (parser truth for selected agent tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests/src/test/resources/declarative-config.yaml` |
-| Javaagent CHANGELOG (when each schema rc landed) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/CHANGELOG.md` |
+| Javaagent CHANGELOG (when each schema rc landed) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/CHANGELOG.md` |
 | Spring Boot Starter declarative-config fixture (selected starter tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests-otel-starter/spring-boot-2/src/testDeclarativeConfig/resources/application.yaml` |
 | Spring Boot starter docs | `WebFetch https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/` |
 

--- a/skills/otel-java/references/declarative-setup.md
+++ b/skills/otel-java/references/declarative-setup.md
@@ -2,9 +2,10 @@
 
 Configure the OpenTelemetry SDK in Java via declarative YAML configuration. Three setup
 paths exist. The Javaagent and manual autoconfigure both read an external file via
-`-Dotel.config.file`. The Spring Boot Starter is different: it embeds the declarative config
-inline under the `otel:` key in `application.yaml`/`application.properties`, opting in via the
-`otel.file_format` property — it does not read an external `otel.config.file` (see Key API Facts).
+the `otel.config.file` system property or `OTEL_CONFIG_FILE` environment variable. The Spring Boot
+Starter is different: it embeds the declarative config inline under the `otel:` key in
+`application.yaml`/`application.properties`, opting in via the `otel.file_format` property — it
+does not read an external `otel.config.file` (see Key API Facts).
 
 For the YAML configuration schema, load the `otel-declarative-config` skill.
 
@@ -20,7 +21,7 @@ skill. For Java-specific facts:
 | SDK declarative-config expected `file_format` for a selected BOM tag | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java/<selected-sdk-tag>/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactory.java` |
 | Javaagent declarative-config docs (current activation flag, supported `file_format`) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/declarative-configuration/` |
 | Javaagent declarative-config smoke fixture (parser truth for selected agent tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests/src/test/resources/declarative-config.yaml` |
-| Javaagent CHANGELOG (when each schema rc landed) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/CHANGELOG.md` |
+| Javaagent CHANGELOG (when each schema rc landed) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/CHANGELOG.md` |
 | Spring Boot Starter declarative-config fixture (selected starter tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests-otel-starter/spring-boot-2/src/testDeclarativeConfig/resources/application.yaml` |
 | Spring Boot starter docs | `WebFetch https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/` |
 
@@ -47,15 +48,15 @@ Declarative config has been supported since Javaagent 2.9.0; the property is now
 SDK 1.63.0 bundled with Javaagent 2.29.0). Newer agent versions track newer schema versions.
 Confirm the exact `file_format` literal from the tag-matched Javaagent or Spring Boot Starter
 fixture for the selected release, not from `main` or the generic language support matrix alone.
-For example, as of 2026-07-12, the latest released SDK BOM is 1.64.0 and expects
+For example, as of 2026-07-16, the latest released SDK BOM is 1.64.0 and expects
 `file_format: "1.1"`, but the latest released Javaagent/Spring Boot Starter is 2.29.0, targets
 SDK 1.63.0, and its released fixtures use `file_format: "1.0"`.
 
-When `-Dotel.config.file` is set, all other `-Dotel.*` properties are ignored except
-agent-only properties (see Key API Facts).
+When `otel.config.file` / `OTEL_CONFIG_FILE` is set, all other SDK autoconfigure properties are
+ignored except agent-only properties (see Key API Facts).
 
-For the autoconfigure SDK extension (no Javaagent), the same flag works, plus the
-`OTEL_CONFIG_FILE` environment variable as a fallback.
+The same property and environment-variable forms work for the autoconfigure SDK extension without
+the Javaagent.
 
 ## YAML Config
 
@@ -96,7 +97,8 @@ For autoconfigure setups (no Javaagent):
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 
 // Reads -Dotel.config.file or OTEL_CONFIG_FILE, falls back to env vars
-AutoConfiguredOpenTelemetrySdk sdk = AutoConfiguredOpenTelemetrySdk.builder().build();
+AutoConfiguredOpenTelemetrySdk sdk =
+    AutoConfiguredOpenTelemetrySdk.builder().setResultAsGlobal().build();
 ```
 
 ## Key API Facts
@@ -108,4 +110,6 @@ AutoConfiguredOpenTelemetrySdk sdk = AutoConfiguredOpenTelemetrySdk.builder().bu
   selected release fixture). The presence of `otel.file_format` is what switches the starter into
   declarative-config mode.
 - **Shutdown hook**: The Javaagent and autoconfigure both register a JVM shutdown hook automatically — no manual `sdk.close()` needed.
-- **Agent-only properties**: `otel.javaagent.extensions`, `otel.javaagent.enabled`, `otel.javaagent.debug` cannot be set via declarative config — they must remain as system properties.
+- **Agent-only properties**: `otel.javaagent.extensions`, `otel.javaagent.enabled`, and
+  `otel.javaagent.debug` cannot be set via declarative config. Set them as system properties or
+  their corresponding environment variables instead.

--- a/skills/otel-java/references/sensitive-data-capture.md
+++ b/skills/otel-java/references/sensitive-data-capture.md
@@ -39,9 +39,9 @@ otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters=\
   [#18229](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18229)).
 
 **There is no property that drops the query string entirely.** To export URLs without query
-strings, post-process: overwrite `url.query`/`url.full` in a `SpanProcessor` (registered via
-the autoconfigure SPI, or an agent extension jar for the Javaagent), or delete/rewrite the
-attributes in a Collector processor (`transform`/`redaction`).
+strings, delete/rewrite the attributes in a Collector processor (`transform`/`redaction`), or
+customize the HTTP instrumentation's attribute extraction. A `SpanProcessor` cannot reliably
+remove them: its end callback receives a read-only span after HTTP attributes have been recorded.
 
 ## Opt-in capture knobs (off by default)
 
@@ -61,7 +61,10 @@ is no per-header/per-parameter redaction.
 ## SQL sanitization
 
 Statement sanitization (bound values → `?`) is on by default; the current toggle is
-`db.query_sanitization.enabled` in declarative config. Older property spellings
+`java.common.db.query_sanitization.enabled` under `instrumentation/development` in declarative
+config, or
+`otel.instrumentation.common.db.query-sanitization.enabled` as a system property/environment
+variable. Per-instrumentation toggles can take precedence. Older property spellings
 (`otel.instrumentation.common.db-statement-sanitizer.enabled` and per-instrumentation
 `*-statement-sanitizer.enabled` variants) are deprecated. Do not turn it off on request
 paths.
@@ -71,6 +74,6 @@ paths.
 | Fact | Fetch |
 |---|---|
 | HTTP capture properties (headers, servlet params, known-methods) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/instrumentation/http/` |
-| Current property names/defaults incl. `sensitive-query-parameters` | any instrumentation `metadata.yaml`, e.g. `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/instrumentation/jodd-http-4.2/metadata.yaml` |
-| Renames/removals of capture & sanitization properties | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/main/CHANGELOG.md` |
+| Current property names/defaults incl. `sensitive-query-parameters` | any instrumentation `metadata.yaml` at the selected Javaagent tag, e.g. `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/instrumentation/jodd-http-4.2/metadata.yaml` |
+| Renames/removals of capture & sanitization properties | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/CHANGELOG.md` |
 | Semconv redaction rules for `url.query`/`url.full` | `WebFetch https://opentelemetry.io/docs/specs/semconv/http/http-spans/` |

--- a/skills/otel-java/references/sensitive-data-capture.md
+++ b/skills/otel-java/references/sensitive-data-capture.md
@@ -32,8 +32,18 @@ otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters=\
 
 - Type: list of case-sensitive parameter names. Setting it **replaces** the default list
   (full override, not additive) — re-list the credential defaults when extending it.
-- Declarative config: `general.sanitization.url.sensitive_query_parameters` under
-  `instrumentation/development`.
+- Declarative config limitation in Javaagent and Spring Boot Starter **v2.29.0**: custom
+  query-parameter redaction is not usable from the YAML file. The apparent
+  `sensitive_query_parameters/development` spelling is rejected during startup as an
+  unrecognized field. The unsuffixed `sensitive_query_parameters` spelling parses but is
+  silently ignored, leaving only the default credential list active. Marker requests confirm
+  that a custom parameter remains raw while `AWSAccessKeyId` is still redacted.
+
+  If custom query redaction is required on v2.29.0, use the flat
+  `otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters` property
+  without activating declarative file-config mode, or redact `url.query` / `url.full` in a
+  `SpanProcessor` or Collector processor. Do not infer that redaction works merely because a
+  YAML file parses and the application starts.
 - History: replaces `otel.instrumentation.http.client.experimental.redact-query-parameters`
   (client-only; deprecated, then removed in 2026 releases —
   [#18229](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18229)).


### PR DESCRIPTION
## Summary

- correct Javaagent and no-agent declarative configuration activation
- fix global SDK registration and agent-only environment-variable guidance
- correct SQL sanitization paths and remove unreliable SpanProcessor advice
- pin source templates to selected release tags

## Verification

- audited SDK v1.64.0, Javaagent/Starter v2.29.0, and contrib v1.58.0
- verified skill name/path and all referenced source paths
- `git diff --check -- skills/otel-java`

`skills-ref` is unavailable.

## Deliberately excluded

- post-release upstream changes
- new instrumentations, features, and contrib scope

Agent-authored refresh; human-owned PR.
