### PR TITLE
docs(otel-ottl): document released flatten gate

### DIFF
--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -193,6 +193,10 @@ truncate_all(span.attributes, 1024)
 
 The OTel `attributes` processor only operates on span/log/metric attributes. To touch a *resource* attribute use the `resource` processor or a `transform` processor with `context: resource`. A config like `attributes/strip_resource: actions: [...delete os.description...]` runs without error but doesn't change resource attributes — silent no-op.
 
+### Per-log resource/scope rewrites may need `flatten_data`
+
+Log records can share resource and scope data. When a log-context statement derives either from record-specific `log.*` data, set `flatten_data: true` and enable the alpha `transform.flatten.logs` feature gate; otherwise records in the same batch can affect one another unexpectedly. In v0.156 the gate is disabled and `flatten_data` is `false` by default. The option is logs-only and incurs copying, hashing, and regrouping overhead.
+
 ### `logdedup` paths use dot-notation only
 
 The processor accepts `include_fields` / `exclude_fields` (not `fields`). Paths must start with `attributes.` or `body.` and use dot-notation. Bracket notation (`attributes["service.name"]`) is rejected, and `resource[...]` paths are not addressable. Default behavior dedups on the full record, which is usually what's wanted.
@@ -239,6 +243,7 @@ Recently added (still useful to know which release introduced them when supporti
 | Exemplar context (transform `metric_statements` only) | v0.156 |
 | Routing connector context inference (`condition` with context-qualified paths) | v0.156 |
 | Routing connector `request` context deprecated; use `otelcol.*` metadata paths | v0.156 |
+| Log-only `flatten_data` via alpha `transform.flatten.logs` feature gate | v0.103 |
 | `connector.routing.defaultErrorModeIgnore` feature gate | v0.155 |
 | `otelcol.*` context via enabled-by-default `ottl.contexts.enableOTelColContext` feature gate | v0.147 |
 | Filter processor top-level `trace_conditions`, `metric_conditions`, `log_conditions` | v0.146 |

--- a/skills/otel-ottl/references/functions.md
+++ b/skills/otel-ottl/references/functions.md
@@ -30,10 +30,10 @@ The contexts and signatures below are pinned to the released
 | `span` | `set_semconv_span_name(semconv_version, original_span_name_attribute?)` | Derives low-cardinality HTTP, RPC, messaging, or database span names. v0.156 accepts semantic-convention versions 1.37.0 through 1.40.0; unrelated spans are unchanged. |
 
 For full behavior, examples, and edge cases, follow the tag-pinned
-[metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#metrics-only-functions),
-[logs](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#logs-only-functions), and
-[traces](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#traces-only-functions)
-sections. The registrations that constrain the contexts are also tag-pinned:
+[metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#convert_sum_to_gauge),
+[logs](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#parseclf), and
+[traces](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#set_semconv_span_name)
+function sections. The registrations that constrain the contexts are also tag-pinned:
 [metric/datapoint](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/internal/metrics/functions.go),
 [log](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/internal/logs/functions.go), and
 [span](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/internal/traces/functions.go).


### PR DESCRIPTION
## Summary

- Document released v0.156 alpha `transform.flatten.logs` / `flatten_data`.
- Replace three broken tag-pinned README fragments with valid function headings.

## Verification

- Exact v0.156 Collector rejects `flatten_data` with the gate off and accepts it with the gate enabled.
- Path/anchor checks, `skills-ref`, registration, and `git diff --check`.

## Deliberately excluded

- Named post-v0.156 functions and feature-gate promotions.
- Prior exhaustive v0.156 runtime coverage was preserved without restamping.

Agent-authored periodic refresh; human-owned repository PR.