### PR TITLE
docs(otel-java): point at Ecosystem Explorer for instrumentation telemetry

### DIFF
--- a/skills/otel-java/SKILL.md
+++ b/skills/otel-java/SKILL.md
@@ -52,8 +52,8 @@ Version-specific or *"what changed between releases"*:
 `https://explorer.opentelemetry.io/data/javaagent/versions/<version>-index.json` gives the
 `id`→`hash` map for a version — a differing hash for the same `id` across two versions means that
 instrumentation changed. Schema:
-`https://explorer.opentelemetry.io/schemas/javaagent-instrumentation.schema.json`; `/llms.txt` is
-the full index.
+`https://explorer.opentelemetry.io/schemas/javaagent-instrumentation.schema.json`; use
+`/llms.txt` for the agent-oriented index and `/llms-full.txt` for the full documentation.
 
 Prefer this Explorer data over the raw `ecosystem-registry` YAML on GitHub: the Explorer applies
 upstream metadata corrections that the raw registry does not.

--- a/skills/otel-java/SKILL.md
+++ b/skills/otel-java/SKILL.md
@@ -30,6 +30,33 @@ For Java-specific facts:
 | Javaagent CHANGELOG (when each schema rc landed) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/CHANGELOG.md` |
 | Spring Boot Starter declarative-config fixture (selected starter tag) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/smoke-tests-otel-starter/spring-boot-2/src/testDeclarativeConfig/resources/application.yaml` |
 | Spring Boot starter docs | `WebFetch https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/` |
+| Per-instrumentation telemetry & config (resolved spans/attributes, metrics, config options, target versions) | `WebFetch https://explorer.opentelemetry.io/data/javaagent/instrumentations/<id>/<id>-<hash>.json` — get `<id>` and the latest `<hash>` from the index (see [below](#what-telemetry-does-an-instrumentation-emit)) |
+
+## What telemetry does an instrumentation emit?
+
+For *"what does the agent produce for library X"* — which spans, attributes, metrics, or config
+knobs — use the [OpenTelemetry Ecosystem Explorer](https://explorer.opentelemetry.io/), which fully
+maps the Java agent and exposes an agent-friendly surface (Markdown indexes and resolved JSON, no
+scraping). Do **not** answer from model memory.
+
+Navigation:
+
+1. `WebFetch https://explorer.opentelemetry.io/agent/javaagent/index.md` — table mapping display
+   name → `id` → the instrumentation's JSON data URL (the URL embeds the content `<hash>`).
+2. `WebFetch` that JSON URL — one self-contained record (a few KB): resolved `configurations`,
+   `telemetry` (spans with `span_kind` + typed attributes, and `metrics`),
+   `javaagent_target_versions`, `semantic_conventions`, and `scope`.
+
+Version-specific or *"what changed between releases"*:
+`https://explorer.opentelemetry.io/agent/javaagent/versions.md` lists versions and marks the latest;
+`https://explorer.opentelemetry.io/data/javaagent/versions/<version>-index.json` gives the
+`id`→`hash` map for a version — a differing hash for the same `id` across two versions means that
+instrumentation changed. Schema:
+`https://explorer.opentelemetry.io/schemas/javaagent-instrumentation.schema.json`; `/llms.txt` is
+the full index.
+
+Prefer this Explorer data over the raw `ecosystem-registry` YAML on GitHub: the Explorer applies
+upstream metadata corrections that the raw registry does not.
 
 ## Cross-References
 


### PR DESCRIPTION
## Summary

`otel-java` had no source of truth for **what telemetry an instrumentation actually emits** (spans, attributes, metrics) or which config options affect it. This adds the [OpenTelemetry Ecosystem Explorer](https://explorer.opentelemetry.io/) — which fully maps the Java agent — as that source, using its purpose-built **agent surface** (`/agent/javaagent/index.md` → fully-resolved per-instrumentation JSON), plus the per-version index for version-accurate and "what changed between releases" lookups.

## Agent involvement

Implemented by Claude Code (Opus 4.8); a human (me) reviewed and owns this PR.

## Harness results (required for new or substantively changed skills)

- **Prompt:** *Using the OpenTelemetry Java agent v2.29.0, what spans and metrics does the `apache-httpclient-5.2` instrumentation emit, what attributes are on those spans, and which configuration options affect it?*
- **Model + harness:** Claude Code with claude-opus-4-8, fresh sessions per arm.
- **Ground truth** (verified from the v2.29.0 record, hash `7e8fa2c263b4`): CLIENT span with 9 attrs (`error.type, http.request.method, http.request.method_original, http.request.resend_count, http.response.status_code, network.protocol.version, server.address, server.port, url.full`); one metric `http.client.request.duration` (histogram, `s`) with 5 attrs; no per-instrumentation config block.

| | Without skill (model knowledge only) | With skill (directed to Explorer) |
|---|---|---|
| Span attributes | ✗ missed `http.request.resend_count`; hallucinated `network.protocol.name`, `network.peer.address/port`, header attrs | ✓ exact 9/9 |
| Metric | ~ correct name; added a non-default attr; invented experimental body-size metrics | ✓ exact name/unit/5 attrs |
| Config options | ✗ plausible but unverifiable, guessed names | ✓ correctly reported no per-instrumentation config for v2.29.0 |
| Version accuracy | none — self-rated low/medium, "approximate, not authoritative for v2.29.0" | version-pinned via 2.29.0 index hash; self-rated high |

**Delta:** without the skill the model produced partly-hallucinated, non-version-specific detail and flagged its own low confidence; with the skill it returned the exact, version-pinned record.

_Transcripts: run in the authoring session; can attach a gist on request._

## Checklist

- [x] I read and agree to follow the Code of Conduct
- [x] `skills-ref validate skills/otel-java` passes
- [x] `python .github/scripts/check-skill-registration.py` passes
- [x] Skill registered in all three places — n/a, no skill added/renamed
- [x] Content is vendor-neutral, non-opinionated, DRY, and token-efficient
- [x] Harness comparison results included above
- [x] Commit messages follow Conventional Commits
- [x] I have signed (or will sign via the CLA bot on this PR) the OllyGarden CLA



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for reviewing telemetry emitted by OpenTelemetry Java instrumentation.
  * Documented how to use the OpenTelemetry Ecosystem Explorer to locate instrumentation details, fetch resolved per-instrumentation telemetry/config data, and compare versions via hashes.
  * Clarified that Explorer-resolved data should be preferred over raw registry content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->