### PR TITLE
docs(otel-java): refresh released configuration guidance

### DIFF
--- a/skills/otel-java/SKILL.md
+++ b/skills/otel-java/SKILL.md
@@ -24,7 +24,7 @@ For Java-specific facts:
 |---|---|
 | Latest BOM (`opentelemetry-bom`) | `gh api repos/open-telemetry/opentelemetry-java/releases/latest -q '.tag_name'` |
 | Latest Javaagent | `gh api repos/open-telemetry/opentelemetry-java-instrumentation/releases/latest -q '.tag_name'` |
-| SDK declarative-config expected `file_format` for a selected BOM tag | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java/<selected-sdk-tag>/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactory.java` |
+| SDK declarative-config accepted and preferred `file_format` for a selected BOM tag | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java/<selected-sdk-tag>/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactory.java` |
 | Javaagent declarative-config docs (current activation flag, supported `file_format`) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/declarative-configuration/` |
 | Javaagent declarative-config smoke fixture (parser truth for selected agent tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests/src/test/resources/declarative-config.yaml` |
 | Javaagent CHANGELOG (when each schema rc landed) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/CHANGELOG.md` |

--- a/skills/otel-java/references/declarative-setup.md
+++ b/skills/otel-java/references/declarative-setup.md
@@ -18,7 +18,7 @@ skill. For Java-specific facts:
 |---|---|
 | Latest BOM (`opentelemetry-bom`) | `gh api repos/open-telemetry/opentelemetry-java/releases/latest -q '.tag_name'` |
 | Latest Javaagent | `gh api repos/open-telemetry/opentelemetry-java-instrumentation/releases/latest -q '.tag_name'` |
-| SDK declarative-config expected `file_format` for a selected BOM tag | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java/<selected-sdk-tag>/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactory.java` |
+| SDK declarative-config accepted and preferred `file_format` for a selected BOM tag | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java/<selected-sdk-tag>/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactory.java` |
 | Javaagent declarative-config docs (current activation flag, supported `file_format`) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/declarative-configuration/` |
 | Javaagent declarative-config smoke fixture (parser truth for selected agent tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests/src/test/resources/declarative-config.yaml` |
 | Javaagent CHANGELOG (when each schema rc landed) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/CHANGELOG.md` |
@@ -46,11 +46,12 @@ java -javaagent:opentelemetry-javaagent.jar \
 Declarative config has been supported since Javaagent 2.9.0; the property is now the stable
 `otel.config.file` (the experimental `otel.experimental.config.file` alias was removed in the
 SDK 1.63.0 bundled with Javaagent 2.29.0). Newer agent versions track newer schema versions.
-Confirm the exact `file_format` literal from the tag-matched Javaagent or Spring Boot Starter
-fixture for the selected release, not from `main` or the generic language support matrix alone.
-For example, as of 2026-07-16, the latest released SDK BOM is 1.64.0 and expects
-`file_format: "1.1"`, but the latest released Javaagent/Spring Boot Starter is 2.29.0, targets
-SDK 1.63.0, and its released fixtures use `file_format: "1.0"`.
+Confirm both the accepted range and preferred `file_format` from the tag-matched parser, then use
+the preferred value from that release's fixture to avoid compatibility warnings for experimental
+properties. As of 2026-07-20, SDK BOM 1.64.0 accepts `0.4` and `1.*` and prefers `"1.1"`.
+Javaagent/Spring Boot Starter 2.29.0 targets SDK 1.63.0, whose parser accepts `0.4` and the
+`1.0` release/RC forms and prefers `"1.0"`; both released fixtures use the value `1.0`. Do not
+infer this from `main` or the generic language support matrix alone.
 
 When `otel.config.file` / `OTEL_CONFIG_FILE` is set, all other SDK autoconfigure properties are
 ignored except agent-only properties (see Key API Facts).
@@ -66,7 +67,7 @@ use the selected Javaagent parser/docs/fixtures. The generic language support ma
 coverage metadata and may not be the exact YAML literal accepted by the Javaagent.
 
 ```yaml
-# file_format: use the exact literal accepted by the selected Javaagent version
+# file_format: use the preferred literal for the selected Javaagent version
 resource:
   attributes:
     - name: service.name
@@ -113,3 +114,12 @@ AutoConfiguredOpenTelemetrySdk sdk =
 - **Agent-only properties**: `otel.javaagent.extensions`, `otel.javaagent.enabled`, and
   `otel.javaagent.debug` cannot be set via declarative config. Set them as system properties or
   their corresponding environment variables instead.
+- **Released 2.29.0 selectors**: Javaagent and Starter declarative config can select semantic
+  conventions per `db`, `code`, `rpc`, or `messaging` domain under
+  `instrumentation/development.general.<domain>.semconv` with `version`, `experimental`, and
+  `dual_emit`. `service.peer` is still flag-only in this release. Check the schema for supported
+  value combinations; unsupported combinations fall back rather than forcing the requested mode.
+- **Starter thread details**: Starter 2.29.0 can add experimental `thread.id` and `thread.name`
+  to spans with `distribution.spring_starter.thread_details_enabled: true`. This path is
+  Starter-only; the Javaagent uses the separate
+  `distribution.javaagent.thread_details_enabled` path.

--- a/skills/otel-java/references/sensitive-data-capture.md
+++ b/skills/otel-java/references/sensitive-data-capture.md
@@ -12,7 +12,7 @@ instrumentation config properties (env-var form: upper-case, dots/dashes → und
 | URL query string | `url.query` (server) / inside `url.full` (client) | **captured**, with only the sensitive-parameter list below redacted |
 | Request/response headers | `http.request.header.<name>` / `http.response.header.<name>` | not captured (opt-in) |
 | Servlet request parameters (form/query) | `servlet.request.parameter.<name>` | not captured (opt-in, experimental) |
-| SQL bound values | `db.query.text` | not captured (statements sanitized to `?` by default) |
+| SQL query text / parameter values | `db.statement` by default; `db.query.text` with stable database semconv; `db.query.parameter.<key>` only when opted in | query text captured but sanitized; parameter values off |
 
 The asymmetry matters: headers, request parameters, and SQL values are **off** by default,
 but the raw query string is **on** — any user data in a query string
@@ -61,6 +61,8 @@ otel.instrumentation.http.server.capture-response-headers=<list>
 otel.instrumentation.http.client.capture-request-headers=<list>
 otel.instrumentation.http.client.capture-response-headers=<list>
 otel.instrumentation.servlet.experimental.capture-request-parameters=<list>
+# High risk: captures JDBC parameter values and disables query sanitization
+otel.instrumentation.jdbc.experimental.capture-query-parameters=true
 ```
 
 Captured headers land as `http.request.header.<lowercase-name>` /
@@ -68,16 +70,41 @@ Captured headers land as `http.request.header.<lowercase-name>` /
 `servlet.request.parameter.<name>`. Enabling any of these captures the raw values — there
 is no per-header/per-parameter redaction.
 
+Those flat properties apply to normal property-based configuration. When declarative config is
+active, flat instrumentation properties are not an overlay; use the corresponding YAML paths:
+
+```yaml
+instrumentation/development:
+  general:
+    http:
+      client:
+        request_captured_headers: [x-request-id]
+        response_captured_headers: [x-request-id]
+      server:
+        request_captured_headers: [x-request-id]
+        response_captured_headers: [x-request-id]
+  java:
+    servlet:
+      capture_request_parameters/development: [customer]
+    jdbc:
+      # High risk: captures values and disables query sanitization
+      capture_query_parameters/development: true
+```
+
 ## SQL sanitization
 
-Statement sanitization (bound values → `?`) is on by default; the current toggle is
+SQL literal/parameter sanitization (values → `?`) is on by default; the current toggle is
 `java.common.db.query_sanitization.enabled` under `instrumentation/development` in declarative
 config, or
 `otel.instrumentation.common.db.query-sanitization.enabled` as a system property/environment
 variable. Per-instrumentation toggles can take precedence. Older property spellings
 (`otel.instrumentation.common.db-statement-sanitizer.enabled` and per-instrumentation
-`*-statement-sanitizer.enabled` variants) are deprecated. Do not turn it off on request
-paths.
+`*-statement-sanitizer.enabled` variants) are deprecated and, when
+`instrumentation/development.java.common.v3_preview: true` in Javaagent/Starter 2.29.0, ignored.
+Use the `db.query_sanitization.enabled` forms above. Do not turn sanitization off on request paths.
+
+JDBC's parameter-capture switch shown above is a separate opt-in. It emits raw values as
+`db.query.parameter.<key>` and disables sanitization even if the sanitization toggle is `true`.
 
 ## Sources of truth
 


### PR DESCRIPTION
## Summary

- Distinguish accepted versus preferred declarative `file_format` values.
- Add released v2.29 semantic-convention selectors and Starter/agent thread-detail paths.
- Correct declarative header/servlet capture and v3-preview SQL alias behavior.

## Verification

- SDK 1.64.0, agent/Starter 2.29.0, and contrib 1.58.0 tag-pinned checks.
- `skills-ref`, 15-skill registration, YAML/source/path assertions, and `git diff --check`.

## Deliberately excluded

- Post-tag instrumentation/config-bridge and contrib changes, plus new modules.
- Exact Gradle runtime was unavailable because host JDK is absent and managed Docker execution was rejected.

Agent-authored periodic refresh; human-owned repository PR.