### PR TITLE
docs(otel-collector-builder): correct released builder guidance

### DIFF
--- a/skills/otel-collector-builder/SKILL.md
+++ b/skills/otel-collector-builder/SKILL.md
@@ -56,7 +56,7 @@ providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.62.0
 ```
 
-**`providers:` semantics.** Omitting the key entirely keeps OCB's built-in default set (env, file, http, https, yaml at the paired stable version). But setting `providers:` at all **replaces** that set — listing only `fileprovider` silently removes `${env:VAR}` substitution. Either omit the key, or list every scheme the collector's config will use.
+**`providers:` semantics.** Omitting the key entirely keeps OCB's built-in default set (env, file, http, https, yaml at the paired stable version). But setting `providers:` at all **replaces** that set. The generated Collector defaults `conf_resolver.default_uri_scheme` to `env`, so an explicit list without `envprovider` fails configuration validation unless you set another included provider as the default. Either omit the key, or include `envprovider` plus every scheme the collector's config will use.
 
 Contrib components use the same list syntax:
 

--- a/skills/otel-collector-builder/references/manifest.md
+++ b/skills/otel-collector-builder/references/manifest.md
@@ -79,7 +79,7 @@ providers:
 
 Providers version on the stable `v1.y.0` stream (see the version-alignment section in SKILL.md for the pairing rule).
 
-**Default behavior:** when `providers:` is omitted, OCB includes all five providers above at its built-in stable version (the manifest is unmarshaled over a default config that pre-populates them). Setting `providers:` **replaces** the whole default set. Minimum sensible explicit set: `fileprovider` + `envprovider`.
+**Default behavior:** when `providers:` is omitted, OCB includes all five providers above at its built-in stable version (the manifest is unmarshaled over a default config that pre-populates them). Setting `providers:` **replaces** the whole default set. With the default `conf_resolver`, `envprovider` is required even when the config has no environment references; omitting it fails with `DefaultScheme not found in providers list`. A common explicit base is `fileprovider` + `envprovider`.
 
 `converters:` accepts the same module spec and hooks confmap converters into config resolution. Core and contrib currently ship no standalone converter modules (`expandconverter` was removed after env-expansion moved into confmap core); the key is only useful for custom converters.
 
@@ -90,7 +90,7 @@ conf_resolver:
   default_uri_scheme: env   # scheme applied to bare ${VAR} references
 ```
 
-When unset, the generated collector falls back to `env` at runtime, so `${VAR}` behaves as `${env:VAR}`. Setting any scheme here requires the matching provider to be in `providers:` — the binary errors at startup otherwise.
+When unset, the generated collector falls back to `env` at runtime, so `${VAR}` behaves as `${env:VAR}` and `envprovider` must be present. Setting any other scheme here requires the matching provider to be in `providers:` — the binary errors at startup otherwise.
 
 ## telemetry
 

--- a/skills/otel-collector-builder/references/troubleshooting.md
+++ b/skills/otel-collector-builder/references/troubleshooting.md
@@ -27,10 +27,10 @@ Strict checking is off by default; run with `--skip-strict-versioning=false` to 
 ## Missing providers at runtime
 
 ```
-cannot load configuration: no provider found for scheme "file"
+invalid 'confmap.ResolverSettings' configuration: DefaultScheme not found in providers list
 ```
 
-The binary was built without the provider for that config URI scheme. This only happens when the manifest sets `providers:` explicitly — the key **replaces** OCB's default set (env, file, http, https, yaml), so listing only `fileprovider` removes `${env:VAR}` expansion. Add the missing provider to `providers:` (or drop the key to restore all defaults) and rebuild.
+The manifest set `providers:` explicitly and omitted `envprovider`. The key **replaces** OCB's default set (env, file, http, https, yaml), while the generated Collector defaults `conf_resolver.default_uri_scheme` to `env`. Add `envprovider` (and every other scheme the config uses), or drop `providers:` to restore all defaults. To intentionally omit `envprovider`, set `conf_resolver.default_uri_scheme` to an included provider and ensure the config has no environment references.
 
 ## Module resolution failures
 
@@ -49,7 +49,7 @@ The binary was built without the provider for that config URI scheme. This only 
 - `cgo: C compiler "gcc" not found`: a component needs CGO. Either install a C toolchain and set `dist.cgo_enabled: true`, or drop the component. Default is CGO off.
 - `build constraints exclude all Go files`: `dist.build_tags` or `GOOS`/`GOARCH` excludes everything — clear the tags or fix the target platform.
 - OOM on small CI runners: the collector dependency graph is large. `GOMAXPROCS=2 ocb --config=builder.yaml`, or split into generate + `go build` stages.
-- `exec: "go": executable file not found`: install Go or set `dist.go` to its path. OCB requires a current Go toolchain (it invokes `go mod tidy` with a recent `-compat` version).
+- `exec: "go": executable file not found`: install a compatible Go toolchain or set `dist.go` to its path. OCB v0.156.0 declares Go 1.25 and runs `go mod tidy -compat=1.25`; selected modules may require newer Go.
 
 ## Runtime failures
 

--- a/skills/otel-collector-builder/references/workflows.md
+++ b/skills/otel-collector-builder/references/workflows.md
@@ -24,7 +24,7 @@ receivers:
 Requirements:
 
 - The local directory must contain a `go.mod` whose module path matches the `gomod` path.
-- The component's Go version must satisfy OCB's floor — OCB runs `go mod tidy` with a `-compat` pinned to the current Go release, so keep the local module's toolchain current.
+- Run OCB with a Go toolchain new enough for both OCB and the selected modules. OCB v0.156.0 declares Go 1.25, generates a `go 1.25` module, and runs `go mod tidy -compat=1.25`; a local component that requires newer Go needs that newer toolchain.
 - Since v0.151.0 the generated `replace` uses a path relative to `dist.output_path`, so the generated tree can be committed or moved. Set `dist.use_absolute_replace_paths: true` if external tooling expects absolute paths.
 
 This is also the fastest verification loop when authoring a new component: manifest with the local component + `otlpreceiver` + `debugexporter`, build, run, send data with `telemetrygen`.


### PR DESCRIPTION
## Summary

- Correct the resolver failure when `envprovider` is omitted.
- Pin released OCB v0.156.0 guidance to Go 1.25 and `go mod tidy -compat=1.25`.

## Verification

- Exact OCB v0.156.0 strict builds and failure/success resolver reproductions.
- Focused upstream CLI/config tests.
- `skills-ref validate skills/otel-collector-builder`, registration, release-path checks, and `git diff --check`.

## Deliberately excluded

- Nightly and post-v0.156 changes.
- Full repository suite because the partial release archive lacks root workspace replacements; focused suites and the actual released build passed.

Agent-authored periodic refresh; human-owned repository PR.