### PR TITLE
fix(otel-collector): split invalid duplicate-key examples

### DIFF
--- a/skills/otel-collector/components/filter/advanced.md
+++ b/skills/otel-collector/components/filter/advanced.md
@@ -42,12 +42,16 @@ Basic (flat strings) and advanced (objects) styles cannot be mixed within one si
 processors:
   filter:
     error_mode: ignore
+```
 
+```yaml
 # Development: catch broken conditions immediately (must set explicitly; ignore is the default)
 processors:
   filter:
     error_mode: propagate   # a failing condition drops the whole batch
+```
 
+```yaml
 # Noisy environments: continue without logging the error at all
 processors:
   filter:

--- a/skills/otel-collector/components/filter/quirks.md
+++ b/skills/otel-collector/components/filter/quirks.md
@@ -50,7 +50,9 @@ All signals are **Alpha** (profiles are **Development**). Config keys can still 
 # Less efficient — inferred as datapoint context, evaluates every datapoint
 metric_conditions:
   - 'datapoint.attributes["env"] == "test"'
+```
 
+```yaml
 # Prefer — resource condition drops the whole resource in one check
 metric_conditions:
   - 'resource.attributes["env"] == "test"'

--- a/skills/otel-collector/components/k8s_attributes/advanced.md
+++ b/skills/otel-collector/components/k8s_attributes/advanced.md
@@ -40,7 +40,9 @@ Run the processor twice across two tiers. A per-node **agent** in `passthrough: 
 processors:
   k8s_attributes:
     passthrough: true
+```
 
+```yaml
 # Gateway (Deployment) — enrich off the IP the agent stamped
 processors:
   k8s_attributes:

--- a/skills/otel-collector/components/memory_limiter/configuration.md
+++ b/skills/otel-collector/components/memory_limiter/configuration.md
@@ -72,7 +72,9 @@ Startup fails (config error) when:
 ```yaml
 # Good — refuse before anything buffers
 processors: [memory_limiter, tail_sampling, batch]
+```
 
+```yaml
 # Bad — memory limiting and sampling happen after batching
 processors: [batch, memory_limiter, tail_sampling]
 ```

--- a/skills/otel-collector/components/probabilistic_sampler/advanced.md
+++ b/skills/otel-collector/components/probabilistic_sampler/advanced.md
@@ -67,7 +67,9 @@ processors:
   probabilistic_sampler:
     mode: proportional
     sampling_percentage: 30
+```
 
+```yaml
 # Gateway collector — content-aware tail sampling on the survivors
 processors:
   tail_sampling:

--- a/skills/otel-collector/components/transform/advanced.md
+++ b/skills/otel-collector/components/transform/advanced.md
@@ -65,7 +65,9 @@ Run `transform` first if `filter`'s conditions depend on attributes `transform` 
 processors:
   transform:
     error_mode: ignore
+```
 
+```yaml
 # Mixed: most groups tolerant, one group must fail loudly
 processors:
   transform:

--- a/skills/otel-collector/components/transform/quirks.md
+++ b/skills/otel-collector/components/transform/quirks.md
@@ -37,7 +37,9 @@ Statements evaluate per item at their inferred context. A `datapoint`- or `spane
 metric_statements:
   - convert_sum_to_gauge() where metric.name == "process.count"
   - limit(datapoint.attributes, 100, ["host.name"])
+```
 
+```yaml
 # WORKS — one group per context
 metric_statements:
   - statements:


### PR DESCRIPTION
## Summary

- split seven Collector examples whose alternative configurations reused duplicate YAML keys
- preserve the intended good/bad or tier-specific comparisons while making each fenced snippet independently valid YAML

## Verification

- `/private/tmp/skills-ref-venv/bin/skills-ref validate skills/otel-collector`
- `python3 .github/scripts/check-skill-registration.py`
- `git diff --check`
- inventoried all 197 fenced YAML blocks in the skill
- tested 194 Collector configs/fragments against `otel/opentelemetry-collector-contrib:0.156.0`
- 180 valid configs passed; three documented expected failures reproduced; environment/non-Collector exclusions recorded
- re-tested all 15 resulting fences from these seven edits: 14 valid examples passed and the one explicitly labeled `FAILS` reproduced its intended context error; zero unexpected failures
- ran the documented `k8s_attributes` kind workflow end-to-end and observed the expected enrichment

## Deliberately excluded

- Kubernetes/EKS behavior requiring environments not represented by a local released Collector
- new Collector components and unreleased post-v0.156 changes

Agent-authored correction; human-owned PR.
