### PR TITLE
docs(otel-browser): correct released browser guidance

### DIFF
--- a/skills/otel-browser/SKILL.md
+++ b/skills/otel-browser/SKILL.md
@@ -9,10 +9,11 @@ Entry point for OpenTelemetry mechanics in web apps. Load a reference below base
 each reference is self-contained.
 
 > **Stability**: Browser/RUM is one of the **newest and most experimental** areas of OpenTelemetry.
-> Only the web *tracing* primitives (`@opentelemetry/sdk-trace-web`, `@opentelemetry/context-zone`)
-> and the JS API are **stable** today. The Browser SDK (`@opentelemetry/browser-sdk`) and the
-> event-based instrumentations are experimental and may break between minor versions — pin exact
-> versions. Verify current status via the Sources of Truth below.
+> Within the RUM packages covered here, the web *tracing* primitives
+> (`@opentelemetry/sdk-trace-web`, `@opentelemetry/context-zone`) and the JS API are **stable** today.
+> The Browser SDK (`@opentelemetry/browser-sdk`) and the event-based instrumentations are
+> experimental and may break between minor versions — pin exact versions. Verify current status
+> via the Sources of Truth below.
 
 ## References
 
@@ -20,13 +21,14 @@ each reference is self-contained.
 |---|---|
 | [`references/setup-sdk.md`](references/setup-sdk.md) | Wiring up the SDK: the direct providers (`WebTracerProvider` + `ZoneContextManager` for spans; `LoggerProvider` for events) vs the experimental `browser-sdk`, sessions, frontend→backend `traceparent`/CORS propagation, and why a Collector sits in front. |
 | [`references/instrumentation.md`](references/instrumentation.md) | Choosing and configuring instrumentations: the event-based catalog (navigation, web vitals, console, errors, …), the span-based catalog (fetch, XHR, document-load, long-task, …), per-instrumentation options, and what each captures. |
-| [`references/performance.md`](references/performance.md) | Keeping it cheap, fast, and private: bundle size, off-main-thread processing, page-lifecycle flushing, telemetry volume/cost, and PII vectors. |
+| [`references/performance.md`](references/performance.md) | Keeping it cheap, fast, and private: bundle size, bounded main-thread work, page-lifecycle flushing, telemetry volume/cost, and PII vectors. |
 
 ## Two telemetry models — read first
 
-Browser telemetry is modeled as **spans** and **events**; there is **no browser metrics story
-yet** (metrics are out of scope for the Browser SDK). Picking the right model per signal is the
-first decision:
+The experimental Browser SDK currently models browser telemetry as **spans** and **events**; it
+does not include metrics. The general JS `MeterProvider` and OTLP/HTTP metrics exporter do support
+browser builds, but metrics are outside this RUM catalog. Picking the right model for the signals
+covered here is the first decision:
 
 | Model | Signal | For | Examples |
 |---|---|---|---|
@@ -41,16 +43,17 @@ released convention under the `browser` group, and `exception` is a released **s
 its own (not under `browser`). Check coverage per signal rather than assuming it; before emitting a
 hand-written span or `LogRecord` with custom attributes:
 
-1. Prefer a catalog instrumentation from [`references/instrumentation.md`](references/instrumentation.md) — it already emits
-   compliant event/attribute names where a convention exists.
+1. Prefer a catalog instrumentation from [`references/instrumentation.md`](references/instrumentation.md), then verify its
+   released output shape against the convention; experimental implementations can lag a merged
+   convention (the released Web Vitals package currently does).
 2. Check whether a released convention covers the signal: use the `otel-semantic-conventions`
    skill to query the relevant group (e.g. `browser` for `event.browser.web_vital`, `exceptions`
    for `exception.type`), or WebFetch the matching page under
    `https://opentelemetry.io/docs/specs/semconv/browser/`.
-3. If one exists, use its event/attribute names verbatim (e.g. the `browser.web_vital` event's
-   `name`, `value`, `delta`, `id` — not a custom `web_vital.*` namespace), even at development
-   stability. If none exists, define bounded, low-cardinality custom attributes under a stable
-   namespace instead of guessing at a released-looking name.
+3. If one exists, use its event, body-field, and attribute names verbatim (e.g. the
+   `browser.web_vital` event's required map body has `name`, `value`, `delta`, and `id`), even at
+   development stability. If none exists, define bounded, low-cardinality custom attributes under
+   a stable namespace instead of guessing at a released-looking name.
 
 ## The browser package ecosystem — three repositories
 
@@ -64,7 +67,7 @@ are the authoritative, current map. Summary:
 | `@opentelemetry/context-zone` | opentelemetry-js | context | **stable** |
 | `@opentelemetry/instrumentation-fetch` | opentelemetry-js | spans | experimental |
 | `@opentelemetry/instrumentation-xml-http-request` | opentelemetry-js | spans | experimental |
-| `@opentelemetry/browser-detector` | opentelemetry-js | resource | experimental |
+| `@opentelemetry/opentelemetry-browser-detector` | opentelemetry-js | resource | experimental |
 | `@opentelemetry/browser-instrumentation` | opentelemetry-browser | events | experimental |
 | `@opentelemetry/browser-sdk` | opentelemetry-browser | SDK | experimental (0.x) |
 | `@opentelemetry/auto-instrumentations-web` | opentelemetry-js-contrib | bundle | experimental |

--- a/skills/otel-browser/references/instrumentation.md
+++ b/skills/otel-browser/references/instrumentation.md
@@ -33,11 +33,11 @@ resource-timing events are correlated automatically.
 
 ## Event-based instrumentations (`@opentelemetry/browser-instrumentation`)
 
-Entry points are subpath exports under `./experimental/*`; they emit through the global
-`LoggerProvider` (see [setup-sdk.md](setup-sdk.md#logger-provider-events)), so call
-`logs.setGlobalLoggerProvider(...)` **before** `registerInstrumentations`. (Span-based
-instrumentations resolve their tracer at registration time too — pass `tracerProvider` or register
-the provider globally first; see [setup-sdk.md](setup-sdk.md#register-the-instrumentations).)
+Entry points are subpath exports under `./experimental/*`. Set the global `LoggerProvider` before
+constructing them, because an enabled instrumentation can emit immediately; `registerInstrumentations`
+also accepts `loggerProvider` and rebinds each instrumentation at registration. (Span-based
+instrumentations are similarly rebound from `tracerProvider` or the then-current global provider;
+see [setup-sdk.md](setup-sdk.md#register-the-instrumentations).)
 
 ```typescript
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
@@ -84,8 +84,9 @@ lost if `load` never fires).
 
 One event per resource the page loads (scripts, CSS, images, fonts, XHR/fetch) from
 [PerformanceResourceTiming](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming).
-Stays off the main thread (`requestIdleCallback`, Safari `setTimeout` fallback), processes in
-batches, captures resources loaded before it was enabled (buffered), and flushes on visibility change.
+Defers processing to main-thread idle time (`requestIdleCallback`, Safari `setTimeout` fallback),
+works in batches, captures resources loaded before it was enabled (buffered), and flushes on
+visibility change.
 
 | Option | Type | Default | Description |
 |---|---|---|---|
@@ -112,11 +113,15 @@ conventions are **merged** (see the
 [WebVital event](https://opentelemetry.io/docs/specs/semconv/browser/browser-events/#webvital-event)).
 
 The released `browser.web_vital` event (development stability; verify via the
-`otel-semantic-conventions` skill, group `browser`, entry `event.browser.web_vital`) carries `name`,
-`value`, `delta`, and `id` — not a custom `web_vital.*` attribute namespace.
-`WebVitalsInstrumentation` already emits these correctly; if you must hand-write reporting (e.g. no
-`LoggerProvider`/instrumentation available), emit a `LogRecord` named `browser.web_vital` with those
-attributes rather than opening a span with invented keys.
+`otel-semantic-conventions` skill, group `browser`, entry `event.browser.web_vital`) requires a map
+**body** with `name`, `value`, `delta`, and `id`. These are body fields, not log attributes.
+
+`@opentelemetry/browser-instrumentation` 0.6.0 does not yet match that released shape: it uses the
+correct event name but emits `browser.web_vital.name`, `.value`, `.rating`, `.delta`, `.id`, and
+`.navigation_type` as attributes; `body` is only set to raw attribution when
+`includeRawAttribution` is enabled. Account for that package shape in queries or transform it at
+the pipeline edge. For strict semconv output from hand-written reporting, emit a `LogRecord` with
+`eventName: 'browser.web_vital'` and the four required fields in its map body.
 
 | Option | Type | Default | Description |
 |---|---|---|---|
@@ -226,6 +231,6 @@ The server must list `traceparent` (and `tracestate`/`baggage` if used) in
 | Putting PII in `data-otel-*` or URLs | Exported verbatim to your backend | Use `sanitizeUrl`; keep `data-otel-*` to non-PII business keys |
 | Tracing your own OTLP export calls | Infinite telemetry-about-telemetry loop | `ignoreUrls` the `/v1/traces` and `/v1/logs` endpoints |
 | Forcing spans around point-in-time facts | Wrong model; bloats traces | Use the event-based instrumentations for vitals/navigation/errors |
-| Hand-rolling event/span attributes without checking semconv | Invents non-standard keys (e.g. `web_vital.name`/`web_vital.value`) instead of the released event/attribute names | Check the `browser` group first via the `otel-semantic-conventions` skill or WebFetch the spec page — see [SKILL.md](../SKILL.md#verify-attributes-against-released-semantic-conventions-before-hand-rolling) |
+| Treating event body fields as attributes | Produces the wrong shape (the released Web Vitals convention requires a map body) | Check the full event definition, not only its name; account for the documented 0.6.0 implementation mismatch above |
 | Relying on navigation *timing* for page-view counts | Lost when `load` never fires / user leaves early | Use the navigation *event* for counts, timing for performance |
 | Assuming an instrumentation works because registration threw no error | These packages are experimental; a misconfigured or no-op instrumentation emits neither errors nor telemetry | Verify each one reaches the Collector (diag logging + `debug` exporter) — see [setup-sdk.md](setup-sdk.md#verify-it-actually-emits) |

--- a/skills/otel-browser/references/performance.md
+++ b/skills/otel-browser/references/performance.md
@@ -8,7 +8,7 @@ across all three.
 | Budget | Main levers |
 |---|---|
 | Bundle size | Tree-shaking, per-signal SDK imports, prefer events over spans, skip `zone.js` when you can |
-| Runtime cost | Off-main-thread processing, batch processors, idle callbacks |
+| Runtime cost | Idle-time scheduling, batch processors, bounded work per callback |
 | Telemetry volume/cost | Fewer instrumentations, restrict resource-timing, sampling, Collector-side trimming |
 | Privacy (PII) | URL sanitization, restrict console capture, redact in the Collector |
 
@@ -33,10 +33,10 @@ more so than for backend SDKs.
 
 ## Runtime cost (don't block the main thread)
 
-The main thread renders the page; telemetry must stay off it.
+The main thread renders the page; telemetry must minimize and bound work on it.
 
-- **Resource timing** already uses `requestIdleCallback` (Safari `setTimeout` fallback), processes in
-  batches, and bounds time per idle callback. Tune `batchSize`, `maxProcessingTime`, and
+- **Resource timing** defers work with `requestIdleCallback` (Safari `setTimeout` fallback), processes
+  in batches, and bounds time per callback. Tune `batchSize`, `maxProcessingTime`, and
   `maxQueueSize` if you load many resources. See
   [instrumentation.md](instrumentation.md#resource-timing-browserresource_timing).
 - **Always use the Batch processors** (`BatchSpanProcessor`, `BatchLogRecordProcessor`), never the

--- a/skills/otel-browser/references/setup-sdk.md
+++ b/skills/otel-browser/references/setup-sdk.md
@@ -1,7 +1,8 @@
 # Browser SDK setup
 
-Setting up OpenTelemetry in the browser for **traces (spans)** and **events (log records)**. There
-is no MeterProvider story in the browser yet.
+Setting up the Browser SDK's two signals: **traces (spans)** and **events (log records)**. The
+general JS SDK also supports a `MeterProvider` in browser builds, but metrics are not part of the
+experimental Browser SDK and are outside this RUM setup.
 
 > **Stability**: `@opentelemetry/browser-sdk` is experimental and on the 0.x line (first published as
 > `0.1.0`) — check the current version with `npm view @opentelemetry/browser-sdk version`. The most settled path today wires the providers
@@ -62,7 +63,7 @@ import { WebTracerProvider, BatchSpanProcessor } from '@opentelemetry/sdk-trace-
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
-// Merge with the default resource so `telemetry.sdk.*` (and any env-detected attributes)
+// Merge with the default resource so `telemetry.sdk.*` and the default `service.name`
 // are preserved. `resourceFromAttributes()` ALONE replaces the default resource and drops
 // them — telemetry then arrives with only the attributes you listed. Reuse this one
 // `resource` for BOTH the tracer and logger providers so spans and events correlate.
@@ -130,17 +131,21 @@ registerInstrumentations({
   // `provider.register()` ran BEFORE this call — register after, and they bind to the no-op
   // tracer and silently emit nothing.
   tracerProvider: provider,
+  // Registration can also bind the logger provider explicitly. Keep the global registration
+  // above as well because enabled browser instrumentations may emit during construction.
+  loggerProvider,
   instrumentations: [
     new FetchInstrumentation(),     // span-based → uses the tracer provider resolved here
-    new WebVitalsInstrumentation(), // event-based → uses the global LoggerProvider set above
+    new WebVitalsInstrumentation(), // event-based → rebound to loggerProvider at registration
   ],
 });
 ```
 
-**Order matters.** Each instrumentation resolves its tracer/logger when `registerInstrumentations`
-runs, so `provider.register()` and `logs.setGlobalLoggerProvider()` must run **before** it. Passing
-`tracerProvider` explicitly (above) removes the ordering dependency for spans; event-based
-instrumentations always read the global logger, so set that first regardless.
+**Order matters.** `registerInstrumentations` rebinds each instrumentation to the explicit provider
+or to the global provider visible at that call. Pass `tracerProvider` / `loggerProvider` explicitly
+as above, or register globals first. Also set the global logger before **constructing** enabled
+event instrumentations: some browser instrumentations can emit immediately, before registration has
+a chance to rebind them.
 
 ### Verify it actually emits
 
@@ -233,9 +238,9 @@ new FetchInstrumentation({
 
 - [ ] SDK initialized **before** app/framework code and before libraries patch globals
 - [ ] `service.name` (and ideally `service.version`) set as resource attributes
-- [ ] Resource built by merging the **default** resource (so `telemetry.sdk.*` survives), and the **same** resource passed to both the tracer and logger providers
+- [ ] Resource built by merging the **default** resource (so `telemetry.sdk.*` and the default `service.name` survive), and the **same** resource passed to both the tracer and logger providers
 - [ ] Exporting OTLP/**HTTP** to a Collector you control (not gRPC, not directly to a backend store)
-- [ ] Providers registered globally (`provider.register()`, `logs.setGlobalLoggerProvider()`) **before** `registerInstrumentations`, or `tracerProvider` passed to it explicitly — else span instrumentations resolve the no-op tracer
+- [ ] Providers passed explicitly to `registerInstrumentations`, or registered globally first; the global logger is set before constructing event instrumentations that may emit immediately
 - [ ] `ZoneContextManager` registered if you need trace context across async boundaries
 - [ ] `BatchSpanProcessor` / `BatchLogRecordProcessor` (not `Simple*`) for export efficiency
 - [ ] Session processor registered **before** the export processor
@@ -254,6 +259,6 @@ new FetchInstrumentation({
 | Flushing on `unload` | Unreliable on mobile/bfcache; blocks navigation | Flush on `visibilitychange`/`pagehide`; use browser OTLP export with `keepalive` when possible |
 | Session processor after the batch processor | Records exported before `session.id` is attached | Put the session processor first |
 | Shipping `sdk-trace-web` without a context manager | Async user interactions lose parent context | Register `ZoneContextManager` |
-| `resource: resourceFromAttributes({...})` as the whole resource | Replaces the default resource; drops `telemetry.sdk.*` and env-detected attributes | Merge: `defaultResource().merge(resourceFromAttributes({...}))` |
+| `resource: resourceFromAttributes({...})` as the whole resource | Replaces the default resource; drops `telemetry.sdk.*` and the default `service.name` | Merge: `defaultResource().merge(resourceFromAttributes({...}))` |
 | Building a `LoggerProvider` with no `resource` | Events carry no `service.name`; can't be attributed or correlated with spans | Pass the same merged resource to the logger provider |
-| `registerInstrumentations` running before `provider.register()` (and no explicit `tracerProvider`) | Span instrumentations resolve the no-op tracer at registration time and emit nothing | Register the provider (or pass `tracerProvider`) **before** registering instrumentations |
+| `registerInstrumentations` running before provider registration (and no explicit providers) | Instrumentations are rebound to no-op providers and emit nothing | Register globals first or pass `tracerProvider` / `loggerProvider`; set the global logger before constructing immediately-emitting event instrumentations |

--- a/skills/otel-browser/references/setup-sdk.md
+++ b/skills/otel-browser/references/setup-sdk.md
@@ -63,10 +63,10 @@ import { WebTracerProvider, BatchSpanProcessor } from '@opentelemetry/sdk-trace-
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
-// Merge with the default resource so `telemetry.sdk.*` and the default `service.name`
-// are preserved. `resourceFromAttributes()` ALONE replaces the default resource and drops
-// them — telemetry then arrives with only the attributes you listed. Reuse this one
-// `resource` for BOTH the tracer and logger providers so spans and events correlate.
+// Merge with the default resource so `telemetry.sdk.*` and other non-conflicting defaults
+// are preserved. The incoming explicit `service.name` overrides the default value.
+// `resourceFromAttributes()` ALONE drops every default attribute not listed here. Reuse this
+// one `resource` for BOTH the tracer and logger providers so spans and events correlate.
 const resource = defaultResource().merge(
   resourceFromAttributes({
     [ATTR_SERVICE_NAME]: 'my-web-app',
@@ -238,7 +238,7 @@ new FetchInstrumentation({
 
 - [ ] SDK initialized **before** app/framework code and before libraries patch globals
 - [ ] `service.name` (and ideally `service.version`) set as resource attributes
-- [ ] Resource built by merging the **default** resource (so `telemetry.sdk.*` and the default `service.name` survive), and the **same** resource passed to both the tracer and logger providers
+- [ ] Resource built by merging the **default** resource (so `telemetry.sdk.*` survives while the explicit `service.name` overrides the default), and the **same** resource passed to both the tracer and logger providers
 - [ ] Exporting OTLP/**HTTP** to a Collector you control (not gRPC, not directly to a backend store)
 - [ ] Providers passed explicitly to `registerInstrumentations`, or registered globally first; the global logger is set before constructing event instrumentations that may emit immediately
 - [ ] `ZoneContextManager` registered if you need trace context across async boundaries
@@ -259,6 +259,6 @@ new FetchInstrumentation({
 | Flushing on `unload` | Unreliable on mobile/bfcache; blocks navigation | Flush on `visibilitychange`/`pagehide`; use browser OTLP export with `keepalive` when possible |
 | Session processor after the batch processor | Records exported before `session.id` is attached | Put the session processor first |
 | Shipping `sdk-trace-web` without a context manager | Async user interactions lose parent context | Register `ZoneContextManager` |
-| `resource: resourceFromAttributes({...})` as the whole resource | Replaces the default resource; drops `telemetry.sdk.*` and the default `service.name` | Merge: `defaultResource().merge(resourceFromAttributes({...}))` |
+| `resource: resourceFromAttributes({...})` as the whole resource | Replaces the default resource; only explicitly listed attributes remain, so `telemetry.sdk.*` and other defaults are dropped | Merge so explicit attributes override collisions while other defaults remain: `defaultResource().merge(resourceFromAttributes({...}))` |
 | Building a `LoggerProvider` with no `resource` | Events carry no `service.name`; can't be attributed or correlated with spans | Pass the same merged resource to the logger provider |
 | `registerInstrumentations` running before provider registration (and no explicit providers) | Instrumentations are rebound to no-op providers and emit nothing | Register globals first or pass `tracerProvider` / `loggerProvider`; set the global logger before constructing immediately-emitting event instrumentations |


### PR DESCRIPTION
## Summary

- Correct browser metrics and provider-registration guidance.
- Document the released 0.6.0 Web Vitals semantic-convention mismatch.
- Fix the browser detector package name, default resource contents, and idle-scheduling behavior.

## Verification

- Checked browser instrumentation 0.6.0, Browser SDK 0.1.0, JS 2.9.0/0.220.0, and semconv 1.43.0.
- Exact released-package TypeScript compilation.
- `skills-ref validate skills/otel-browser`, registration, path/anchor checks, semantic-convention lookup, and `git diff --check`.

## Deliberately excluded

- Planned JS SDK 3.0 and unreleased js-contrib sdk-trace migration.
- New modules outside the existing skill scope.

Agent-authored periodic refresh; human-owned repository PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified browser tracing, event instrumentation, and experimental SDK stability guidance.
  * Updated setup instructions for correlating traces and events, provider registration, and resource preservation.
  * Refined Web Vitals guidance, including released output shapes, implementation differences, and common configuration pitfalls.
  * Documented Resource Timing’s idle-time processing, batching, buffering, and visibility-change flushing.
  * Updated performance recommendations to emphasize bounded main-thread work.
  * Corrected the browser resource-detector package reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->