### PR TITLE
docs(otel-java): document declarative sanitization limitation

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,5 +22,5 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    # Pinned to the immutable squash-merge SHA of ollygarden/.github#6.
-    uses: ollygarden/.github/.github/workflows/cla.yml@f9fba8552bebbf8b9c01d20d6cfd30041065b4aa
+    # Pinned to the immutable squash-merge SHA of ollygarden/.github#7.
+    uses: ollygarden/.github/.github/workflows/cla.yml@70ff386ab5c462ba56c631873571f5a8b407e9af

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,5 +22,5 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    # Pinned to the immutable squash-merge SHA of ollygarden/.github#7.
-    uses: ollygarden/.github/.github/workflows/cla.yml@70ff386ab5c462ba56c631873571f5a8b407e9af
+    # Pinned to the immutable squash-merge SHA of ollygarden/.github#6.
+    uses: ollygarden/.github/.github/workflows/cla.yml@f9fba8552bebbf8b9c01d20d6cfd30041065b4aa

--- a/skills/otel-java/references/sensitive-data-capture.md
+++ b/skills/otel-java/references/sensitive-data-capture.md
@@ -32,8 +32,26 @@ otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters=\
 
 - Type: list of case-sensitive parameter names. Setting it **replaces** the default list
   (full override, not additive) — re-list the credential defaults when extending it.
-- Declarative config: `general.sanitization.url.sensitive_query_parameters` under
-  `instrumentation/development`.
+- Declarative config: the leaf key carries the experimental `/development` suffix —
+
+  ```yaml
+  instrumentation/development:
+    general:
+      sanitization:
+        url:
+          sensitive_query_parameters/development:
+            - AWSAccessKeyId   # re-list the credential defaults
+            - Signature
+            - sig
+            - X-Goog-Signature
+            - <your-parameter>
+  ```
+
+  Writing the key without the `/development` suffix does nothing: nodes under
+  `instrumentation/development` are not schema-validated, so a misspelled or unrecognized
+  key is **silently ignored** and the default credential-only list stays active
+  (verified against `CommonConfig` in v2.29.0). A config file that parses and boots is no
+  evidence the redaction applies — only a marker request is.
 - History: replaces `otel.instrumentation.http.client.experimental.redact-query-parameters`
   (client-only; deprecated, then removed in 2026 releases —
   [#18229](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18229)).

--- a/skills/otel-java/references/sensitive-data-capture.md
+++ b/skills/otel-java/references/sensitive-data-capture.md
@@ -32,26 +32,18 @@ otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters=\
 
 - Type: list of case-sensitive parameter names. Setting it **replaces** the default list
   (full override, not additive) — re-list the credential defaults when extending it.
-- Declarative config: the leaf key carries the experimental `/development` suffix —
+- Declarative config limitation in Javaagent and Spring Boot Starter **v2.29.0**: custom
+  query-parameter redaction is not usable from the YAML file. The apparent
+  `sensitive_query_parameters/development` spelling is rejected during startup as an
+  unrecognized field. The unsuffixed `sensitive_query_parameters` spelling parses but is
+  silently ignored, leaving only the default credential list active. Marker requests confirm
+  that a custom parameter remains raw while `AWSAccessKeyId` is still redacted.
 
-  ```yaml
-  instrumentation/development:
-    general:
-      sanitization:
-        url:
-          sensitive_query_parameters/development:
-            - AWSAccessKeyId   # re-list the credential defaults
-            - Signature
-            - sig
-            - X-Goog-Signature
-            - <your-parameter>
-  ```
-
-  Writing the key without the `/development` suffix does nothing: nodes under
-  `instrumentation/development` are not schema-validated, so a misspelled or unrecognized
-  key is **silently ignored** and the default credential-only list stays active
-  (verified against `CommonConfig` in v2.29.0). A config file that parses and boots is no
-  evidence the redaction applies — only a marker request is.
+  If custom query redaction is required on v2.29.0, use the flat
+  `otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters` property
+  without activating declarative file-config mode, or redact `url.query` / `url.full` in a
+  `SpanProcessor` or Collector processor. Do not infer that redaction works merely because a
+  YAML file parses and the application starts.
 - History: replaces `otel.instrumentation.http.client.experimental.redact-query-parameters`
   (client-only; deprecated, then removed in 2026 releases —
   [#18229](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18229)).


### PR DESCRIPTION
## Summary

- document that declarative custom query-parameter redaction is broken in released Javaagent and Spring Boot Starter 2.29.0
- recommend the working flat property mode or application/Collector post-processing
- remove an unrelated CLA workflow change from this PR

## Verification

- `/private/tmp/skills-ref-venv/bin/skills-ref validate skills/otel-java`
- `python3 .github/scripts/check-skill-registration.py`
- `git diff --check`
- real Javaagent 2.29.0 and Spring Boot Starter 2.29.0 startup tests: the suffixed YAML key is rejected as unrecognized
- marker requests with the unsuffixed YAML key: custom `secret` remains raw while default `AWSAccessKeyId` is redacted, proving the custom list is ignored
- flat-property control run: custom and default parameters are both redacted
- programmatic SDK 1.64.0 compile/emission and file-loader checks

## Deliberately excluded

- unreleased fixes to the Java declarative configuration mapping
- changes outside `otel-java`

Agent-authored correction; human-owned PR.
