### PR TITLE
docs(otel-weaver): fill gaps found vs. a broader Weaver skill

### DIFF
--- a/skills/otel-weaver/SKILL.md
+++ b/skills/otel-weaver/SKILL.md
@@ -22,8 +22,8 @@ If a companion skill is unavailable:
 Three moving parts:
 
 1. **Registry** — directory of YAML files. `manifest.yaml` is required; its `schema_url` (OTel schema URL format, `http[s]://host/path/<version>`) both names the registry and carries its version in the final path segment. Dependency entries also use `schema_url` plus optional `registry_path`. The rest declare `attributes`, `metrics`, `spans`, `events`, `entities`. The version segment of `schema_url` is yours to manage; bump it on changes. (`name`, `semconv_version`, and `schema_base_url` are legacy/deprecated in favor of `schema_url`.)
-2. **Templates** — directory of Jinja2 files plus a `weaver.yaml` per target language describing which templates to run, with what filter, in what `application_mode`, and with what output filename.
-3. **Policies** — Rego rules. Built-in OTel policies are the floor; custom policies layer on org rules.
+2. **Templates** — directory of MiniJinja files (Jinja2-compatible, not full Jinja2 — auto-escaping is off by default since v0.24.x and loop `break`/`continue` are supported) plus a `weaver.yaml` per target language describing which templates to run, with what filter, in what `application_mode`, and with what output filename.
+3. **Policies** — Rego rules evaluated by the Regorus (OPA-compatible) engine, in four packages: `before_resolution` (raw parsed groups), `after_resolution` (resolved registry), `comparison_after_resolution` (only when `--baseline-registry` is passed), and `live_check_advice` (per-sample during `live-check`). Built-in OTel policies are the floor; custom policies layer on org rules.
 
 These three replace a hand-rolled `const.go` (or equivalent): const blocks become the registry, the act of writing them becomes codegen, and tribal knowledge becomes policies.
 
@@ -43,6 +43,8 @@ These three replace a hand-rolled `const.go` (or equivalent): const blocks becom
 3. **Author templates.** One target dir per language under `templates/registry/<lang>/` with `weaver.yaml` plus `*.j2`. See `references/template-authoring.md`.
 4. **Validate and generate.** `weaver registry check -r ./telemetry/registry/` for fast feedback. `weaver registry generate --registry ./telemetry/registry/ --templates ./telemetry/templates/ <lang> <output-dir>` for codegen. Run the language formatter on the output.
 5. **Wire into CI.** Three gates: `check` (schema), `generate` + `git diff --exit-code` (checked-in code is current), `diff` against the base branch (surfaces breaking changes). See `references/ci-integration.md`.
+
+The Weaver CLI has more subcommands than this workflow touches: `stats` and `json-schema` for quick registry sanity checks, `update-markdown` for keeping semconv snippets in docs current, `emit`/`live-check`/`infer` for working against live OTLP telemetry, `mcp` for exposing a registry to LLM tooling, and `serve` for an HTTP+UI mode. All are out of scope here (see below) but worth knowing exist before assuming `check`/`generate`/`diff` is the whole surface.
 
 ## Gotchas
 
@@ -75,7 +77,8 @@ These cost time and are not obvious from the upstream docs:
 These are natural follow-ups but not part of this skill:
 - publishing the registry as a versioned artifact for downstream consumers
 - declaring upstream semantic-conventions as a manifest dependency
-- `weaver registry live-check` against a local collector
+- `weaver registry live-check`/`emit`/`infer` against live OTLP telemetry
+- `weaver registry mcp` / `weaver serve`
 - custom Rego policies beyond the built-ins
 - helper-function codegen (`MyMetricName(meter)` wrappers)
 

--- a/skills/otel-weaver/references/registry-authoring.md
+++ b/skills/otel-weaver/references/registry-authoring.md
@@ -126,6 +126,22 @@ Notes:
 - Upstream OTel HTTP/db/messaging spans use `{action} {target}` patterns derived from attributes — those should not appear in an org-local registry.
 - `sampling_relevant: true` flags attributes that the SDK should make available at sampling time.
 
+## Entities
+
+```yaml
+file_format: definition/2
+
+entities:
+  - id: ecommerce.warehouse
+    stability: development
+    brief: "A physical or virtual warehouse fulfilling orders."
+    attributes:
+      - ref: ecommerce.warehouse.id
+        requirement_level: required
+```
+
+Entities describe resource-like things your telemetry is *about* (was called `resource` before v0.15.0 — use `entity` now). Most application registries won't need one: OTel's built-in resource entities (`service`, `host`, `k8s.*`, ...) already cover the common cases. Add an org-local entity only when you have a first-class domain concept that spans can attach attributes to but that isn't itself a span, metric, or event.
+
 ## What does NOT belong in your local registry
 
 Boundary domains owned by upstream OTel semconv:

--- a/skills/otel-weaver/references/template-authoring.md
+++ b/skills/otel-weaver/references/template-authoring.md
@@ -81,7 +81,7 @@ templates:
 
 Notes:
 - `application_mode: single` renders the template once with the filter result bound to `ctx`.
-- Bundled jq filters live in [`defaults/jq/semconv.jq`](https://github.com/open-telemetry/weaver/blob/main/defaults/jq/semconv.jq) in the Weaver repo. In v0.24.2, released grouped helpers are `semconv_grouped_attributes`, `semconv_grouped_metrics`, `semconv_grouped_spans`, and `semconv_grouped_events` (all barewords).
+- Bundled jq filters live in [`defaults/jq/semconv.jq`](https://github.com/open-telemetry/weaver/blob/main/defaults/jq/semconv.jq) in the Weaver repo. In v0.24.2, released grouped helpers are `semconv_grouped_attributes`, `semconv_grouped_metrics`, `semconv_grouped_spans`, `semconv_grouped_events`, and `semconv_grouped_entities` (all barewords).
 - **Single-quote only raw jq expressions.** The `semconv_grouped_*` helpers are barewords and need no quoting. If you write a custom multi-clause jq expression, single-quote it — colons in jq syntax otherwise collide with YAML mapping rules (`mapping values are not allowed in this context`).
 - `acronyms` shapes how `pascal_case_const` and similar filters split words.
 - `comment_formats` lets `comment(format="go")` know what comment prefix to emit.
@@ -152,6 +152,14 @@ const (
 - `comment(format="go")`: emits a comment with the configured prefix. Already includes `// `; do not double-prefix.
 - `pascal_case_const`: converts `ecommerce.order.id` → `EcommerceOrderId`. Honors the `acronyms` list.
 - `replace("a", "b")`: literal replace; useful for stripping the `span.` prefix from resolved span ids.
+
+Weaver ships more MiniJinja filters/tests/functions than any one template needs — reach for these instead of hand-rolling string manipulation in a template:
+
+- **Case filters**: `snake_case`, `camel_case`, `pascal_case`, `screaming_snake_case`, `kebab_case`, `acronym`, `pascal_case_const` (all honor the `acronyms` list from `weaver.yaml`).
+- **Other filters**: `map_text` (looks up a value in a `text_maps` table from `weaver.yaml`, e.g. `attr.type | map_text("go_types")`), `attribute_sort`, `required`, `not_required`, `instantiated_type`, `enum_type`, `body_fields`, `prometheus_metric_name`, `prometheus_unit_name`, plus ANSI color filters (rarely needed outside CLI output templates).
+- **Tests**: `stable`, `experimental`, `deprecated`, `enum`, `simple_type`, `template_type`, `enum_type`, `array` — e.g. `{% if attr is deprecated %}`.
+- **Functions**: `concat_if(...)`, `now()`.
+- **Loop controls**: `break`/`continue` are supported inside `{% for %}` loops (a MiniJinja extension beyond stock Jinja2).
 
 ## Generation
 


### PR DESCRIPTION
## Summary
- Compared this skill against a separate, more CLI/architecture-exhaustive Weaver skill and verified discrepancies against the upstream `open-telemetry/weaver` repo (README/CHANGELOG/docs as of v0.24.2) before changing anything.
- Fixes terminology (MiniJinja, not full Jinja2) and fills a few verified content gaps: Rego policy packages/engine, wider CLI surface awareness, MiniJinja filter/test/function reference, `semconv_grouped_entities`, and an `entities` registry section (previously named in the mental model but never documented).
- No workflow/scope changes — the skill's out-of-scope boundary (registry authoring/codegen/CI for adopters, not live-check/mcp/infer/serve) is preserved and made explicit for the newly-mentioned commands.

## Test plan
- [x] Read through `SKILL.md`, `references/registry-authoring.md`, `references/template-authoring.md` after editing to confirm consistency with existing content and formatting
- [ ] Maintainer sanity-check against a local Weaver install if desired (no registry/CI changes here, docs only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Weaver templates, policies, workflow commands, and out-of-scope features.
  * Added guidance and examples for defining registry entities.
  * Documented grouped entity helpers, additional MiniJinja filters and functions, and loop controls.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->