### PR TITLE
docs(otel-js): refresh released sources

### DIFF
--- a/skills/otel-js/SKILL.md
+++ b/skills/otel-js/SKILL.md
@@ -24,10 +24,10 @@ For Node.js-specific facts:
 | Latest `@opentelemetry/configuration` | `npm view @opentelemetry/configuration version` |
 | Latest `@opentelemetry/sdk-node` | `npm view @opentelemetry/sdk-node version` |
 | Latest `@opentelemetry/auto-instrumentations-node` | `npm view @opentelemetry/auto-instrumentations-node version` |
-| Package status / breaking changes | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/configuration/README.md` and `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/opentelemetry-sdk-node/README.md` |
-| `sdk-node` CHANGELOG (experimental packages) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/CHANGELOG.md` |
-| ESM / CJS preload mechanics | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/doc/esm-support.md` |
-| Auto-instrumentations register entry point | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js-contrib/main/packages/auto-instrumentations-node/README.md` |
+| Released package status / breaking changes (`2.10.0` / `0.221.0`) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/configuration/README.md` and `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/opentelemetry-sdk-node/README.md` |
+| Experimental CHANGELOG through `0.221.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/CHANGELOG.md` |
+| ESM / CJS preload mechanics at `2.10.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/doc/esm-support.md` |
+| Auto-instrumentations register entry point at `0.79.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js-contrib/auto-instrumentations-node-v0.79.0/packages/auto-instrumentations-node/README.md` |
 | Node.js getting-started docs | `WebFetch https://opentelemetry.io/docs/languages/js/getting-started/nodejs/` |
 
 ## Cross-References

--- a/skills/otel-js/references/declarative-setup.md
+++ b/skills/otel-js/references/declarative-setup.md
@@ -19,13 +19,13 @@ skill. For JS-specific facts:
 | Latest `@opentelemetry/configuration` | `npm view @opentelemetry/configuration version` |
 | Latest `@opentelemetry/sdk-node` | `npm view @opentelemetry/sdk-node version` |
 | Latest `@opentelemetry/auto-instrumentations-node` | `npm view @opentelemetry/auto-instrumentations-node version` |
-| Package status / breaking changes | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/configuration/README.md` and `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/opentelemetry-sdk-node/README.md` |
-| SDK declarative startup helper | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/opentelemetry-sdk-node/src/start.ts` |
-| File config parser for current source (`file_format` acceptance) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/configuration/src/FileConfigFactory.ts` |
-| File config fixtures for current source | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/packages/configuration/test/fixtures/sdk-config.yaml` |
-| `sdk-node` CHANGELOG (experimental packages) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/experimental/CHANGELOG.md` |
-| ESM / CJS preload mechanics | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/doc/esm-support.md` |
-| Auto-instrumentations register entry point | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js-contrib/main/packages/auto-instrumentations-node/README.md` |
+| Released package status / breaking changes (`2.10.0` / `0.221.0`) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/configuration/README.md` and `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/opentelemetry-sdk-node/README.md` |
+| SDK declarative startup helper at `0.221.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/opentelemetry-sdk-node/src/start.ts` |
+| Released file config parser (`file_format` acceptance) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/configuration/src/FileConfigFactory.ts` |
+| Released file config fixtures | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/configuration/test/fixtures/sdk-config.yaml` |
+| Experimental CHANGELOG through `0.221.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/CHANGELOG.md` |
+| ESM / CJS preload mechanics at `2.10.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/doc/esm-support.md` |
+| Auto-instrumentations register entry point at `0.79.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js-contrib/auto-instrumentations-node-v0.79.0/packages/auto-instrumentations-node/README.md` |
 | Node.js getting-started docs | `WebFetch https://opentelemetry.io/docs/languages/js/getting-started/nodejs/` |
 
 ## Activation
@@ -122,3 +122,4 @@ declarative YAML via `OTEL_CONFIG_FILE`.
 - **`@opentelemetry/sdk-node` is experimental** but is the recommended way to set up OTel in Node.js. It handles context manager, propagator, and provider registration automatically.
 - **v2.0 migration**: `Resource` class is no longer exported. Use `resourceFromAttributes()`, `defaultResource()`, `emptyResource()` instead.
 - **2.9.0 / 0.220.0 migration note**: `@opentelemetry/sdk-node` now uses `@opentelemetry/sdk-trace`; the `node` and `tracing` namespace re-exports are deprecated. Import trace SDK types/classes directly from their packages.
+- **2.10.0 / 0.221.0 propagator note**: Selecting `jaeger` through `OTEL_PROPAGATORS` or declarative config emits a deprecation warning. Use `tracecontext`; the Jaeger propagator still works in this release but is planned for removal.


### PR DESCRIPTION
## Summary

- Pin JavaScript source pointers to the released `v2.10.0` / `0.221.0` baseline and auto-instrumentations `v0.79.0`.
- Document the released Jaeger propagator deprecation and recommend `tracecontext`.

## Verification

- `skills-ref validate skills/otel-js`
- `python3 .github/scripts/check-skill-registration.py`
- `git diff --check -- skills/otel-js`
- Released tag, package-version, path, and export checks against the synchronized local upstream checkouts.

## Deliberately excluded

- Unreleased `main` changes.
- Unrelated semantic-convention, logging SDK, and dependency-only instrumentation catalog changes.

Agent-authored periodic refresh; human-owned repository PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenTelemetry JavaScript reference links to specific, versioned release artifacts for improved accuracy.
  * Refreshed declarative setup documentation with current configuration and SDK references.
  * Added guidance that the Jaeger propagator is deprecated and recommended `tracecontext` as the preferred option, while noting Jaeger remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->