### PR TITLE
fix(ci): update CLA concurrency workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,5 +22,5 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    # Pinned to the immutable squash-merge SHA of ollygarden/.github#7.
-    uses: ollygarden/.github/.github/workflows/cla.yml@70ff386ab5c462ba56c631873571f5a8b407e9af
+    # Pinned to the immutable squash-merge SHA of ollygarden/.github#8.
+    uses: ollygarden/.github/.github/workflows/cla.yml@57a9e9f54c6e3970fc5d9e722b20efab0aa47397


### PR DESCRIPTION
## What changed

Update the pinned reusable CLA workflow to the immutable squash-merge commit from [ollygarden/.github#8](https://github.com/ollygarden/.github/pull/8).

## Why

The updated shared workflow scopes concurrency by pull request, preventing CLA checks on unrelated pull requests from replacing one another in GitHub Actions' pending concurrency slot.

Linear: [E-2652](https://linear.app/ollygarden/issue/E-2652/prevent-cla-workflow-runs-from-cancelling-across-pull-requests)

## Validation

- Confirmed commit `57a9e9f54c6e3970fc5d9e722b20efab0aa47397` exposes the reusable workflow through the GitHub API
- Parsed `.github/workflows/cla.yml` with Ruby/Psych
- `git diff --check`

## Agent involvement

Implemented with Codex as the downstream rollout of the merged shared-workflow fix.