### PR TITLE
docs(otel-span-events-to-logs-migration): refresh released SDK guidance

### DIFF
--- a/skills/otel-span-events-to-logs-migration/SKILL.md
+++ b/skills/otel-span-events-to-logs-migration/SKILL.md
@@ -11,7 +11,7 @@ Use this skill to migrate instrumentation from the Span Event API (`AddEvent`, `
 
 The OpenTelemetry project accepted a plan to deprecate `Span.AddEvent` and `Span.RecordException` in favor of emitting events and exceptions through the Logs API. Span Events as a concept remain valid -- they can be emitted via logs that correlate to the active span, and optionally bridged back into the span proto.
 
-Status as of 2026-07-16: OTEP 4430 is accepted, log-based event/exception emission is specified in the Logs API, and the SDK "event to span event bridge" is specified with Development status. The trace API methods `AddEvent`/`RecordException` are not yet formally marked Deprecated in the specification -- that step is still pending. Treat existing span-event calls as migration candidates, not automatically invalid code; some SDK-specific equivalents have already changed status (for example OpenTelemetry .NET's `Activity.RecordException` extension is `[Obsolete]` in favor of `Activity.AddException`, which is still a span-event API).
+Status as of 2026-07-20: OTEP 4430 is accepted, log-based event/exception emission is specified in the Logs API, and the SDK "event to span event bridge" is specified with Development status. The trace API methods `AddEvent`/`RecordException` are not yet formally marked Deprecated in the specification -- that step is still pending. Treat existing span-event calls as migration candidates, not automatically invalid code; some SDK-specific equivalents have already changed status (for example OpenTelemetry .NET's `Activity.RecordException` extension is `[Obsolete]` in favor of `Activity.AddException`, which is still a span-event API).
 
 See `references/deprecation-plan.md` for the full context.
 

--- a/skills/otel-span-events-to-logs-migration/references/deprecation-plan.md
+++ b/skills/otel-span-events-to-logs-migration/references/deprecation-plan.md
@@ -7,7 +7,7 @@ This reference summarizes the [OTEP 4430](https://github.com/open-telemetry/open
 - `Span.AddEvent` -- the API method for attaching events to spans
 - `Span.RecordException` -- the API method for recording exceptions on spans
 
-As of 2026-07-16, these methods are planned deprecation targets from the accepted OTEP. They are not yet marked Deprecated in `specification/trace/api.md`.
+As of 2026-07-20, these methods are planned deprecation targets from the accepted OTEP. They are not yet marked Deprecated in `specification/trace/api.md`.
 
 ## What Is NOT Being Deprecated
 
@@ -41,10 +41,10 @@ Stabilize log-based Events. (The `event_name` LogRecord field is part of the sta
 - Next major version: migrate to the Logs API; for span-detail-without-a-timestamp cases, record span attributes instead ([semantic-conventions#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010), [opentelemetry-specification#4446](https://github.com/open-telemetry/opentelemetry-specification/issues/4446))
 - Users opt into the SDK bridge if they need span events in the proto envelope
 
-## Current Status (2026-07-16)
+## Current Status (2026-07-20)
 
-- **Proto**: log-based Events are stable; `event_name` is a stable LogRecord field.
-- **Spec**: the Logs API is Stable, including the `event_name` field and the optional `Exception` parameter to Emit, so log-based exception/event emission is specified. The "event to span event bridge" `LogRecordProcessor` is specified in `specification/logs/sdk.md` (Status: Development), with a matching `event_to_span_event_bridge/development` declarative-config key.
+- **Proto 1.10.0**: log-based Events are stable; `event_name` is a stable LogRecord field.
+- **Specification 1.59.0**: the Logs API is Stable, including the `event_name` field and the optional `Exception` parameter to Emit, so log-based exception/event emission is specified. The "event to span event bridge" `LogRecordProcessor` is specified in `specification/logs/sdk.md` (Status: Development), with a matching `event_to_span_event_bridge/development` declarative-config key.
 - **Not yet done in spec**: `Span.AddEvent` and `Span.RecordException` are **not** yet marked Deprecated in `specification/trace/api.md`. That step remains pending.
 - **Semantic conventions 1.43.0**: exception events normally use an operation-specific name with a `.exception` suffix; the generic `exception` name is for handlers not tied to an operation or domain. Existing instrumentations introducing log-based exceptions should use `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN` with `logs` or `logs/dup` for a phased rollout while keeping span events as the default in the current major version.
 - **SDKs**: implementation status varies. Do not claim all `AddEvent`/`RecordException` equivalents are deprecated unless that language SDK marks them so.
@@ -52,16 +52,16 @@ Stabilize log-based Events. (The `event_name` LogRecord field is part of the sta
 ## Language Status Snapshot
 
 Use current released source for the target language before editing user code.
-The snapshot below was verified against locally available releases on
-2026-07-16 against synced upstream checkouts and exact released tags:
+The snapshot below was verified against synced upstream checkouts and exact
+released tags on 2026-07-20:
 
 | Language | Current migration-relevant status |
 |---|---|
-| Go 1.44.0 | `trace.Span.AddEvent` / `RecordError` are present and not marked deprecated; `log.Record.SetEventName` is available. No event-to-span-event bridge implementation was found in this release. |
+| Go trace 1.44.0 / logs 0.20.0 | `trace.Span.AddEvent` / `RecordError` are present and not marked deprecated. `log.Record.SetEventName` and `SetErr` are available; the log SDK derives `exception.type` and `exception.message` from the error. No event-to-span-event bridge implementation was found in these releases. |
 | Java 1.64.0 | `Span.addEvent` / `recordException` are present and not marked deprecated; `LogRecordBuilder.setEventName` is available since 1.50.0 and `setException(Throwable)` since 1.60.0. The bridge is available in `opentelemetry-sdk-extension-incubator`; the older Java contrib bridge is deprecated. |
 | JavaScript / TypeScript 2.9.0 / experimental 0.220.0 | `Span.addEvent` / `recordException` are present and not marked deprecated; `@opentelemetry/api-logs` / `@opentelemetry/sdk-logs` support `eventName`; the `exception` log-record field is marked experimental. No event-to-span-event bridge implementation was found in these releases. |
-| Python 1.43.0 | `span.add_event` / `record_exception` are present and not marked deprecated; `opentelemetry._logs.Logger.emit` accepts `event_name` and `exception`, and the SDK derives exception attributes. No event-to-span-event bridge implementation was found in this release. |
-| .NET 1.16.0 | `ActivityExtensions.RecordException` is `[Obsolete]` and points to `Activity.AddException`; both record span events. `TelemetrySpan.AddEvent` / `RecordException` are not marked obsolete. `ILogger` supplies an event name through `EventId.Name`; the lower-level Logs API is pre-release. No event-to-span-event bridge implementation was found in this release. |
+| Python 1.44.0 / 0.65b0 | `span.add_event` / `record_exception` are present and not marked deprecated; `opentelemetry._logs.Logger.emit` accepts `event_name` and `exception`, and the SDK derives exception attributes. The deprecated standalone Events API/SDK was removed in favor of `LogRecord` with `event_name`. No event-to-span-event bridge implementation was found in this release. |
+| .NET 1.17.0 | `ActivityExtensions.RecordException` is `[Obsolete]` and points to `Activity.AddException`; both record span events. `TelemetrySpan.AddEvent` / `RecordException` are not marked obsolete. `ILogger` supplies an event name through `EventId.Name`; the lower-level Logs API is pre-release. No event-to-span-event bridge implementation was found in this release. |
 
 Treat the deprecation as the accepted direction, not a completed spec change; verify the current status of each step against the linked sources before making hard claims.
 

--- a/skills/otel-span-events-to-logs-migration/references/migration-patterns.md
+++ b/skills/otel-span-events-to-logs-migration/references/migration-patterns.md
@@ -29,20 +29,23 @@ record := log.Record{}
 record.SetTimestamp(time.Now())
 record.SetEventName(exceptionEventName)
 record.SetSeverity(log.SeverityError)
+record.SetErr(err) // the SDK derives exception.type and exception.message
 // exception.stacktrace is intentionally omitted: the Go error value does
 // not carry its origin stack, and capturing runtime.Stack here would
 // point at the emit site, not where the error arose. Per semconv, the
 // attribute is Recommended, not Required. If the project uses an error
 // library that preserves the origin stack (e.g., github.com/pkg/errors,
-// github.com/cockroachdb/errors), extract the stack from the error and
-// add an exception.stacktrace attribute. Do not call runtime.Stack here.
-record.AddAttributes(
-    log.String("exception.type", fmt.Sprintf("%T", err)),
-    log.String("exception.message", err.Error()),
-)
+// github.com/cockroachdb/errors), see the note below. Do not call
+// runtime.Stack here.
 logger.Emit(ctx, record)
 span.SetStatus(codes.Error, err.Error())
 ```
+
+Go log SDK 0.20.0 derives `exception.type` and `exception.message` from
+`SetErr`. If `exception.type`, `exception.message`, or `exception.stacktrace`
+is supplied explicitly, this SDK release suppresses all automatic exception
+derivation. When an error library preserves the origin stack, set all three
+attributes together instead of adding only the stacktrace.
 
 Prefer `record.SetEventName(name)` over adding an `event.name` attribute in Go: it is a first-class field on `log.Record` and produces cleaner output in backends that special-case event records.
 


### PR DESCRIPTION
## Summary

- Refresh exact released SDK/proto/spec versions.
- Document Python 1.44 removal of the standalone Events API/SDK.
- Replace stale Go exception handling with released `Record.SetErr` behavior.

## Verification

- Tagged assertions across spec, proto, semconv, Go, Java, JS, Python, and .NET.
- `skills-ref`, registration, shell/scanner checks, source paths, and `git diff --check`.

## Deliberately excluded

- Main-only Go derivation behavior and other post-tag changes; no new languages.

Agent-authored periodic refresh; human-owned repository PR.