### PR TITLE
fix(otel-browser): verify web vitals attributes against semantic conventions

### DIFF
--- a/skills/otel-browser/SKILL.md
+++ b/skills/otel-browser/SKILL.md
@@ -35,19 +35,22 @@ first decision:
 
 ## Verify attributes against released semantic conventions before hand-rolling
 
-Every browser signal (`browser.navigation`, `browser.web_vital`, `browser.resource_timing`,
-`exception`, …) has a released semantic-convention group, even while `browser.*` is still
-**development** stability. Before emitting a hand-written span or `LogRecord` with custom
-attributes:
+Not every browser signal has a released convention yet — e.g. `browser.web_vital` is a released
+**development**-stability event, but `browser.navigation` and `browser.resource_timing` have no
+released convention under the `browser` group, and `exception` is a released **stable** group of
+its own (not under `browser`). Check coverage per signal rather than assuming it; before emitting a
+hand-written span or `LogRecord` with custom attributes:
 
 1. Prefer a catalog instrumentation from [`references/instrumentation.md`](references/instrumentation.md) — it already emits
-   compliant event/attribute names.
-2. If no instrumentation covers the signal, check the released names first instead of inventing a
-   namespace: use the `otel-semantic-conventions` skill to query the `browser` group (e.g. its
-   `events` kind, or one entry like `event.browser.web_vital`), or WebFetch the matching page under
+   compliant event/attribute names where a convention exists.
+2. Check whether a released convention covers the signal: use the `otel-semantic-conventions`
+   skill to query the relevant group (e.g. `browser` for `event.browser.web_vital`, `exceptions`
+   for `exception.type`), or WebFetch the matching page under
    `https://opentelemetry.io/docs/specs/semconv/browser/`.
-3. Use the released event/attribute names verbatim (e.g. the `browser.web_vital` event's `name`,
-   `value`, `delta`, `id` — not a custom `web_vital.*` namespace), even at development stability.
+3. If one exists, use its event/attribute names verbatim (e.g. the `browser.web_vital` event's
+   `name`, `value`, `delta`, `id` — not a custom `web_vital.*` namespace), even at development
+   stability. If none exists, define bounded, low-cardinality custom attributes under a stable
+   namespace instead of guessing at a released-looking name.
 
 ## The browser package ecosystem — three repositories
 

--- a/skills/otel-browser/SKILL.md
+++ b/skills/otel-browser/SKILL.md
@@ -33,6 +33,22 @@ first decision:
 | **Events** | Logs API → `LogRecord` | point-in-time facts (no duration/children) | web vitals, navigation, console, errors, user action |
 | **Spans** | Trace API | operations with a duration and parent/child | `fetch`, XHR, document load, long task |
 
+## Verify attributes against released semantic conventions before hand-rolling
+
+Every browser signal (`browser.navigation`, `browser.web_vital`, `browser.resource_timing`,
+`exception`, …) has a released semantic-convention group, even while `browser.*` is still
+**development** stability. Before emitting a hand-written span or `LogRecord` with custom
+attributes:
+
+1. Prefer a catalog instrumentation from [`references/instrumentation.md`](references/instrumentation.md) — it already emits
+   compliant event/attribute names.
+2. If no instrumentation covers the signal, check the released names first instead of inventing a
+   namespace: use the `otel-semantic-conventions` skill to query the `browser` group (e.g. its
+   `events` kind, or one entry like `event.browser.web_vital`), or WebFetch the matching page under
+   `https://opentelemetry.io/docs/specs/semconv/browser/`.
+3. Use the released event/attribute names verbatim (e.g. the `browser.web_vital` event's `name`,
+   `value`, `delta`, `id` — not a custom `web_vital.*` namespace), even at development stability.
+
 ## The browser package ecosystem — three repositories
 
 Browser packages are spread across three upstream repos. The
@@ -89,6 +105,6 @@ relying on these notes.
 
 - Shared JS API and Node.js SDK (the browser builds on the same API): `otel-js` skill.
 - Schema-level facts for declarative YAML config: `otel-declarative-config` skill.
-- Semantic conventions lookup (`browser.*`, `session.*`, `exception`): `otel-semantic-conventions` skill.
+- Semantic conventions lookup (`browser.*`, `session.*`, `exception`): `otel-semantic-conventions` skill — use it before hand-rolling any event/span attributes (see above).
 - Edge sampling / redaction / rate limiting in front of browsers: `otel-collector` skill.
 - SDK version selection across languages: `otel-sdk-versions` skill.

--- a/skills/otel-browser/references/instrumentation.md
+++ b/skills/otel-browser/references/instrumentation.md
@@ -111,6 +111,13 @@ aggressively (see
 conventions are **merged** (see the
 [WebVital event](https://opentelemetry.io/docs/specs/semconv/browser/browser-events/#webvital-event)).
 
+The released `browser.web_vital` event (development stability; verify via the
+`otel-semantic-conventions` skill, group `browser`, entry `event.browser.web_vital`) carries `name`,
+`value`, `delta`, and `id` — not a custom `web_vital.*` attribute namespace.
+`WebVitalsInstrumentation` already emits these correctly; if you must hand-write reporting (e.g. no
+`LoggerProvider`/instrumentation available), emit a `LogRecord` named `browser.web_vital` with those
+attributes rather than opening a span with invented keys.
+
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `includeRawAttribution` | `boolean` | `false` | Set the record body to the JSON-stringified `web-vitals` attribution object (which element/event caused the metric). |
@@ -219,5 +226,6 @@ The server must list `traceparent` (and `tracestate`/`baggage` if used) in
 | Putting PII in `data-otel-*` or URLs | Exported verbatim to your backend | Use `sanitizeUrl`; keep `data-otel-*` to non-PII business keys |
 | Tracing your own OTLP export calls | Infinite telemetry-about-telemetry loop | `ignoreUrls` the `/v1/traces` and `/v1/logs` endpoints |
 | Forcing spans around point-in-time facts | Wrong model; bloats traces | Use the event-based instrumentations for vitals/navigation/errors |
+| Hand-rolling event/span attributes without checking semconv | Invents non-standard keys (e.g. `web_vital.name`/`web_vital.value`) instead of the released event/attribute names | Check the `browser` group first via the `otel-semantic-conventions` skill or WebFetch the spec page — see [SKILL.md](../SKILL.md#verify-attributes-against-released-semantic-conventions-before-hand-rolling) |
 | Relying on navigation *timing* for page-view counts | Lost when `load` never fires / user leaves early | Use the navigation *event* for counts, timing for performance |
 | Assuming an instrumentation works because registration threw no error | These packages are experimental; a misconfigured or no-op instrumentation emits neither errors nor telemetry | Verify each one reaches the Collector (diag logging + `debug` exporter) — see [setup-sdk.md](setup-sdk.md#verify-it-actually-emits) |


### PR DESCRIPTION
## Summary

- The `otel-browser` skill's Web Vitals guidance mentioned that the `browser.web_vital` event's semantic conventions are "merged" but never required checking them before hand-writing attributes. In production use, an agent following the skill produced a hand-rolled span with an invented `web_vital.*` attribute namespace (`web_vital.name`, `web_vital.value`, `web_vital.rating`) instead of the released `browser.web_vital` **event** (`name`, `value`, `delta`, `id`).
- Adds an explicit "verify before hand-rolling" step to `SKILL.md` directing agents to the `otel-semantic-conventions` skill (or the spec page directly) before writing any custom browser event/span attributes, and spells out the released Web Vitals attribute names in `references/instrumentation.md` so nothing is left to guess. Also adds a matching anti-pattern row.

## Agent involvement

This change was authored and implemented by Claude (Claude Code), based on a real defect the reporter hit while using the skill. I (a human) reviewed the diff, ran the validation and harness comparison below, and am submitting this PR.

## Harness results

**Prompt:** "Add OpenTelemetry instrumentation to report Core Web Vitals (LCP, INP, CLS, FCP, TTFB) from our React single-page app to our OTel collector." (assume the Web SDK is already configured elsewhere; focus on the vitals reporting code)

**Model / harness:** Claude Sonnet 5 via Claude Code subagents, fresh session per run, each primed with one of three skill states (no skill / current `main` / this PR's version) framed as "already loaded because its description matched the task" — matching how skill triggering works in practice. Each run had real, read-only access to the actual `otel-semantic-conventions` skill and its lookup script, so any semconv check reported is a genuine tool call.

| Variant | Runs | Result |
|---|---|---|
| No `otel-browser` skill | 1 | ❌ Invented a `webvital.*` namespace, explicitly noted no known released spec exists |
| Pre-fix skill (current `main`) | 3 | 1 fail (reproduces the reported bug: invented `browser.web_vital.name/value/rating/delta/…`, explicitly said it skipped the check because "the skill's guidance... didn't explicitly instruct me to consult the lookup before naming attributes"), 2 incidental passes (self-initiative, or sidestepped by using the catalog instrumentation instead of resolving the naming question) |
| Post-fix skill (this PR) | 3 | ✅ 3/3 — `browser.web_vital` event with `{name, value, delta, id}` every time, each trial explicitly quoting the new instruction as the reason it ran the semconv check |

Full transcripts and per-trial detail: https://gist.github.com/julianocosta89/3b872964d374f7c5368bd2e4c9d2c15f

The pre-fix run that reproduces the bug is a clean match for the original report: same failure mode (custom namespace, fabricated field), and the agent itself names the root cause the fix addresses — the skill's semconv pointer was passive, not a required step.

## Test plan

- [x] `skills-ref validate skills/otel-browser`
- [x] `python .github/scripts/check-skill-registration.py`
- [x] Harness A/B/C comparison (baseline / pre-fix / post-fix), 3 trials each for pre-fix and post-fix — see gist above

## Checklist

- [x] I read and agree to follow the Code of Conduct
- [x] `skills-ref validate skills/otel-browser` passes
- [x] `python .github/scripts/check-skill-registration.py` passes
- [ ] Skill registered in all three places — n/a, no skill added/renamed
- [x] Content is vendor-neutral, non-opinionated, DRY, and token-efficient
- [x] Harness comparison results included above
- [x] Commit messages follow Conventional Commits
- [ ] I have signed (or will sign via the CLA bot on this PR) the OllyGarden CLA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added step-by-step guidance to verify browser signal attributes against released OpenTelemetry semantic conventions before hand-writing span or `LogRecord` attributes.
  * Clarified the standardized `browser.web_vital` event name and attribute shape: `name`, `value`, `delta`, `id`.
  * Added explicit anti-pattern warnings to avoid inventing custom attribute namespaces/keys and to reuse released event/attribute names when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->