### PR TITLE
fix(ci): invoke Lychee directly on Blacksmith

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
             *) echo "Unsupported runner architecture: $RUNNER_ARCH" >&2; exit 1 ;;
           esac
 
-          archive="lychee-${lychee_arch}-unknown-linux-gnu.tar.gz"
+          archive="lychee-${lychee_arch}-unknown-linux-musl.tar.gz"
           release_url="https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}"
           install_dir="$RUNNER_TEMP/lychee"
           mkdir -p "$install_dir"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Link Checker
-        id: lychee
-        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
-        with:
-          args: "--verbose --no-progress skills/otel-sdk-versions/references/generated/otel-version-index.md --config .github/lychee.toml"
-          failIfEmpty: false
+      - name: Install Lychee
+        env:
+          LYCHEE_VERSION: "0.24.2"
+        run: |
+          case "$RUNNER_ARCH" in
+            X64) lychee_arch="x86_64" ;;
+            ARM64) lychee_arch="aarch64" ;;
+            *) echo "Unsupported runner architecture: $RUNNER_ARCH" >&2; exit 1 ;;
+          esac
+
+          archive="lychee-${lychee_arch}-unknown-linux-gnu.tar.gz"
+          release_url="https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}"
+          install_dir="$RUNNER_TEMP/lychee"
+          mkdir -p "$install_dir"
+
+          curl --fail --location --silent --show-error \
+            --output "$RUNNER_TEMP/$archive" "$release_url/$archive"
+          curl --fail --location --silent --show-error \
+            --output "$RUNNER_TEMP/$archive.sha256" "$release_url/$archive.sha256"
+          cd "$RUNNER_TEMP"
+          sha256sum --check "$archive.sha256"
+          tar --extract --gzip --file "$archive" --directory "$install_dir" \
+            --strip-components=1
+          echo "LYCHEE_BIN=$install_dir/lychee" >> "$GITHUB_ENV"
+
+      - name: Check Links
         env:
           GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          "$LYCHEE_BIN" --verbose --no-progress
+          skills/otel-sdk-versions/references/generated/otel-version-index.md
+          --config .github/lychee.toml


### PR DESCRIPTION
## Summary

- replace `lycheeverse/lychee-action` with a direct, pinned Lychee 0.24.2 install
- use the static musl artifact and verify its official release checksum before extraction
- invoke the binary by absolute path while preserving the existing generated version-index target, `.github/lychee.toml`, GitHub token, and failure behavior

## Root cause

The action adds `$RUNNER_TEMP/lychee/bin` through `$GITHUB_PATH`, but its entrypoint uses `#!/bin/bash -l`. On Blacksmith, login-shell initialization resets `PATH`, so both the version probe and link check fail with `lychee: command not found`.

The GNU Lychee artifact also requires newer glibc than Blacksmith's Ubuntu 22.04 image; the official static musl artifact avoids that host dependency.

## Validation

Local:

- `go test ./tools/otel-agent-tools/...`
- `go build ./tools/otel-agent-tools/cmd/otel-agent-tools`
- workflow YAML parse
- Lychee 0.24.2 against `skills/otel-sdk-versions/references/generated/otel-version-index.md` with `.github/lychee.toml`: 34 total, 32 OK, 2 excluded, 0 errors

Fresh Blacksmith PR CI:

- `check-links`: passed
- `skill-validation`: passed
- `tool-tests`: passed
- CLA: passed

Linear: [OTEL-273](https://linear.app/ollygarden/issue/OTEL-273/fix-lychee-action-path-failure-on-blacksmith-runners)

Agent involvement: Codex implemented and validated this workflow fix under human direction.