### PR TITLE
docs(otel-python): refresh released 1.44 guidance

### DIFF
--- a/skills/otel-python/SKILL.md
+++ b/skills/otel-python/SKILL.md
@@ -12,7 +12,7 @@ the task; each reference is self-contained.
 
 | File | Use when |
 |---|---|
-| [`references/declarative-setup.md`](references/declarative-setup.md) | Configuring the SDK via declarative YAML (`opentelemetry.sdk._configuration.file`): `load_config_file`, `configure_sdk`, `file_format`, env substitution, `OTEL_CONFIG_FILE` and programmatic activation. |
+| [`references/declarative-setup.md`](references/declarative-setup.md) | Configuring the SDK via declarative YAML (`opentelemetry-configuration` / `opentelemetry.configuration`): `load_config_file`, `configure_sdk`, `file_format`, env substitution, `OTEL_CONFIG_FILE` and programmatic activation. |
 | [`references/api.md`](references/api.md) | Import paths, global API access, tracer/meter/logger usage, attributes, propagation, the Python logging bridge (`LoggingHandler`). |
 | [`references/instrumentation-libraries.md`](references/instrumentation-libraries.md) | Zero-code (`opentelemetry-distro`, `opentelemetry-bootstrap`, `opentelemetry-instrument`), the contrib catalog, and manual instrumentation following semconv. |
 | [`references/performance.md`](references/performance.md) | Tuning sampling, batch span processor, periodic metric reader, views, asyncio context, exporters, graceful shutdown. |
@@ -26,13 +26,14 @@ For Python-specific facts:
 | Fact | Fetch |
 |---|---|
 | Latest `opentelemetry-sdk` / `opentelemetry-api` | `WebFetch https://pypi.org/pypi/opentelemetry-sdk/json` (`.info.version`) |
+| Latest `opentelemetry-configuration` | `WebFetch https://pypi.org/pypi/opentelemetry-configuration/json` |
 | Latest `opentelemetry-distro` | `WebFetch https://pypi.org/pypi/opentelemetry-distro/json` |
 | Latest `opentelemetry-instrumentation-<pkg>` (contrib) | `WebFetch https://pypi.org/pypi/opentelemetry-instrumentation-<pkg>/json` |
 | Latest OTLP exporter | `WebFetch https://pypi.org/pypi/opentelemetry-exporter-otlp/json` |
-| Declarative config support (released 1.43.0 overview) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.43.0/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/README.md` |
-| Declarative config vendored schema (released 1.43.0 parser-accepted `file_format`) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.43.0/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/schema.json` |
-| SDK CHANGELOG | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/main/CHANGELOG.md` |
-| Contrib CHANGELOG | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python-contrib/main/CHANGELOG.md` |
+| Declarative config support (released 1.44.0 overview) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.44.0/opentelemetry-configuration/README.rst` |
+| Declarative config vendored schema (released 1.44.0) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.44.0/opentelemetry-configuration/src/opentelemetry/configuration/schema.json` |
+| SDK CHANGELOG through 1.44.0 | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.44.0/CHANGELOG.md` |
+| Contrib CHANGELOG through 0.65b0 | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python-contrib/v0.65b0/CHANGELOG.md` |
 | Python getting-started docs | `WebFetch https://opentelemetry.io/docs/languages/python/getting-started/` |
 
 ## Cross-References

--- a/skills/otel-python/references/api.md
+++ b/skills/otel-python/references/api.md
@@ -230,6 +230,8 @@ log.info("handled request")  # emitted as OTel log record with trace context
 ```
 
 The handler automatically injects the active span's `trace_id` and `span_id` into each log record, correlating logs to traces.
+As of contrib 0.65b0, attributes that a configured stdlib formatter adds to the
+`LogRecord` are also included in the exported OTel log attributes.
 
 > **Deprecated path:** `opentelemetry.sdk._logs.LoggingHandler` is deprecated as of SDK 1.40.0/0.61b0. Always import from `opentelemetry.instrumentation.logging.handler`.
 

--- a/skills/otel-python/references/breaking-changes.md
+++ b/skills/otel-python/references/breaking-changes.md
@@ -6,11 +6,12 @@ rots with each release.
 
 ## Step 1: Fetch the CHANGELOGs
 
-Fetch both upstream sources before reviewing any code:
+Fetch both released upstream sources before reviewing any code. As of
+2026-07-20, the released ceiling is core **1.44.0** and contrib **0.65b0**:
 
 ```
-WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/main/CHANGELOG.md
-WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python-contrib/main/CHANGELOG.md
+WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.44.0/CHANGELOG.md
+WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python-contrib/v0.65b0/CHANGELOG.md
 ```
 
 Scan for entries marked **Deprecated**, **Removed**, or **Breaking** in the version range you are
@@ -24,11 +25,11 @@ Python OpenTelemetry uses two independent version tracks:
 
 | Track | Packages | Example |
 |---|---|---|
-| Stable (SemVer 1.x) | `opentelemetry-api`, `opentelemetry-sdk` | `1.43.0` |
-| Beta (`0.Yb`-suffix) | `opentelemetry-instrumentation-*`, contrib packages, some SDK extras (OTLP exporters track stable 1.x) | `0.64b0` |
+| Stable (SemVer 1.x) | `opentelemetry-api`, `opentelemetry-sdk` | `1.44.0` |
+| Beta (`0.Yb`-suffix) | `opentelemetry-instrumentation-*`, contrib packages, and experimental packages such as `opentelemetry-configuration` (OTLP exporters track stable 1.x) | `0.65b0` |
 
-The two tracks move in lock-step: SDK `1.43.x` pairs with contrib `0.64bx`. When the CHANGELOG
-entry says "version 0.64b0", look up the paired SDK version before concluding which SDK release
+The two tracks move in lock-step: SDK `1.44.x` pairs with contrib `0.65bx`. When the CHANGELOG
+entry says "version 0.65b0", look up the paired SDK version before concluding which SDK release
 introduced the change.
 
 The definitive indicator of which track a given package follows is its version string, not its
@@ -71,6 +72,33 @@ For each finding, grep the codebase for the old symbol before concluding impact:
 grep -r "LoggingHandler" .  # adjust pattern per finding
 ```
 
+### Released 1.44.0 / 0.65b0 audit points
+
+When crossing this release boundary, explicitly check for:
+
+- Imports from `opentelemetry.sdk._configuration.file`; declarative setup moved
+  to the public, experimental `opentelemetry.configuration` namespace. The old
+  SDK extra remains only as an install alias.
+- The removed Events API/SDK; emit a `LogRecord` with `event_name` instead.
+- Custom environment-carrier code: `EnvironmentGetter.get` now requires the
+  source mapping as its first argument rather than using a cached environment
+  snapshot.
+- Custom log exporters that read `ReadableLogRecord.context`; records buffered
+  by `BatchLogRecordProcessor` now carry an empty `Context()` to reduce retained
+  memory.
+- `ProcessResourceDetector` consumers expecting `process.command_args` or
+  `process.command_line`; these privacy-sensitive attributes are now omitted by
+  default and require `include_command_args=True`.
+- In-place mutation of `opentelemetry.context.Context`; inherited `dict`
+  mutation methods no longer modify it. Use the context API to create updated
+  contexts.
+- Histogram configurations with non-finite or non-increasing explicit bucket
+  boundaries; creating the metric stream's aggregation now raises `ValueError`.
+  NaN and Inf measurements are dropped at the instrument boundary.
+- `opentelemetry-instrumentation-elasticsearch`; contrib removed the package in
+  0.65b0 because supported Elasticsearch clients provide native OTel
+  instrumentation.
+
 ## Step 4: Audit Semantic Convention Renames
 
 Instrumentation libraries adopt updated semconv attribute names on their own schedule; the SDK
@@ -84,31 +112,35 @@ For the canonical attribute-level mapping, cross-reference the **`otel-semantic-
 skill, which fetches the upstream semconv CHANGELOG and spec. Do not rely on memory for attribute
 names — fetch the spec.
 
+Core 1.44.0 updates `opentelemetry-semantic-conventions` to the 1.43.0
+semantic-conventions release. Re-run this audit even when your application API
+imports did not change.
+
 If your code or dashboards query raw attribute names (e.g. Prometheus label names, Datadog facets,
 log filters), a semconv rename is a silent breaking change: telemetry keeps flowing but queries
 return no data. Treat semconv entries in the CHANGELOG with the same urgency as API removals.
 
-## Step 5: Check the `_configuration` Module
+## Step 5: Check Declarative Configuration
 
-The `opentelemetry.sdk._configuration` module (declarative YAML config) is **private and
-experimental**. The leading underscore is intentional: the public API is not guaranteed. Any
-release may rename the entry-point, change the schema, or remove the module without a deprecation
-period.
+In 1.44.0 / 0.65b0, declarative configuration moved from the private
+`opentelemetry.sdk._configuration.file` module to the separate
+`opentelemetry-configuration` package and public `opentelemetry.configuration`
+namespace. The new package remains experimental, so audit it on each upgrade.
 
 Before upgrading, fetch the README/schema for the release you are upgrading to. As of the
-latest released SDK (1.43.0), the declarative configuration README and schema are:
+latest released SDK (1.44.0), the declarative configuration README and schema are:
 
 ```text
-WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.43.0/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/README.md
-WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.43.0/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/schema.json
+WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.44.0/opentelemetry-configuration/README.rst
+WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.44.0/opentelemetry-configuration/src/opentelemetry/configuration/schema.json
 ```
 
-Upstream `main` has moved this code into an unreleased `opentelemetry-configuration`
-package; do not apply that import-path change to released guidance until it appears in a
-release.
+Install `opentelemetry-configuration` directly. The old
+`opentelemetry-sdk[file-configuration]` extra is a deprecated alias that still
+installs it for compatibility.
 
 Cross-reference the **`references/declarative-setup.md`** reference in this skill for the current
-YAML schema and activation API. If a release changes `_configuration`, that reference is the
+YAML schema and activation API. If a release changes the package, that reference is the
 authoritative source of the updated usage pattern.
 
 ## Step 6: Verify Installed Versions Match
@@ -116,7 +148,8 @@ authoritative source of the updated usage pattern.
 After identifying changes, confirm the running environment matches the target version:
 
 ```bash
-pip show opentelemetry-sdk opentelemetry-api opentelemetry-distro opentelemetry-instrumentation
+pip show opentelemetry-sdk opentelemetry-api opentelemetry-configuration \
+  opentelemetry-distro opentelemetry-instrumentation
 ```
 
 A mismatch between `opentelemetry-api` and `opentelemetry-sdk` versions is a common source of

--- a/skills/otel-python/references/declarative-setup.md
+++ b/skills/otel-python/references/declarative-setup.md
@@ -1,17 +1,13 @@
 # Python SDK Setup with Declarative File Configuration
 
 Configure the OpenTelemetry SDK in Python via a YAML file processed by
-`opentelemetry.sdk._configuration.file`.
+the `opentelemetry-configuration` package (`opentelemetry.configuration`).
 
-> **Experimental / private API.** The `opentelemetry.sdk._configuration.*`
-> modules are private (leading underscore) and experimental. They may change
-> or be removed without a deprecation notice between SDK releases. Check the
-> SDK CHANGELOG (see Sources of Truth) before upgrading.
->
-> **Main-branch note (post-1.43.0):** upstream `main` has moved the
-> declarative configuration implementation into an unreleased
-> `opentelemetry-configuration` package. Keep released guidance on
-> `opentelemetry.sdk._configuration.*` until that package is released.
+> **Experimental public package.** Release 1.44.0 / 0.65b0 moved declarative
+> configuration from the private `opentelemetry.sdk._configuration.*` modules
+> into the public `opentelemetry-configuration` package. The package is still
+> experimental (Development Status: Alpha), so its API and models may change
+> between minor releases. Pin and audit the changelog when upgrading.
 
 For the YAML configuration schema, load the `otel-declarative-config` skill.
 
@@ -23,19 +19,26 @@ For YAML schema details, fetch the upstream sources listed in the
 | Fact | Fetch |
 |---|---|
 | Latest `opentelemetry-sdk` / `opentelemetry-api` | `WebFetch https://pypi.org/pypi/opentelemetry-sdk/json` (`.info.version`) |
+| Latest `opentelemetry-configuration` | `WebFetch https://pypi.org/pypi/opentelemetry-configuration/json` |
 | Latest `opentelemetry-distro` | `WebFetch https://pypi.org/pypi/opentelemetry-distro/json` |
 | Latest OTLP exporter | `WebFetch https://pypi.org/pypi/opentelemetry-exporter-otlp/json` |
-| Declarative config support + vendored schema version (released 1.43.0) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.43.0/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/README.md` |
-| SDK CHANGELOG | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/main/CHANGELOG.md` |
+| Declarative config support (released 1.44.0) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.44.0/opentelemetry-configuration/README.rst` |
+| Vendored schema (released 1.44.0) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.44.0/opentelemetry-configuration/src/opentelemetry/configuration/schema.json` |
+| SDK CHANGELOG through 1.44.0 | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.44.0/CHANGELOG.md` |
 
 ## Install
 
-The `file-configuration` extras group is required; plain `opentelemetry-sdk`
-lacks `pyyaml` and `jsonschema` and `load_config_file` will raise `ImportError`.
+Install the separate experimental package directly. It installs matching
+`opentelemetry-api` and `opentelemetry-sdk` versions plus the YAML/schema
+dependencies:
 
 ```bash
-pip install "opentelemetry-sdk[file-configuration]" opentelemetry-api
+pip install opentelemetry-configuration
 ```
+
+`opentelemetry-sdk[file-configuration]` remains as a deprecated compatibility
+alias that installs `opentelemetry-configuration`; prefer the direct package for
+new setups.
 
 Add exporters and instrumentation libraries as needed:
 
@@ -47,7 +50,7 @@ pip install opentelemetry-exporter-otlp opentelemetry-distro \
 
 ## Activation
 
-As of SDK **1.43.0 / 0.64b0** there are two supported activation paths.
+As of SDK **1.44.0 / 0.65b0** there are two supported activation paths.
 
 ### Zero-code: `OTEL_CONFIG_FILE`
 
@@ -63,6 +66,9 @@ When `OTEL_CONFIG_FILE` is set, the file is the **sole** source of SDK
 construction: spec-defined `OTEL_*` variables that have schema equivalents are
 ignored. Env vars are still read via `${VAR}` / `${VAR:-default}` substitution
 inside the file and by components the file enables (e.g. resource detectors).
+Python-specific `OTEL_PYTHON_*` configuration extensions are also bypassed
+because the regular env-var initialization path is skipped; express equivalent
+behavior in the file or in code.
 
 ### Programmatic: `configure_sdk`
 
@@ -73,7 +79,7 @@ tracer/meter/logger providers and propagator globally — honoring the top-level
 
 ```python
 """bootstrap.py — import before any application code."""
-from opentelemetry.sdk._configuration.file import load_config_file, configure_sdk
+from opentelemetry.configuration import configure_sdk, load_config_file
 
 configure_sdk(load_config_file("otel.yaml"))
 ```
@@ -84,11 +90,11 @@ validates against the vendored schema, and returns a **fully-typed**
 `meter_provider`, `logger_provider`) are typed dataclasses, not raw dicts. (Prior
 to 1.43.0 the loader returned raw dicts for nested fields and callers had to
 build the dataclass tree by hand.) Both `load_config_file` and `configure_sdk`
-are exported from `opentelemetry.sdk._configuration.file`.
+are exported from `opentelemetry.configuration`.
 
 For finer control, the per-signal factories (`configure_tracer_provider`,
 `configure_meter_provider`, `configure_logger_provider`, `configure_propagator`,
-`create_resource`) are also exported from the same package.
+`create_resource`) are exported from `opentelemetry.configuration.file`.
 
 ### Application entry point
 
@@ -104,10 +110,12 @@ imported (or before the CLI activates the config) uses no-op providers.
 
 ## YAML Config
 
-`file_format` is required and must be a string version. SDK 1.43.0 validates it
+`file_format` is required and must be a string version. Release 1.44.0 validates it
 per the configuration spec: unsupported major versions are rejected; newer minor
 versions with the same major version are accepted with a warning. Use `"1.0"`
 unless you have checked the currently vendored schema and SDK loader.
+The package vendors configuration schema 1.1.0 in this release, while the loader
+still declares 1.0 as its supported `file_format` target.
 
 Minimal verified skeleton (all three signals, console exporters):
 
@@ -140,7 +148,29 @@ logger_provider:
 For OTLP exporters and the full schema, load the `otel-declarative-config` skill.
 
 Env-var substitution uses `${VAR}` and `${VAR:-default}` syntax; it is handled
-by `load_config_file` before the YAML is further processed.
+by `load_config_file` before the YAML is further processed. Use `$$` for a
+literal dollar sign.
+
+## Instrumentor Activation
+
+Release 1.44.0 can activate installed contrib instrumentors from the
+`instrumentation/development.python` section. Keys are
+`opentelemetry_instrumentor` entry-point names; `enabled: false` skips one:
+
+```yaml
+instrumentation/development:
+  python:
+    requests:
+      enabled: true
+    urllib3:
+      enabled: false
+```
+
+Additional keys are passed to `instrument()`. If an instrumentor publishes a
+dataclass in its `configuration` attribute, those values are type-coerced and
+validated first. Already-active instrumentors are skipped to avoid double
+instrumentation; unknown or failing instrumentors are logged and do not stop
+the remaining entries.
 
 ## Key Facts
 
@@ -154,6 +184,10 @@ by `load_config_file` before the YAML is further processed.
 - **Absent section ⇒ global left unset.** A config section that is absent
   (`None`) leaves the corresponding global untouched — it stays the no-op
   default. Each signal is independent.
+
+- **Configured ID generator is applied.** Release 1.44.0 wires the
+  `tracer_provider.id_generator` configuration into `TracerProvider`; resolve
+  the supported shape from the vendored schema.
 
 - **`LoggingHandler` import.** The deprecated
   `opentelemetry.sdk._logs.LoggingHandler` (deprecated in 1.40.0/0.61b0) should be

--- a/skills/otel-python/references/instrumentation-libraries.md
+++ b/skills/otel-python/references/instrumentation-libraries.md
@@ -39,7 +39,11 @@ opentelemetry-instrument \
   python -m uvicorn app:app
 ```
 
-Configuration is entirely via environment variables (`OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_TRACES_SAMPLER`, etc.) or distro defaults. This is distinct from the declarative YAML path — see `declarative-setup.md` for that approach.
+Without `OTEL_CONFIG_FILE`, configuration comes from environment variables
+(`OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_TRACES_SAMPLER`,
+etc.) or distro defaults. With `opentelemetry-configuration` installed, the
+same CLI can activate declarative YAML through `OTEL_CONFIG_FILE`; see
+`declarative-setup.md`.
 
 ### Common env vars
 
@@ -54,6 +58,12 @@ Configuration is entirely via environment variables (`OTEL_SERVICE_NAME`, `OTEL_
 | `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` | `requests,logging` |
 | `OTEL_SEMCONV_STABILITY_OPT_IN` | `http,database` |
 | `OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION` | `false` |
+
+In contrib 0.65b0, the aiopg, asyncpg, Cassandra, pymemcache, pymongo, and
+Tortoise ORM instrumentors added database semantic-convention migration
+support. Their behavior now follows `OTEL_SEMCONV_STABILITY_OPT_IN`; audit
+attributes and downstream queries before enabling `database` or
+`database/dup`.
 
 ## Per-App Instrumentation
 
@@ -71,7 +81,11 @@ FastAPIInstrumentor.instrument_app(app)   # attaches ASGI middleware to this app
 
 `instrument_app` is the per-app variant: it attaches the ASGI middleware to a specific app instance and produces `SpanKind.SERVER` spans for incoming requests.
 
-> The API shape differs across instrumentors. FastAPI uses the class method `FastAPIInstrumentor.instrument_app(app)`; Flask uses an instance method `FlaskInstrumentor().instrument_app(app)`; Django uses `DjangoInstrumentor().instrument()` with no app argument. Check the contrib package for the exact form.
+> The API shape differs across instrumentors. FastAPI and Flask define static
+> `instrument_app(app)` methods (the upstream Flask usage commonly calls it
+> through `FlaskInstrumentor()`); Django uses the inherited instance method
+> `DjangoInstrumentor().instrument()` with no app argument. Check the contrib
+> package for the exact form.
 
 ### Flask
 
@@ -148,9 +162,13 @@ Source of truth: `instrumentation/` directory in the [opentelemetry-python-contr
 | Redis | `opentelemetry-instrumentation-redis` |
 | pymemcache | `opentelemetry-instrumentation-pymemcache` |
 | Cassandra | `opentelemetry-instrumentation-cassandra` |
-| Elasticsearch | `opentelemetry-instrumentation-elasticsearch` |
 | Tortoise ORM | `opentelemetry-instrumentation-tortoiseorm` |
 | DB-API 2.0 (generic) | `opentelemetry-instrumentation-dbapi` |
+
+`opentelemetry-instrumentation-elasticsearch` was removed from contrib in
+0.65b0 because the supported Elasticsearch client versions provide native OTel
+instrumentation. Remove that package when upgrading and follow the client's
+instrumentation guidance.
 
 ### Messaging
 

--- a/skills/otel-python/references/performance.md
+++ b/skills/otel-python/references/performance.md
@@ -16,14 +16,14 @@ Performance tuning reference for the OpenTelemetry Python SDK. Covers sampling, 
 
 ## Default Configuration Values
 
-The SDK reads defaults from environment variables; check the [OpenTelemetry Python SDK changelog](https://github.com/open-telemetry/opentelemetry-python/blob/main/CHANGELOG.md) or env-var spec for current values — do not treat any number here as authoritative.
+The SDK reads defaults from environment variables; check the [released OpenTelemetry Python SDK changelog](https://github.com/open-telemetry/opentelemetry-python/blob/v1.44.0/CHANGELOG.md) or env-var spec for current values — do not treat any number here as authoritative.
 
 | Parameter | Environment Variable | Note |
 |-----------|---------------------|------|
 | BSP max queue size | `OTEL_BSP_MAX_QUEUE_SIZE` | Check SDK default |
 | BSP max export batch size | `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | Check SDK default |
 | BSP schedule delay (ms) | `OTEL_BSP_SCHEDULE_DELAY` | Check SDK default |
-| BSP export timeout (ms) | `OTEL_BSP_EXPORT_TIMEOUT` | Accepted but not applied by `BatchSpanProcessor` in SDK 1.43.0 |
+| BSP export timeout (ms) | `OTEL_BSP_EXPORT_TIMEOUT` | Accepted but not applied by `BatchSpanProcessor` in SDK 1.44.0 |
 | Span attribute count limit | `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` | Check SDK default |
 | Span event count limit | `OTEL_SPAN_EVENT_COUNT_LIMIT` | Check SDK default |
 | Span link count limit | `OTEL_SPAN_LINK_COUNT_LIMIT` | Check SDK default |
@@ -114,7 +114,7 @@ Application thread              Background thread
 | `max_queue_size` | `OTEL_BSP_MAX_QUEUE_SIZE` | In-memory queue capacity |
 | `max_export_batch_size` | `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | Spans per export call |
 | `schedule_delay_millis` | `OTEL_BSP_SCHEDULE_DELAY` | Max wait before export |
-| `export_timeout_millis` | `OTEL_BSP_EXPORT_TIMEOUT` | Stored but not applied by `BatchSpanProcessor` in SDK 1.43.0 |
+| `export_timeout_millis` | `OTEL_BSP_EXPORT_TIMEOUT` | Stored but not applied by `BatchSpanProcessor` in SDK 1.44.0 |
 
 ### Tuning for Throughput
 
@@ -385,7 +385,7 @@ exporter = OTLPSpanExporter(compression=Compression.Gzip)
 
 ### Retry and Timeout
 
-The OTLP exporters retry on transient errors (connection refused, 5xx responses). Check the current retry defaults in the [exporter source](https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter) — do not assume specific backoff intervals.
+The OTLP exporters retry on transient errors (connection refused, 5xx responses). Check the current released retry behavior in the [exporter source](https://github.com/open-telemetry/opentelemetry-python/tree/v1.44.0/exporter) — do not assume specific backoff intervals.
 
 Configure timeout via environment variable or constructor:
 
@@ -512,5 +512,5 @@ Key signals to watch:
 | Indicator | Meaning |
 |-----------|---------|
 | `Queue full, dropping Span.` warnings | Queue overflow — increase `max_queue_size` or reduce `schedule_delay_millis` |
-| Export timeout errors | Backend/exporter too slow or batch too large — tune the exporter timeout or `max_export_batch_size`; BSP `export_timeout_millis` is not applied in SDK 1.43.0 |
+| Export timeout errors | Backend/exporter too slow or batch too large — tune the exporter timeout or `max_export_batch_size`; BSP `export_timeout_millis` is not applied in SDK 1.44.0 |
 | High memory growth | Metric cardinality explosion — add Views to filter attributes |


### PR DESCRIPTION
## Summary

- Move declarative guidance to released experimental `opentelemetry-configuration` and clarify activation/env precedence.
- Refresh the 1.44.0/0.65b0 breaking-change ceiling, Events removal, instrumentation catalog, and API wording.
- Record released logging formatter and BSP behavior.

## Verification

- Exact published-package environment for imports, declarative loading, ID generator, instrumentors, semconv, context, and resources.
- 46 Python code blocks compiled; all 50 documented contrib packages exist.
- `skills-ref validate skills/otel-python`, pinned paths/references, and `git diff --check`.

## Deliberately excluded

- New structlog and other uncovered modules, plus 1.45.0.dev/0.66b0.dev changes.

Agent-authored periodic refresh; human-owned repository PR.