### PR TITLE
feat(otel-go): add otelc compile-time instrumentation reference

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -56,7 +56,7 @@
     {
       "name": "otel-go",
       "source": "./skills/otel-go",
-      "description": "OpenTelemetry in Go: declarative SDK setup with otelconf, API surface, contrib instrumentation libraries (otelhttp, otelgrpc), performance tuning, breaking-change audits."
+      "description": "OpenTelemetry in Go: declarative SDK setup with otelconf, API surface, contrib instrumentation libraries (otelhttp, otelgrpc), compile-time zero-code instrumentation (otelc), performance tuning, breaking-change audits."
     },
     {
       "name": "otel-java",

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ skills bundle task-focused references; language-agnostic skills sit alongside th
 skills/
   otel-go/
     SKILL.md           # name: otel-go
-    references/        # declarative-setup, api, instrumentation-libraries, performance, breaking-changes
+    references/        # declarative-setup, api, instrumentation-libraries, performance, breaking-changes, compile-time-instrumentation
   otel-java/
     SKILL.md
     references/
@@ -103,7 +103,7 @@ Language-specific skills:
 
 | Skill | Path | Use When |
 | --- | --- | --- |
-| `otel-go` | `skills/otel-go/` | OpenTelemetry in Go: declarative SDK setup with `otelconf`, API surface, contrib instrumentation libraries (otelhttp, otelgrpc, etc.), performance tuning, and breaking-change audits. |
+| `otel-go` | `skills/otel-go/` | OpenTelemetry in Go: declarative SDK setup with `otelconf`, API surface, contrib instrumentation libraries (otelhttp, otelgrpc, etc.), compile-time zero-code instrumentation (`otelc`), performance tuning, and breaking-change audits. |
 | `otel-java` | `skills/otel-java/` | OpenTelemetry in Java: Javaagent zero-code instrumentation, Spring Boot Starter, manual autoconfigure SDK, declarative YAML configuration, and BOM dependency management. |
 | `otel-js` | `skills/otel-js/` | OpenTelemetry in Node.js / JavaScript / TypeScript: NodeSDK setup, declarative YAML configuration via `@opentelemetry/configuration`, auto-instrumentations, and ESM vs CJS import patterns. |
 | `otel-python` | `skills/otel-python/` | OpenTelemetry in Python: declarative SDK setup via file config, API surface and logging bridge, zero-code instrumentation (opentelemetry-distro / opentelemetry-instrument) and contrib catalog, performance tuning, breaking-change audits. |

--- a/skills/otel-go/SKILL.md
+++ b/skills/otel-go/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: otel-go
-description: OpenTelemetry in Go — SDK setup, API surface, breaking changes, contrib instrumentation libraries (otelhttp, otelgrpc, otelmongo), and performance tuning. Use when adding, reviewing, or configuring OpenTelemetry in a Go service. Triggers on "setup otel in go", "go telemetry", "go tracing", "otelconf go", "otelhttp", "otelgrpc", "TracerProvider go", "MeterProvider go", or any Go-related OTel question.
+description: OpenTelemetry in Go — SDK setup, API surface, breaking changes, contrib instrumentation libraries (otelhttp, otelgrpc, otelmongo), compile-time zero-code instrumentation (otelc), and performance tuning. Use when adding, reviewing, or configuring OpenTelemetry in a Go service. Triggers on "setup otel in go", "go telemetry", "go tracing", "otelconf go", "otelhttp", "otelgrpc", "TracerProvider go", "MeterProvider go", "otelc", "compile-time instrumentation go", "zero-code go instrumentation", "go build instrumentation", or any Go-related OTel question.
 ---
 
 # OpenTelemetry in Go
@@ -17,6 +17,7 @@ task; each reference is self-contained.
 | [`references/instrumentation-libraries.md`](references/instrumentation-libraries.md) | Picking or wiring contrib libraries (otelhttp, otelgrpc, database, AWS, message queues, propagators, resource detectors), and writing manual instrumentation that follows semconv. |
 | [`references/performance.md`](references/performance.md) | Tuning sampling, batch processor, metric reader, exporter compression/retry, attribute allocation, log `Enabled()` short-circuiting, graceful shutdown. |
 | [`references/breaking-changes.md`](references/breaking-changes.md) | Auditing existing code for deprecated calls, renamed semantic conventions, and removed APIs across recent SDK / contrib releases. |
+| [`references/compile-time-instrumentation.md`](references/compile-time-instrumentation.md) | Zero-code, compile-time instrumentation with `otelc`: usage modes (`otelc go build`, tool dependency, toolexec drop-in), subcommands, supported libraries, rule sources/precedence, and pinning via `otel.instrumentation.go`. |
 
 ## Module versioning — read before adding dependencies
 

--- a/skills/otel-go/references/compile-time-instrumentation.md
+++ b/skills/otel-go/references/compile-time-instrumentation.md
@@ -1,0 +1,152 @@
+# Compile-time instrumentation with `otelc`
+
+`otelc` (`go.opentelemetry.io/otelc`, first stable release **v1.0.0**) instruments Go applications
+with OpenTelemetry **at compile time**. It wraps the Go toolchain via the compiler's `-toolexec`
+hook and injects trampoline hooks (linked with `//go:linkname`) into target functions, so
+instrumentation is baked into the binary — **no source-code changes**, and it reaches third-party
+dependencies and stdlib packages you don't own.
+
+## When to use it (vs. the rest of this skill)
+
+| Approach | Reach for it when |
+|---|---|
+| **`otelc`** (this file) | You can rebuild the app and want zero code changes, zero runtime overhead, and automatic coverage of dependencies/stdlib you don't control. |
+| **Hand-written SDK + contrib libraries** ([`instrumentation-libraries.md`](instrumentation-libraries.md), [`api.md`](api.md)) | You need explicit, fine-grained control over spans/metrics, or you cannot change the build toolchain. |
+
+`otelc` is **not** [`opentelemetry-go-instrumentation`](https://github.com/open-telemetry/opentelemetry-go-instrumentation),
+which is a separate **eBPF/uprobe runtime** auto-instrumentation project. `otelc` is
+compile-time / build-time.
+
+## Requirements
+
+- **Go 1.25+** toolchain (`go 1.25.0` in the project's `go.mod`).
+- **Go 1.24+** for the tool-dependency workflow (`go get -tool` / `go tool otelc`).
+- Operates on the module containing your `go.mod`.
+
+## Usage modes
+
+All three produce an instrumented binary; they differ in how `otelc` wires into the build.
+
+```bash
+# Mode 1 — wrap the build (simplest). Prefix the normal go command.
+otelc go build -o bin/app .
+otelc go test ./...
+
+# Mode 2 — tool dependency (Go 1.24+, reproducible: version tracked in go.mod)
+go get -tool go.opentelemetry.io/otelc/tool/cmd/otelc
+go tool otelc go build -o bin/app .
+
+# Mode 3 — toolexec drop-in via GOFLAGS (build command owned by a Makefile/CI)
+otelc setup                                             # run once; re-run when deps change
+export GOFLAGS="${GOFLAGS} '-toolexec=otelc toolexec'"  # single quotes are required
+go build -o myapp .
+```
+
+Obtain the binary by building from source (`make build` in the upstream repo), `go install
+go.opentelemetry.io/otelc/tool/cmd/otelc`, or the tool-dependency mode above.
+
+**Zero-config:** with no instrumentation file present, `otelc go build` analyzes the dependency
+graph, generates a temporary config for the build, and cleans up. Convenient, but **not
+reproducible** — upgrading `otelc` can silently change what gets instrumented. For auditable builds,
+pin instrumentations explicitly (see below).
+
+## Subcommands
+
+| Subcommand | Purpose |
+|---|---|
+| `otelc go …` | Instrument and run the go toolchain; everything after `go` is forwarded verbatim. |
+| `otelc setup` | Analyze the module, generate instrumentation sources, write the matched rule set to `.otelc-build/` (needed before Mode 3). Also runs the interactive wizard. |
+| `otelc pin` | Create/update `otel.instrumentation.go` to pin instrumentation packages. Flags: `--prune` (default on), `--validate`, `--generate`. |
+| `otelc cleanup` | Delete `.otelc-build/` and generated files. |
+| `otelc version` | Print the tool version (`--verbose` adds the Go runtime version). |
+| `otelc toolexec …` | Hidden interceptor invoked by `-toolexec=otelc toolexec`; never call it directly. |
+
+**Flag ordering:** global flags (`--rules`, `--debug`/`-d`, `--work-dir`/`-w`) must come **before**
+the `go` subcommand. `otelc go` and `otelc toolexec` skip flag parsing, so anything after them goes
+straight to the Go toolchain — `otelc go build --rules …` sends `--rules` to `go build` and fails.
+
+## Supported libraries (v1)
+
+Verified against the upstream `instrumentation/` tree. The active set is `otelc`'s embedded bundle;
+confirm against the tree when a version changes.
+
+| Library | Signals |
+|---|---|
+| `net/http` (client & server) | HTTP spans |
+| `google.golang.org/grpc` (client & server) | RPC spans |
+| `database/sql` | DB client spans |
+| `github.com/gin-gonic/gin` | HTTP server spans |
+| `github.com/redis/go-redis/v9` | Redis DB spans |
+| `go.mongodb.org/mongo-driver` | MongoDB DB spans |
+| `k8s.io/client-go` | K8s resource spans |
+| `github.com/openai/openai-go` (v1/v2/v3) | GenAI spans |
+| `github.com/segmentio/kafka-go` (consumer & producer) | Kafka messaging spans |
+| `log/slog` | Log records |
+| `github.com/sirupsen/logrus` | Log records |
+| Go runtime | Runtime metrics |
+
+## Selecting & configuring instrumentation
+
+**Rule sources, highest priority first — there is NO merging; each source entirely replaces the
+ones below it:**
+
+| Priority | Source |
+|---|---|
+| 1 | `OTELC_RULES` env var (file / dir / comma-separated list) |
+| 2 | `--rules` flag (same format; used only when `OTELC_RULES` is unset) |
+| 3 | Tool file `otel.instrumentation.go` (alias `otelc.tool.go`) |
+| 4 | Embedded default bundle |
+
+This is the top cause of "nothing got instrumented": an `OTELC_RULES`/`--rules` override silently
+masks the tool file and the embedded bundle. `--rules`/`OTELC_RULES` are for dev/debugging;
+pin via the tool file for production.
+
+**Explicit pinning** uses the standard Go `tools.go` blank-import pattern in a module-scoped file
+next to `go.mod`:
+
+```go
+//go:build tools
+
+package tools
+
+import (
+	_ "go.opentelemetry.io/otelc/instrumentation/net/http/server"
+	_ "go.opentelemetry.io/otelc/instrumentation/google.golang.org/grpc"
+)
+```
+
+Only blank (`_`) imports are allowed; run `go mod tidy` after editing, or let `otelc pin` manage it.
+
+**Runtime tuning:** instrumented binaries embed an auto-initialized SDK that reads the standard
+[OTel SDK env vars](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)
+(`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_TRACES_SAMPLER`, `OTEL_SERVICE_NAME`, …). There is no
+`otelc`-specific exporter/sampler config. The one `otelc`-specific knob is `OTEL_GLS_MAX_SPANS`
+(goroutine-local-storage span-stack depth, for instrumentation that doesn't thread `context.Context`).
+
+**Verify what matched:** `.otelc-build/matched.json` lists every rule that matched; `[]` means
+nothing matched (and `otelc` prints `Warning: no instrumentation will be applied`). Enable
+`--debug`/`OTELC_DEBUG=1` for `.otelc-build/debug.log`.
+
+## Rule schema (authoring)
+
+Custom rules and new-library instrumentation use YAML rules with `target` (import path; globs and
+`$root` supported), optional `version`, `where`/`where.file` predicates, and a `do` action. The
+seven rule types: `inject_hooks` (function hook), `add_struct_fields`, `inject_code`, `wrap_call`,
+`expand_directive`, `add_file`, `assign_value`. See the fetch table for the full grammar.
+
+## Sources of truth
+
+`otelc` ships stable and evolves; fetch upstream docs rather than trusting a snapshot. Repo:
+`open-telemetry/opentelemetry-go-compile-instrumentation` (module `go.opentelemetry.io/otelc`).
+
+| Fact / task | Fetch |
+|---|---|
+| Latest `otelc` release tag | `gh api repos/open-telemetry/opentelemetry-go-compile-instrumentation/releases/latest -q '.tag_name'` |
+| Install, usage modes, managing instrumentations | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-go-compile-instrumentation/main/docs/getting-started.md` |
+| Full rule schema (all 7 types, glob grammar, predicates) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-go-compile-instrumentation/main/docs/rules.md` |
+| Scope, filtering, precedence, runtime tuning, verification | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-go-compile-instrumentation/main/docs/configuration.md` |
+| Declaring instrumentations via `otel.instrumentation.go` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-go-compile-instrumentation/main/docs/external-configuration.md` |
+| Add instrumentation for a new library; semconv | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-go-compile-instrumentation/main/docs/instrument-guide.md` |
+| Internals (`-toolexec`, trampolines, `//go:linkname`, GLS) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-go-compile-instrumentation/main/docs/implementation.md` |
+| Diagnose why instrumentation was not applied | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-go-compile-instrumentation/main/docs/troubleshooting.md` |
+| Current supported-library set | List the `instrumentation/` tree in the repo (each leaf ships its own rules). |


### PR DESCRIPTION
## Summary

Adds coverage of **`otelc`** — OpenTelemetry's newly released **compile-time, zero-code** instrumentation for Go (`go.opentelemetry.io/otelc`) — to the existing `otel-go` skill, rather than creating a separate skill.

- **New** `skills/otel-go/references/compile-time-instrumentation.md`: what `otelc` is and when to reach for it vs. the hand-written SDK/contrib libraries and vs. the eBPF `opentelemetry-go-instrumentation` project; the three usage modes (`otelc go build`, `go get -tool` tool dependency, `-toolexec`/`GOFLAGS` drop-in); subcommands and the global-flags-before-`go` trap; the supported-libraries table; rule sources & precedence (the "no merging" gotcha); pinning via `otel.instrumentation.go`; runtime tuning; and a **fetch table** pointing at the upstream docs as the source of truth for deeper detail (rule schema, authoring, internals, troubleshooting).
- **`SKILL.md`**: new references-table row + `otelc` trigger phrases in the `description`.
- **`marketplace.json`** and **`README.md`** description/tree kept in sync (no new skill registration — this extends an existing skill).

Facts (version v1.0.1, module path, Go 1.25, supported-library set, `pin` being a shipped subcommand) were verified against a local checkout of `open-telemetry/opentelemetry-go-compile-instrumentation`. Kept DRY/token-efficient per `AGENTS.md`: deep detail links to upstream rather than being copied in.

Closes OTEL-274.

## Agent involvement

Implemented by an AI coding agent (Claude Code, `claude-opus-4-8[1m]`) — design brainstormed and approved interactively, facts verified against the upstream source checkout. A human owns this PR and will review every line before merge.

## Harness results (required for new or substantively changed skills)

**Method.** Same prompt, same model + harness (Claude Code, `claude-opus-4-8[1m]`), two fresh isolated agent runs — baseline with no skill content, skill run handed only the new `compile-time-instrumentation.md` reference. Neither run opened other files or used web search.

**Prompt.** _"I have a Go service and I want to add OpenTelemetry instrumentation WITHOUT modifying my application's source code. What are my options, and how do I actually do it? I'd prefer zero code changes."_

**Baseline (no skill) — knew the concept but got the specifics wrong:**
- Wrong module path / install command for the compile-time tool: suggested `go.opentelemetry.io/contrib/otel...` and `go install go.opentelemetry.io/auto/cmd/...@latest`, **conflating `otelc` with the eBPF `go.opentelemetry.io/auto` project**.
- Wrong binary/command: `otel go build` (the tool is `otelc`, e.g. `otelc go build`).
- Hedged throughout ("name/module per current release docs", "or the otel build tool per docs") and flagged the tool as "still maturing" — it is in fact stable (v1.0.x).
- No subcommands (`setup`/`pin`), no tool-dependency or `GOFLAGS` toolexec mode, no supported-library list, no rule-source precedence, no `.otelc-build/matched.json` verification.

**Skill run — accurate and actionable:**
- Correct module `go.opentelemetry.io/otelc` and `otelc` binary; identified it as stable v1.0.0 requiring Go 1.25+.
- All three usage modes with correct commands, including the single-quote requirement in the `GOFLAGS` drop-in.
- `otelc pin` for a committed `otel.instrumentation.go`; the exact supported-libraries set; env-var runtime config incl. the `otelc`-specific `OTEL_GLS_MAX_SPANS`.
- Surfaced the top real-world gotcha — rule sources resolve highest-priority-first with **no merging**, so an `OTELC_RULES`/`--rules` override silently masks the tool file — plus `.otelc-build/matched.json` verification.

**Net:** the baseline would send a user to a non-existent module path and the wrong command; the skill run produces a correct, copy-pasteable setup. Runs were executed as subagents in this harness (transcripts not externally hosted); reproducible with the prompt above.

## Checklist

- [x] I read and agree to follow the Code of Conduct
- [x] `skills-ref validate skills/otel-go` passes
- [x] `python .github/scripts/check-skill-registration.py` passes
- [x] Skill registered in all three places (existing skill; description/tree kept in sync)
- [x] Content is vendor-neutral, non-opinionated, DRY, and token-efficient
- [x] Harness comparison results included above
- [x] Commit messages follow Conventional Commits
- [ ] I have signed (or will sign via the CLA bot on this PR) the OllyGarden CLA
