### PR TITLE
docs(otel-browser): refresh released APIs

### DIFF
--- a/skills/otel-browser/references/instrumentation.md
+++ b/skills/otel-browser/references/instrumentation.md
@@ -195,6 +195,11 @@ registerInstrumentations({
 | `instrumentation-web-exception` | js-contrib | Event-based unhandled exception capture. |
 | `plugin-react-load` | js-contrib | React component mount/load performance; **unmaintained** upstream. |
 
+The released fetch/XHR instrumentations `0.221.0` and document-load `0.66.0` emit only the stable
+HTTP semantic conventions. Their `semconvStabilityOptIn` migration option and legacy attributes
+(`http.method`, `http.url`, `http.status_code`, …) are gone; query the stable names such as
+`http.request.method`, `url.full`, and `http.response.status_code`.
+
 ### fetch / XHR cross-origin propagation
 
 ```typescript

--- a/skills/otel-browser/references/setup-sdk.md
+++ b/skills/otel-browser/references/setup-sdk.md
@@ -77,9 +77,11 @@ const resource = defaultResource().merge(
 const provider = new WebTracerProvider({
   resource,
   spanProcessors: [
-    new BatchSpanProcessor(
-      new OTLPTraceExporter({ url: 'https://collector.example.com/v1/traces' }),
-    ),
+    new BatchSpanProcessor({
+      exporter: new OTLPTraceExporter({
+        url: 'https://collector.example.com/v1/traces',
+      }),
+    }),
   ],
 });
 

--- a/skills/otel-browser/references/setup-sdk.md
+++ b/skills/otel-browser/references/setup-sdk.md
@@ -77,11 +77,9 @@ const resource = defaultResource().merge(
 const provider = new WebTracerProvider({
   resource,
   spanProcessors: [
-    new BatchSpanProcessor({
-      exporter: new OTLPTraceExporter({
-        url: 'https://collector.example.com/v1/traces',
-      }),
-    }),
+    new BatchSpanProcessor(
+      new OTLPTraceExporter({ url: 'https://collector.example.com/v1/traces' }),
+    ),
   ],
 });
 


### PR DESCRIPTION
## Summary

- Document the stable-only HTTP semantic conventions in released fetch/XHR `0.221.0` and document-load `0.66.0`.
- Preserve the positional `BatchSpanProcessor(exporter, config?)` constructor re-exported by `@opentelemetry/sdk-trace-web` in JavaScript `2.10.0`.

## Verification

- `skills-ref validate skills/otel-browser`
- `python3 .github/scripts/check-skill-registration.py`
- `git diff --check -- skills/otel-browser`
- Released-tag source assertions for the `sdk-trace-web` processor API, HTTP semantics, and the browser SDK sampler limitation.
- Relative Markdown target validation.

## Deliberately excluded

- Unreleased browser SDK sampler wiring and user-action custom-attribute changes.
- Post-release JavaScript contrib fixes.

Agent-authored periodic refresh; human-owned repository PR.