### PR TITLE
docs(otel-weaver): fill gaps found vs. a broader Weaver skill

### DIFF
--- a/skills/otel-weaver/SKILL.md
+++ b/skills/otel-weaver/SKILL.md
@@ -22,8 +22,8 @@ If a companion skill is unavailable:
 Three moving parts:
 
 1. **Registry** — directory of YAML files. `manifest.yaml` is required; its `schema_url` (OTel schema URL format, `http[s]://host/path/<version>`) both names the registry and carries its version in the final path segment. Dependency entries also use `schema_url` plus optional `registry_path`. The rest declare `attributes`, `metrics`, `spans`, `events`, `entities`. The version segment of `schema_url` is yours to manage; bump it on changes. (`name`, `semconv_version`, and `schema_base_url` are legacy/deprecated in favor of `schema_url`.)
-2. **Templates** — directory of Jinja2 files plus a `weaver.yaml` per target language describing which templates to run, with what filter, in what `application_mode`, and with what output filename.
-3. **Policies** — Rego rules. Built-in OTel policies are the floor; custom policies layer on org rules.
+2. **Templates** — directory of MiniJinja files (Jinja2-compatible, not full Jinja2 — auto-escaping is off by default since v0.24.x and loop `break`/`continue` are supported) plus a `weaver.yaml` per target language describing which templates to run, with what filter, in what `application_mode`, and with what output filename.
+3. **Policies** — Rego rules evaluated by the Regorus (OPA-compatible) engine, in four packages: `before_resolution` (raw parsed groups), `after_resolution` (resolved registry), `comparison_after_resolution` (only when `--baseline-registry` is passed), and `live_check_advice` (per-sample during `live-check`). Built-in OTel policies are the floor; custom policies layer on org rules.
 
 These three replace a hand-rolled `const.go` (or equivalent): const blocks become the registry, the act of writing them becomes codegen, and tribal knowledge becomes policies.
 
@@ -43,6 +43,8 @@ These three replace a hand-rolled `const.go` (or equivalent): const blocks becom
 3. **Author templates.** One target dir per language under `templates/registry/<lang>/` with `weaver.yaml` plus `*.j2`. See `references/template-authoring.md`.
 4. **Validate and generate.** `weaver registry check --v2 -r ./telemetry/registry/` for fast feedback. `weaver registry generate --v2 --registry ./telemetry/registry/ --templates ./telemetry/templates/ <lang> <output-dir>` for codegen. Run the language formatter on the output.
 5. **Wire into CI.** Three gates: `check` (schema), `generate` + `git diff --exit-code` (checked-in code is current), `diff` against the base branch (surfaces breaking changes). See `references/ci-integration.md`.
+
+The Weaver CLI has more subcommands than this workflow touches: `stats` and `json-schema` for quick registry sanity checks, `update-markdown` for keeping semconv snippets in docs current, `emit`/`live-check`/`infer` for working against live OTLP telemetry, `mcp` for exposing a registry to LLM tooling, and `serve` for an HTTP+UI mode. All are out of scope here (see below) but worth knowing exist before assuming `check`/`generate`/`diff` is the whole surface.
 
 ## Gotchas
 
@@ -75,7 +77,8 @@ These cost time and are not obvious from the upstream docs:
 These are natural follow-ups but not part of this skill:
 - publishing the registry as a versioned artifact for downstream consumers
 - declaring upstream semantic-conventions as a manifest dependency
-- `weaver registry live-check` against a local collector
+- `weaver registry live-check`/`emit`/`infer` against live OTLP telemetry
+- `weaver registry mcp` / `weaver serve`
 - custom Rego policies beyond the built-ins
 - helper-function codegen (`MyMetricName(meter)` wrappers)
 

--- a/skills/otel-weaver/SKILL.md
+++ b/skills/otel-weaver/SKILL.md
@@ -21,7 +21,7 @@ If a companion skill is unavailable:
 
 Three moving parts:
 
-1. **Registry** — directory of YAML files. `manifest.yaml` is required; its `schema_url` (OTel schema URL format, `http[s]://host/path/<version>`) both names the registry and carries its version in the final path segment. Dependency entries also use `schema_url` plus optional `registry_path`. The rest declare `attributes`, `metrics`, `spans`, `events`, `entities`. The version segment of `schema_url` is yours to manage; bump it on changes. (`name`, `semconv_version`, and `schema_base_url` are legacy/deprecated in favor of `schema_url`.)
+1. **Registry** — directory of YAML files. `manifest.yaml` is required; its `schema_url` (OTel schema URL format, `http[s]://host/path/<version>`) both names the registry and carries its version in the final path segment. Dependency entries also use `schema_url` plus optional `registry_path`. The rest declare `attributes`, `metrics`, `spans`, `events`, `entities`. The version segment of `schema_url` is yours to manage; bump it on changes. (`semconv_version` and `schema_base_url` are deprecated in favor of `schema_url`; top-level `name` is not a v0.24.2 manifest field.)
 2. **Templates** — directory of MiniJinja files (Jinja2-compatible, not full Jinja2 — auto-escaping is off by default since v0.24.x and loop `break`/`continue` are supported) plus a `weaver.yaml` per target language describing which templates to run, with what filter, in what `application_mode`, and with what output filename.
 3. **Policies** — Rego rules evaluated by the Regorus (OPA-compatible) engine, in four packages: `before_resolution` (raw parsed groups), `after_resolution` (resolved registry), `comparison_after_resolution` (only when `--baseline-registry` is passed), and `live_check_advice` (per-sample during `live-check`). Built-in OTel policies are the floor; custom policies layer on org rules.
 
@@ -31,7 +31,7 @@ These three replace a hand-rolled `const.go` (or equivalent): const blocks becom
 
 - Install Weaver via one of the methods documented at <https://github.com/open-telemetry/weaver#install> (release binary, `otel/weaver:vX.Y.Z` Docker image, or the `setup-weaver` GitHub Action). Never `brew install weaver` — that resolves to an unrelated Scribd tool.
 - Reference upstream semconv attributes by `ref` rather than redeclaring them. Boundary domains (`http`, `db`, `messaging`, `rpc`, `network`, `gen-ai`, ...) belong in upstream OTel semconv, not in a local registry. Use the language SDK's semconv package for those at runtime.
-- Every entry needs `stability`. Weaver refuses to generate without it.
+- Every attribute and signal definition needs `stability`; include it on enum members too, as required by the v2 syntax guide. Weaver v0.24.2 rejects missing definition stability but does not enforce enum-member stability.
 - Use a domain prefix (e.g. `ecommerce.`, `acme.`) for org-local attributes, metrics, and spans.
 - Run the language formatter (`gofmt -w`, `prettier`, `ruff format`, ...) on generated output. Jinja whitespace produces multiple blank lines; without formatting, the diff check in CI will fail spuriously.
 - Confirm the resolved schema shape before writing a template. For a `definition/2` registry, call the grouped jq helpers with `{"v2": true}`; the v2 template `ctx` preserves fields such as attribute `key`, metric `name`, span `type`/`kind`, and structured `span.name.note`. See `references/template-authoring.md` for how to dump the exact shape.
@@ -39,7 +39,7 @@ These three replace a hand-rolled `const.go` (or equivalent): const blocks becom
 ## Workflow
 
 1. **Install or locate Weaver.** Follow the upstream install instructions at <https://github.com/open-telemetry/weaver#install> — pick a pinned release binary, the `otel/weaver:vX.Y.Z` Docker image, or the `setup-weaver` GitHub Action. Use Docker for CI and reproducible local runs.
-2. **Author the registry.** Required: `manifest.yaml` plus at least one of `attributes.yaml` / `metrics.yaml` / `spans.yaml` / `events.yaml`. See `references/registry-authoring.md`.
+2. **Author the registry.** Required: `manifest.yaml` plus one or more `definition/2` YAML files declaring attributes, attribute groups, metrics, spans, events, or entities. See `references/registry-authoring.md`.
 3. **Author templates.** One target dir per language under `templates/registry/<lang>/` with `weaver.yaml` plus `*.j2`. See `references/template-authoring.md`.
 4. **Validate and generate.** `weaver registry check --v2 -r ./telemetry/registry/` for fast feedback. `weaver registry generate --v2 --registry ./telemetry/registry/ --templates ./telemetry/templates/ <lang> <output-dir>` for codegen. Run the language formatter on the output.
 5. **Wire into CI.** Three gates: `check` (schema), `generate` + `git diff --exit-code` (checked-in code is current), `diff` against the base branch (surfaces breaking changes). See `references/ci-integration.md`.
@@ -60,8 +60,8 @@ These cost time and are not obvious from the upstream docs:
 8. CLI argument ordering for `generate`: target directory name is positional **after** `--registry` and `--templates`; the output directory follows. `--templates` points at the **parent** that contains target dirs, not at the language-specific subdir.
 9. Span name in registry vs. runtime: required schema fields are `type`, `kind` (`client`/`server`/`producer`/`consumer`/`internal`), `brief`, `stability`, and a structured `name: { note: "..." }`. For internal business spans, putting the dotted type identifier in `name.note` and rendering the resolved `span.name.note` string at runtime is clean.
 10. **What does NOT belong in your local registry.** DB, HTTP, messaging, RPC, network, GenAI, and similar boundary spans/attributes follow upstream OTel semconv. Until upstream is pulled in as a manifest dependency, instrumentation for those should reference the language SDK's semconv package directly. This is the most common modeling mistake.
-11. Drop the `.total` suffix from counter names — OTel naming has moved away from it.
-12. Use seconds (`s`) for duration histograms, not milliseconds. Migrating from `ms` is a natural step when authoring the schema; flag it.
+11. Counter and UpDownCounter names should not append `_total`; this is the current semconv v1.43.0 naming rule.
+12. Duration instruments should use seconds (`s`) under the current semconv v1.43.0 unit guidance.
 
 ## References To Load On Demand
 
@@ -97,10 +97,10 @@ Report the final check with:
 
 Use these items:
 - registry has `manifest.yaml` with a `schema_url` whose final path segment is the version
-- every entry has `stability`
+- every definition and enum member has `stability`
 - org-local attributes/metrics/spans use a domain prefix
 - no boundary-domain (http/db/messaging/rpc/network/gen-ai) entries duplicated locally
-- counter names have no `.total` suffix
+- Counter and UpDownCounter names have no `_total` suffix
 - duration histograms use `s` (seconds)
 - templates use jq filters that match the resolved schema (for `definition/2`, call the prebuilt `semconv_grouped_*` helpers with `{"v2": true}`)
 - generated output is formatter-clean

--- a/skills/otel-weaver/references/migration-playbook.md
+++ b/skills/otel-weaver/references/migration-playbook.md
@@ -30,7 +30,7 @@ Build the four files:
 See `references/registry-authoring.md` for field reference and a working sample.
 
 While moving entries, normalize:
-- counter names: drop `.total`
+- Counter and UpDownCounter names: drop an appended `_total`
 - duration histograms: convert `ms` → `s` and rescale bucket boundaries (e.g. `0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5`)
 - enum-shaped strings: declare them as enum types so consumers see allowed values
 
@@ -88,4 +88,4 @@ See `references/ci-integration.md`. Ship the workflow in the same PR as the migr
 - `weaver registry generate --v2` followed by the language formatter leaves `git diff --exit-code` clean
 - the application builds and tests pass
 - a sample trace shows org-local span names and attributes from the generated symbols
-- a sample metric shows the renamed/rescaled units and no leftover `.total` suffix
+- a sample metric shows the renamed/rescaled units and no leftover `_total` suffix

--- a/skills/otel-weaver/references/registry-authoring.md
+++ b/skills/otel-weaver/references/registry-authoring.md
@@ -10,7 +10,8 @@ telemetry/registry/
 ├── attributes.yaml        # optional
 ├── metrics.yaml           # optional
 ├── spans.yaml             # optional
-└── events.yaml            # optional
+├── events.yaml            # optional
+└── entities.yaml          # optional
 ```
 
 Files other than `manifest.yaml` are discovered by their `file_format: definition/2` header and the top-level array key (`attributes`, `metrics`, `spans`, ...).
@@ -25,7 +26,7 @@ description: "Telemetry conventions for the ecommerce monolith"
 stability: development
 ```
 
-`schema_url` is required and must follow the OTel schema URL format `http[s]://host/path/<version>`. The registry name is derived from the path (`example.com/schemas/ecommerce`) and the version from the final segment (`0.1.0`) — bump that segment on any schema change. Pick a stable URL even if it does not yet resolve. `description`, `stability`, and `dependencies` are optional. Dependency entries require `schema_url` and may add `registry_path` for the local, archive, or Git location. (The older `name` and `semconv_version`/`schema_base_url` fields are legacy/deprecated in favor of `schema_url`.)
+`schema_url` is required and must follow the OTel schema URL format `http[s]://host/path/<version>`. The registry name is derived from the path (`example.com/schemas/ecommerce`) and the version from the final segment (`0.1.0`) — bump that segment on any schema change. Pick a stable URL even if it does not yet resolve. `description`, `stability`, and `dependencies` are optional. Dependency entries require `schema_url` and may add `registry_path` for the local, archive, or Git location. The older top-level `semconv_version`/`schema_base_url` pair is deprecated; top-level `name` is not a v0.24.2 manifest field. Dependencies may still accept legacy `name`, but use `schema_url`.
 
 ## Attributes
 
@@ -69,7 +70,7 @@ attributes:
 Notes:
 - Required fields: `key`, `type`, `stability`, `brief`.
 - Primitive `type` values: `string`, `int`, `double`, `boolean`, plus their `[]` array variants.
-- Enum types use the `members` form. Semantic-convention enums are open by definition — values outside the listed `id`s are allowed (the removed `allow_custom_values` flag no longer applies). The member `value` type (`string`/`int`/`boolean`) determines the attribute type.
+- Enum types use the `members` form. Semantic-convention enums are open by definition — values outside the listed `id`s are allowed (the removed `allow_custom_values` flag no longer applies). The member `value` type (`string`/`int`/`boolean`) determines the attribute type. The v2 syntax guide requires member `stability`, although Weaver v0.24.2 does not enforce it.
 - Provide `examples` for non-enum strings; it improves generated docs and helps reviewers.
 
 ## Metrics
@@ -82,6 +83,7 @@ metrics:
     instrument: histogram
     unit: s
     stability: stable
+    requirement_level: recommended
     brief: "End-to-end duration of processing a single order."
     attributes:
       - ref: ecommerce.payment.method
@@ -93,19 +95,22 @@ metrics:
     instrument: updowncounter
     unit: "{order}"
     stability: stable
+    requirement_level: recommended
     brief: "Number of orders currently being processed."
 
   - name: ecommerce.products.inventory.value
     instrument: gauge
     unit: "USD"
     stability: stable
+    requirement_level: recommended
     brief: "Current value of products currently in stock, in USD."
 ```
 
 Notes:
 - `instrument` is one of `counter`, `updowncounter`, `histogram`, `gauge`.
-- Counter names: drop the `.total` suffix.
-- Duration histograms: use `s`. Bucket boundaries scale accordingly (e.g. `0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5`).
+- Counter and UpDownCounter names should not append `_total`.
+- Duration instruments should use `s`. Bucket boundaries scale accordingly (e.g. `0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5`).
+- Signal-level `requirement_level` is `recommended` or `opt_in`; it defaults to `recommended`, but spelling it out avoids the v0.24.2 future-validation warning. This field is separate from each attribute reference's requirement level.
 - `attributes:` here are by `ref` only. Declare attributes once in `attributes.yaml` and reference them across metrics, spans, and events.
 
 ## Spans
@@ -117,6 +122,7 @@ spans:
   - type: ecommerce.order.process
     kind: internal
     stability: stable
+    requirement_level: recommended
     name:
       note: "ecommerce.order.process"
     brief: "Process a single customer order end-to-end."
@@ -137,6 +143,7 @@ Notes:
 - For internal business spans with static names, put the dotted type identifier in `name.note` and render the resolved `span.name.note` string at runtime.
 - Upstream OTel HTTP/db/messaging spans use `{action} {target}` patterns derived from attributes — those should not appear in an org-local registry.
 - `sampling_relevant: true` flags attributes that the SDK should make available at sampling time.
+- Signal-level `requirement_level` is also available on events and entities.
 
 ## Entities
 

--- a/skills/otel-weaver/references/registry-authoring.md
+++ b/skills/otel-weaver/references/registry-authoring.md
@@ -138,6 +138,22 @@ Notes:
 - Upstream OTel HTTP/db/messaging spans use `{action} {target}` patterns derived from attributes — those should not appear in an org-local registry.
 - `sampling_relevant: true` flags attributes that the SDK should make available at sampling time.
 
+## Entities
+
+```yaml
+file_format: definition/2
+
+entities:
+  - id: ecommerce.warehouse
+    stability: development
+    brief: "A physical or virtual warehouse fulfilling orders."
+    attributes:
+      - ref: ecommerce.warehouse.id
+        requirement_level: required
+```
+
+Entities describe resource-like things your telemetry is *about* (was called `resource` before v0.15.0 — use `entity` now). Most application registries won't need one: OTel's built-in resource entities (`service`, `host`, `k8s.*`, ...) already cover the common cases. Add an org-local entity only when you have a first-class domain concept that spans can attach attributes to but that isn't itself a span, metric, or event.
+
 ## What does NOT belong in your local registry
 
 Boundary domains owned by upstream OTel semconv:

--- a/skills/otel-weaver/references/template-authoring.md
+++ b/skills/otel-weaver/references/template-authoring.md
@@ -86,8 +86,8 @@ templates:
 
 Notes:
 - `application_mode: single` renders the template once with the filter result bound to `ctx`.
-- Bundled jq filters live in [`defaults/jq/semconv.jq`](https://github.com/open-telemetry/weaver/blob/main/defaults/jq/semconv.jq) in the Weaver repo. In v0.24.2, released grouped helpers are `semconv_grouped_attributes`, `semconv_grouped_metrics`, `semconv_grouped_spans`, and `semconv_grouped_events`.
-- The no-argument helpers default to the legacy schema. For a `definition/2` registry, call them with `{"v2": true}`. Use a folded YAML scalar as above so the object colon is unambiguous to YAML.
+- Bundled jq filters live in [`defaults/jq/semconv.jq`](https://github.com/open-telemetry/weaver/blob/main/defaults/jq/semconv.jq) in the Weaver repo. In v0.24.2, released grouped helpers are `semconv_grouped_attributes`, `semconv_grouped_metrics`, `semconv_grouped_spans`, `semconv_grouped_events`, and `semconv_grouped_entities`.
+- The no-argument helpers default to the legacy schema. For a `definition/2` registry, call them with `{"v2": true}` (as shown above). Use a folded YAML scalar (`filter: >`) so the object's colon doesn't collide with YAML mapping syntax. A custom multi-clause jq expression that takes no arguments should be single-quoted instead — for the same reason.
 - `acronyms` shapes how `pascal_case_const` and similar filters split words.
 - `comment_formats` lets `comment(format="go")` know what comment prefix to emit.
 
@@ -156,6 +156,14 @@ const (
 
 - `comment(format="go")`: emits a comment with the configured prefix. Already includes `// `; do not double-prefix.
 - `pascal_case_const`: converts `ecommerce.order.id` → `EcommerceOrderId`. Honors the `acronyms` list.
+
+Weaver ships more MiniJinja filters/tests/functions than any one template needs — reach for these instead of hand-rolling string manipulation in a template:
+
+- **Case filters**: `snake_case`, `camel_case`, `pascal_case`, `screaming_snake_case`, `kebab_case`, `acronym`, `pascal_case_const` (all honor the `acronyms` list from `weaver.yaml`).
+- **Other filters**: `map_text` (looks up a value in a `text_maps` table from `weaver.yaml`, e.g. `attr.type | map_text("go_types")`), `attribute_sort`, `required`, `not_required`, `instantiated_type`, `enum_type`, `body_fields`, `prometheus_metric_name`, `prometheus_unit_name`, plus ANSI color filters (rarely needed outside CLI output templates).
+- **Tests**: `stable`, `experimental`, `deprecated`, `enum`, `simple_type`, `template_type`, `enum_type`, `array` — e.g. `{% if attr is deprecated %}`.
+- **Functions**: `concat_if(...)`, `now()`.
+- **Loop controls**: `break`/`continue` are supported inside `{% for %}` loops (a MiniJinja extension beyond stock Jinja2).
 
 ## Generation
 

--- a/skills/otel-weaver/references/template-authoring.md
+++ b/skills/otel-weaver/references/template-authoring.md
@@ -86,7 +86,7 @@ templates:
 
 Notes:
 - `application_mode: single` renders the template once with the filter result bound to `ctx`.
-- Bundled jq filters live in [`defaults/jq/semconv.jq`](https://github.com/open-telemetry/weaver/blob/main/defaults/jq/semconv.jq) in the Weaver repo. In v0.24.2, released grouped helpers are `semconv_grouped_attributes`, `semconv_grouped_metrics`, `semconv_grouped_spans`, `semconv_grouped_events`, and `semconv_grouped_entities`.
+- Bundled jq filters live in [`defaults/jq/semconv.jq`](https://github.com/open-telemetry/weaver/blob/main/defaults/jq/semconv.jq) in the Weaver repo. In v0.24.2, released grouped helpers are `semconv_grouped_attributes`, `semconv_grouped_metrics`, `semconv_grouped_spans`, and `semconv_grouped_events`. Entities are valid `definition/2` registry content, but v0.24.2 does not ship a `semconv_grouped_entities` helper; use a custom jq filter when generating entity code.
 - The no-argument helpers default to the legacy schema. For a `definition/2` registry, call them with `{"v2": true}` (as shown above). Use a folded YAML scalar (`filter: >`) so the object's colon doesn't collide with YAML mapping syntax. A custom multi-clause jq expression that takes no arguments should be single-quoted instead — for the same reason.
 - `acronyms` shapes how `pascal_case_const` and similar filters split words.
 - `comment_formats` lets `comment(format="go")` know what comment prefix to emit.
@@ -193,4 +193,4 @@ Equivalents: `prettier -w`, `ruff format`, `rustfmt`, etc.
 
 ## Inspecting the resolved schema
 
-`scripts/inspect-resolved.sh` wraps `weaver registry resolve` and pretty-prints with `jq`. Useful for a quick raw dump, but note `resolve` is deprecated and its raw shape is pre-filter — to see the exact fields a template gets, dump `{{ ctx | tojson }}` through the real `semconv_grouped_*` filter as shown at the top of this file.
+`scripts/inspect-resolved.sh` wraps `weaver registry resolve --v2` and pretty-prints with `jq`. Useful for a quick raw v2 dump, but note `resolve` is deprecated and its raw shape is pre-filter — to see the exact fields a template gets, dump `{{ ctx | tojson }}` through the real `semconv_grouped_*` filter as shown at the top of this file.

--- a/skills/otel-weaver/scripts/inspect-resolved.sh
+++ b/skills/otel-weaver/scripts/inspect-resolved.sh
@@ -2,7 +2,7 @@
 # Resolve a Weaver registry to JSON and pretty-print a slice with jq.
 #
 # Use this for a quick raw dump of the resolved schema. Note: `weaver registry
-# resolve` is deprecated (still works; errors under --future), and its raw shape
+# resolve --v2` is deprecated (still works; errors under --future), and its raw shape
 # is PRE-filter — it differs from the `ctx` a template receives via the
 # semconv_grouped_* jq helpers. To see the exact template fields, render
 # {{ ctx | tojson }} through the real filter (see references/template-authoring.md).
@@ -12,7 +12,7 @@
 #
 # Examples:
 #   inspect-resolved.sh ./telemetry/registry/
-#   inspect-resolved.sh ./telemetry/registry/ '.groups[] | select(.type=="span")'
+#   inspect-resolved.sh ./telemetry/registry/ '.registry.spans[]'
 #   inspect-resolved.sh ./telemetry/registry/ 'semconv_grouped_attributes'   # not supported here; jq only
 
 set -euo pipefail
@@ -39,6 +39,6 @@ fi
 tmp="$(mktemp -t weaver-resolved.XXXXXX.json)"
 trap 'rm -f "$tmp"' EXIT
 
-"$WEAVER" registry resolve -r "$REGISTRY" -f json -o "$tmp" >/dev/null
+"$WEAVER" registry resolve --v2 -r "$REGISTRY" -f json -o "$tmp" >/dev/null
 
 jq "$FILTER" "$tmp"


### PR DESCRIPTION
## Summary

This PR now combines the original in-scope Weaver coverage additions with the periodic released-version refresh:

- Clarifies MiniJinja behavior, the four Rego policy packages, the wider CLI surface, and entity registry authoring.
- Adds the released template filter/test/function reference.
- Corrects the v0.24.2 manifest schema, signal `requirement_level`, stability enforcement, and metric `_total` naming.
- Fixes `inspect-resolved.sh` to pass `--v2` for `definition/2` registries.
- Corrects the helper catalog: entities are valid registry content, but v0.24.2 does **not** ship `semconv_grouped_entities`; entity code generation requires a custom jq filter.

## Verification

- Exact `otel/weaver:v0.24.2` image: registry check, generate, diff, and resolve.
- Corrected inspection script returned the expected v2 `{type, kind, name.note}` shape.
- Generated Go output passed formatting and compilation.
- Exact v0.24.2 `defaults/jq/semconv.jq` contains grouped helpers for attributes, metrics, spans, and events, but not entities.
- `skills-ref validate skills/otel-weaver`.
- 15-skill registration, shell syntax, release-path checks, and `git diff --check`.

## Harness note

The original same-model comparison correctly exposed stale legacy entity syntax and an uncertain acronym configuration. Its with-skill result also asserted `semconv_grouped_entities`; exact released-source and image verification disproved that assertion. The branch now explicitly documents the released limitation rather than preserving a harness-derived false claim.

## Deliberately excluded

- Main-only `semconv_grouped_entities`, TOML/config customization, `live-check --fail-on`, v2 infer/refinement/dependency work, enum defaults, and unrelated commands.
- No unreleased facts were promoted into the skill.

## Agent involvement

The original additions were agent-authored and human-owned. The periodic refresh and released-artifact corrections were also agent-authored; the repository maintainer remains responsible for the PR.

## Checklist

- [x] `skills-ref validate skills/otel-weaver`
- [x] Registration validation
- [x] Vendor-neutral, non-opinionated, DRY, and token-efficient
- [x] Conventional commits
- [x] Agent involvement disclosed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenTelemetry Weaver guidance for v2 registry, template, policy, and workflow conventions.
  * Clarified schema URL usage, stability requirements, requirement levels, entity definitions, and metric naming rules.
  * Expanded authoring guidance for templates, filters, registry inspection, and supported CLI scope.
  * Updated the migration playbook with current counter naming normalization.
* **Tools**
  * Registry inspection now uses v2 resolution behavior for improved schema compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->