### PR TITLE
ci(cla): update reusable workflow pin

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,5 +22,5 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    # Pinned to the immutable squash-merge SHA of ollygarden/.github#6.
-    uses: ollygarden/.github/.github/workflows/cla.yml@f9fba8552bebbf8b9c01d20d6cfd30041065b4aa
+    # Pinned to the immutable squash-merge SHA of ollygarden/.github#7.
+    uses: ollygarden/.github/.github/workflows/cla.yml@70ff386ab5c462ba56c631873571f5a8b407e9af


### PR DESCRIPTION
## Summary

- update the reusable CLA workflow pin from `ollygarden/.github#6` to `ollygarden/.github#7`
- use the immutable squash-merge SHA `70ff386ab5c462ba56c631873571f5a8b407e9af`

## Why

The updated organization workflow allowlists the confirmed OllyGarden organization members while preserving the existing automation bot entries. This prevents internal contributors from blocking otherwise valid pull requests on the CLA check.

## Impact

This repository will consume the updated centralized CLA allowlist. External contributors remain subject to the existing CLA flow.

## Validation

- `git diff --check`
- parsed `.github/workflows/cla.yml` successfully as YAML
- confirmed the pinned upstream commit contains the expected allowlist
