### PR TITLE
docs(otel-collector): correct released routing guidance

### DIFF
--- a/skills/otel-collector/components/attributes/quirks.md
+++ b/skills/otel-collector/components/attributes/quirks.md
@@ -2,7 +2,7 @@
 
 ## Action order matters
 
-`actions` run strictly in the order listed, and each sees the result of the previous ones. A `delete` before a `from_attribute` copy removes the source first; an `insert` of a default before an `upsert` copy changes what gets copied. Order cheap actions (`delete`, `insert`) before expensive ones (`extract`, `convert`) when possible. Do **not** split related actions across two processor instances and rely on order between them — a temporary key created in `attributes/first` may not exist yet when `attributes/second` runs.
+`actions` run strictly in the order listed, and each sees the result of the previous ones. A `delete` before a `from_attribute` copy removes the source first; an `insert` of a default before an `upsert` copy changes what gets copied. Order cheap actions (`delete`, `insert`) before expensive ones (`extract`, `convert`) when possible. If related actions are split across named processor instances, their order in `service.pipelines.<signal>.processors` is likewise load-bearing: the later instance sees changes from the earlier one only when it is listed after it.
 
 ## It does NOT touch resource attributes
 

--- a/skills/otel-collector/components/otlp/README.md
+++ b/skills/otel-collector/components/otlp/README.md
@@ -20,7 +20,7 @@ The most important operational fact is the **default endpoint**: each protocol b
 Use when:
 - You need to ingest OTLP from OpenTelemetry SDKs, the OTel Collector `otlp` exporter, or any OTLP-native agent — the default and recommended Collector ingress.
 - You want one receiver to handle traces, metrics, and logs over gRPC, HTTP/protobuf, and HTTP/JSON.
-- You front a tier that needs per-request metadata (header-based auth, metadata routing, metadata-keyed load balancing) — set `include_metadata: true`.
+- You front a tier that needs per-request metadata **inside the downstream pipeline** (metadata routing, or `from_context: metadata.*` actions) — set `include_metadata: true`. Server authenticator extensions read transport headers directly and do not require it.
 
 Avoid when:
 - The source speaks a non-OTLP protocol (Prometheus scrape, Jaeger, Zipkin, Kafka, syslog, filelog, …) — use the matching receiver instead.
@@ -31,11 +31,11 @@ Avoid when:
 - [`otlp` exporter](../otlp_exporter/README.md) — the sending counterpart; a Collector-to-Collector hop is this receiver on one end and the `otlp_grpc`/`otlp` exporter on the other.
 - [`memory_limiter`](../memory_limiter/README.md) — belongs **first** in every pipeline fed by this receiver, to apply backpressure before buffers grow.
 - [`routing`](../routing/README.md) — to route by request metadata, this receiver must run with `include_metadata: true` so the headers survive into the pipeline.
-- [`load_balancing`](../load_balancing/README.md) — its `routing_key: attributes` over client-metadata keys likewise needs `include_metadata: true` on the upstream `otlp` receiver.
+- [`load_balancing`](../load_balancing/README.md) — hashes telemetry resource/scope/record attributes (not transport metadata) when `routing_key: attributes` is selected.
 
 ## Details
 
 - [Configuration](configuration.md) — the `protocols.grpc` and `protocols.http` sub-blocks with every key, default, the URL-path overrides, and the "at least one protocol" validation rule.
 - [Verification](verification.md) — telemetrygen recipe sending OTLP/gRPC (and OTLP/HTTP) into a single collector with a `debug` exporter, binding `0.0.0.0` so containerized traffic is accepted.
-- [Advanced use-cases](advanced.md) — enabling a single protocol, `include_metadata` for auth/routing/load_balancing, CORS for browser OTLP, mTLS, large-payload tuning, and named instances.
+- [Advanced use-cases](advanced.md) — enabling a single protocol, `include_metadata` for downstream metadata consumers, CORS for browser OTLP, mTLS, large-payload tuning, and named instances.
 - [Known quirks](quirks.md) — the `localhost` vs `0.0.0.0` default (top item), the "at least one protocol" error, the 4317/4318 ports, OTLP/JSON on the HTTP port, `include_metadata` default, and per-signal stability.

--- a/skills/otel-collector/components/otlp/advanced.md
+++ b/skills/otel-collector/components/otlp/advanced.md
@@ -25,8 +25,6 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
         include_metadata: true     # headers survive into the pipeline
-        auth:
-          authenticator: bearertokenauth
 ```
 
 `include_metadata: true` is the prerequisite for:

--- a/skills/otel-collector/components/otlp/advanced.md
+++ b/skills/otel-collector/components/otlp/advanced.md
@@ -14,9 +14,9 @@ receivers:
 
 HTTP-only is the mirror image — list only `http:`. Listing neither fails startup (`must specify at least one protocol when using the OTLP receiver`).
 
-## `include_metadata` for auth, routing, and load balancing
+## `include_metadata` for downstream metadata consumers
 
-Per-request gRPC/HTTP headers (and other client metadata) are **dropped** by default. Downstream features that read them need the receiver to carry them into the pipeline:
+Per-request gRPC/HTTP headers (and other client metadata) are **not propagated into the downstream pipeline** by default. Downstream features that read them need the receiver to carry them into the pipeline. Server authenticator extensions are different: they read the transport headers directly and do not require `include_metadata`.
 
 ```yaml
 receivers:
@@ -30,11 +30,10 @@ receivers:
 ```
 
 `include_metadata: true` is the prerequisite for:
-- **Header-based auth** extensions (the `auth.authenticator` reads the incoming token from request metadata).
 - [`routing`](../routing/README.md) by request metadata.
-- [`load_balancing`](../load_balancing/README.md) with `routing_key: attributes` over client-metadata keys.
+- `attributes` / `resource` actions that use `from_context: metadata.*`.
 
-Without it, those features see no metadata and behave as if the headers were absent.
+Without it, those downstream consumers see no metadata and behave as if the headers were absent. The [`load_balancing`](../load_balancing/README.md) exporter's `routing_key: attributes` reads telemetry resource/scope/record attributes, not transport metadata; copy a header into a telemetry attribute first if it must become a load-balancing key.
 
 ## CORS for browser OTLP
 

--- a/skills/otel-collector/components/otlp/configuration.md
+++ b/skills/otel-collector/components/otlp/configuration.md
@@ -40,7 +40,7 @@ enables both at their defaults. Listing only `grpc:` disables HTTP, and vice ver
 | `write_buffer_size` | int | 0 (gRPC default) | gRPC write buffer. |
 | `keepalive` | object | — | Server keepalive (see [keepalive](#grpc-keepalive)). |
 | `auth` | object | — | `authenticator:` referencing an auth extension. |
-| `include_metadata` | bool | `false` | Propagate per-request gRPC metadata (headers) into the pipeline. Required for header-based auth, metadata routing, and metadata-keyed load balancing. |
+| `include_metadata` | bool | `false` | Propagate per-request gRPC metadata (headers) into the downstream pipeline. Required for metadata routing and `from_context: metadata.*`; server authenticator extensions read transport headers directly. |
 | `middlewares` | list | — | gRPC server middleware extensions. |
 
 ### grpc keepalive

--- a/skills/otel-collector/components/otlp/quirks.md
+++ b/skills/otel-collector/components/otlp/quirks.md
@@ -32,7 +32,7 @@ The HTTP endpoint accepts both OTLP/protobuf and **OTLP/JSON** on the same paths
 
 ## `include_metadata` is off by default
 
-Per-request headers/metadata are dropped unless `include_metadata: true`. Header-based auth extensions, metadata [`routing`](../routing/README.md), and [`load_balancing`](../load_balancing/README.md) keyed on client-metadata attributes all silently see no metadata without it. There is no error — the feature just behaves as if the headers weren't sent.
+Per-request headers/metadata are not propagated into downstream consumers unless `include_metadata: true`. Metadata [`routing`](../routing/README.md) and `attributes` / `resource` actions using `from_context: metadata.*` silently see no metadata without it. Server authenticator extensions still read transport headers directly, and [`load_balancing`](../load_balancing/README.md) with `routing_key: attributes` hashes telemetry attributes rather than transport metadata.
 
 ## No configurable profiles URL path
 


### PR DESCRIPTION
## Summary

- Clarify that OTLP `include_metadata` exposes headers to downstream consumers, not server authentication.
- Correct load-balancing attribute routing to describe telemetry attributes rather than request metadata.
- Correct named-processor ordering guidance.

## Verification

- Audited all 22 indexed components at core v0.156.0/v1.62.0 and contrib v0.156.0.
- `skills-ref validate skills/otel-collector`, registration, release-path/link/anchor checks, and `git diff --check`.
- No YAML changed; prior empirical v0.156 evidence was preserved without restamping.

## Deliberately excluded

- All post-v0.156/v1.62 main-only changes and new components.

Agent-authored periodic refresh; human-owned repository PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how OTLP request metadata is propagated to downstream processing.
  - Documented that `include_metadata: true` is required for metadata-based routing and metadata-aware attribute or resource actions.
  - Clarified that server authenticator extensions read transport headers directly.
  - Updated load-balancing guidance to explain that `routing_key: attributes` uses telemetry attributes, not transport metadata.
  - Clarified action ordering across processor instances in configured pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->