### PR TITLE
docs(otel-collector-builder): refresh released OCB

### DIFF
--- a/skills/otel-collector-builder/SKILL.md
+++ b/skills/otel-collector-builder/SKILL.md
@@ -26,7 +26,7 @@ Pick the OCB version equal to the Collector core version you're targeting.
 ```bash
 # Release binary (named ocb): https://github.com/open-telemetry/opentelemetry-collector-releases/releases?q=cmd/builder
 # Go install (binary is named `builder`, not `ocb`):
-go install go.opentelemetry.io/collector/cmd/builder@v0.156.0
+go install go.opentelemetry.io/collector/cmd/builder@v0.157.0
 ```
 
 `ocb init` (experimental) scaffolds a new distribution repo — manifest, Makefile, sample config, README — in `--path` (default `.`).
@@ -42,18 +42,18 @@ dist:
   version: 1.0.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.156.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.157.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.156.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.157.0
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.156.0
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.156.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.157.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.157.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.62.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.62.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.63.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.63.0
 ```
 
 **`providers:` semantics.** Omitting the key entirely keeps OCB's built-in default set (env, file, http, https, yaml at the paired stable version). But setting `providers:` at all **replaces** that set. The generated Collector defaults `conf_resolver.default_uri_scheme` to `env`, so an explicit list without `envprovider` fails configuration validation unless you set another included provider as the default. Either omit the key, or include `envprovider` plus every scheme the collector's config will use.
@@ -62,7 +62,7 @@ Contrib components use the same list syntax:
 
 ```yaml
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.157.0
 ```
 
 ## Version alignment
@@ -71,14 +71,14 @@ Two version streams exist and must be paired:
 
 | Stream | Modules | Example |
 |--------|---------|---------|
-| `v0.x.0` | OCB itself, all core components (`go.opentelemetry.io/collector/...`), all contrib components | `v0.156.0` |
-| `v1.y.0` (stable) | confmap providers (`confmap/provider/...`), other 1.x modules (pdata, etc.) | `v1.62.0` |
+| `v0.x.0` | OCB itself, all core components (`go.opentelemetry.io/collector/...`), all contrib components | `v0.157.0` |
+| `v1.y.0` (stable) | confmap providers (`confmap/provider/...`), other 1.x modules (pdata, etc.) | `v1.63.0` |
 
 Rules:
 
 - Use the **same `v0.x.0`** for every core and contrib component, matched to the OCB version.
-- The paired provider version for a given release is authoritative in that release's embedded default manifest: `https://github.com/open-telemetry/opentelemetry-collector/blob/cmd/builder/v0.x.0/cmd/builder/internal/config/default.yaml` — check it rather than guessing (for `v0.156.0` it is `v1.62.0`).
-- Versions require the `v` prefix (`v0.156.0`, not `0.156.0`).
+- The paired provider version for a given release is authoritative in that release's embedded default manifest: `https://github.com/open-telemetry/opentelemetry-collector/blob/cmd/builder/v0.x.0/cmd/builder/internal/config/default.yaml` — check it rather than guessing (for `v0.157.0` it is `v1.63.0`).
+- Versions require the `v` prefix (`v0.157.0`, not `0.157.0`).
 - `--skip-strict-versioning` defaults to `true`, so mismatches surface as Go module resolution errors, not friendly OCB errors. Align versions up front instead of debugging `go mod tidy` output.
 
 ## Build commands and flags

--- a/skills/otel-collector-builder/SKILL.md
+++ b/skills/otel-collector-builder/SKILL.md
@@ -29,6 +29,9 @@ Pick the OCB version equal to the Collector core version you're targeting.
 go install go.opentelemetry.io/collector/cmd/builder@v0.157.0
 ```
 
+The commands below use `ocb`, the release-archive binary name. If you install with
+`go install`, invoke the same commands as `builder ...` instead.
+
 `ocb init` (experimental) scaffolds a new distribution repo — manifest, Makefile, sample config, README — in `--path` (default `.`).
 
 ## Minimal manifest
@@ -77,7 +80,7 @@ Two version streams exist and must be paired:
 Rules:
 
 - Use the **same `v0.x.0`** for every core and contrib component, matched to the OCB version.
-- The paired provider version for a given release is authoritative in that release's embedded default manifest: `https://github.com/open-telemetry/opentelemetry-collector/blob/cmd/builder/v0.x.0/cmd/builder/internal/config/default.yaml` — check it rather than guessing (for `v0.157.0` it is `v1.63.0`).
+- The paired provider version for a given release is authoritative in that release's embedded default manifest: `https://github.com/open-telemetry/opentelemetry-collector/blob/cmd/builder/v0.157.0/cmd/builder/internal/config/default.yaml` — check it rather than guessing (for `v0.157.0` it is `v1.63.0`).
 - Versions require the `v` prefix (`v0.157.0`, not `0.157.0`).
 - `--skip-strict-versioning` defaults to `true`, so mismatches surface as Go module resolution errors, not friendly OCB errors. Align versions up front instead of debugging `go mod tidy` output.
 

--- a/skills/otel-collector-builder/references/manifest.md
+++ b/skills/otel-collector-builder/references/manifest.md
@@ -70,11 +70,11 @@ Providers implement config URI schemes. The built binary can only load config th
 
 ```yaml
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.62.0   # file: and bare paths
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.62.0    # env: (${env:VAR})
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.62.0   # http://
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.62.0  # https://
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.62.0   # yaml: (inline YAML)
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.63.0   # file: and bare paths
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.63.0    # env: (${env:VAR})
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.63.0   # http://
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.63.0  # https://
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.63.0   # yaml: (inline YAML)
 ```
 
 Providers version on the stable `v1.y.0` stream (see the version-alignment section in SKILL.md for the pairing rule).
@@ -98,7 +98,7 @@ Advanced, single module (not a list). Overrides the collector's internal-telemet
 
 ```yaml
 telemetry:
-  gomod: go.opentelemetry.io/collector/service v0.156.0
+  gomod: go.opentelemetry.io/collector/service v0.157.0
   import: go.opentelemetry.io/collector/service/telemetry/otelconftelemetry
 ```
 
@@ -141,29 +141,29 @@ dist:
   version: 2.1.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.156.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.156.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.157.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.157.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.156.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.156.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.156.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.157.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.157.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.157.0
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.156.0
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.156.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.157.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.157.0
 
 extensions:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension v0.156.0
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension v0.157.0
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.157.0
 
 connectors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.157.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.62.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.62.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.62.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.63.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.63.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.63.0
 
 replaces:
   - github.com/acme/private-exporter => ../private-exporter

--- a/skills/otel-collector-builder/references/troubleshooting.md
+++ b/skills/otel-collector-builder/references/troubleshooting.md
@@ -19,7 +19,7 @@ Symptoms: `go mod tidy` errors during the "get modules" step, `there is a mismat
 Fix: align every core and contrib component on the same `v0.x.0` matching the OCB version, and providers on the paired `v1.y.0` (pairing rule in SKILL.md). Common mistakes:
 
 - One component pinned at an older `v0.x.0` than the rest — Go resolves the highest requested version and the manifest no longer matches reality.
-- Version written without the `v` prefix (`0.156.0`) — module query fails outright.
+- Version written without the `v` prefix (`0.157.0`) — module query fails outright.
 - OCB binary older than the component versions in the manifest — upgrade OCB first; the generated templates encode assumptions about the core APIs of the matching release.
 
 Strict checking is off by default; run with `--skip-strict-versioning=false` to make OCB verify resolved versions against the manifest instead of failing later in `go build`.
@@ -49,7 +49,7 @@ The manifest set `providers:` explicitly and omitted `envprovider`. The key **re
 - `cgo: C compiler "gcc" not found`: a component needs CGO. Either install a C toolchain and set `dist.cgo_enabled: true`, or drop the component. Default is CGO off.
 - `build constraints exclude all Go files`: `dist.build_tags` or `GOOS`/`GOARCH` excludes everything — clear the tags or fix the target platform.
 - OOM on small CI runners: the collector dependency graph is large. `GOMAXPROCS=2 ocb --config=builder.yaml`, or split into generate + `go build` stages.
-- `exec: "go": executable file not found`: install a compatible Go toolchain or set `dist.go` to its path. OCB v0.156.0 declares Go 1.25 and runs `go mod tidy -compat=1.25`; selected modules may require newer Go.
+- `exec: "go": executable file not found`: install a compatible Go toolchain or set `dist.go` to its path. OCB v0.157.0 declares Go 1.25 and runs `go mod tidy -compat=1.25`; selected modules may require newer Go.
 
 ## Runtime failures
 

--- a/skills/otel-collector-builder/references/workflows.md
+++ b/skills/otel-collector-builder/references/workflows.md
@@ -24,7 +24,7 @@ receivers:
 Requirements:
 
 - The local directory must contain a `go.mod` whose module path matches the `gomod` path.
-- Run OCB with a Go toolchain new enough for both OCB and the selected modules. OCB v0.156.0 declares Go 1.25, generates a `go 1.25` module, and runs `go mod tidy -compat=1.25`; a local component that requires newer Go needs that newer toolchain.
+- Run OCB with a Go toolchain new enough for both OCB and the selected modules. OCB v0.157.0 declares Go 1.25, generates a `go 1.25` module, and runs `go mod tidy -compat=1.25`; a local component that requires newer Go needs that newer toolchain.
 - Since v0.151.0 the generated `replace` uses a path relative to `dist.output_path`, so the generated tree can be committed or moved. Set `dist.use_absolute_replace_paths: true` if external tooling expects absolute paths.
 
 This is also the fastest verification loop when authoring a new component: manifest with the local component + `otlpreceiver` + `debugexporter`, build, run, send data with `telemetrygen`.
@@ -56,7 +56,7 @@ Run OCB in a container (no local Go needed):
 
 ```bash
 docker run --rm -v "$(pwd):/work" -w /work \
-  otel/opentelemetry-collector-builder:0.156.0 \
+  otel/opentelemetry-collector-builder:0.157.0 \
   --config=/work/builder.yaml
 ```
 
@@ -68,7 +68,7 @@ Typical multi-stage Dockerfile for shipping the result:
 FROM golang:1.25 AS build
 WORKDIR /build
 COPY builder.yaml .
-RUN go install go.opentelemetry.io/collector/cmd/builder@v0.156.0 \
+RUN go install go.opentelemetry.io/collector/cmd/builder@v0.157.0 \
  && builder --config=builder.yaml
 
 FROM gcr.io/distroless/static-debian12:nonroot


### PR DESCRIPTION
## Summary

- Advance OCB, core, and contrib examples to released `v0.157.0`.
- Advance the paired stable provider modules to released `v1.63.0`.
- Keep manifest, troubleshooting, workflow, and toolchain guidance aligned with the released builder source.

## Verification

- `skills-ref validate skills/otel-collector-builder`
- `python3 .github/scripts/check-skill-registration.py`
- `git diff --check -- skills/otel-collector-builder`
- Built and ran OCB from the exact `cmd/builder/v0.157.0` source tag.
- Generated a distribution from the updated minimal manifest and ran focused builder/config tests.
- Verified all documented released module paths and paired defaults.

## Deliberately excluded

- Unreleased post-`v0.157.0` changes.
- Full Collector compilation/runtime validation, because the required modules were unavailable offline; released-source build and focused tests passed.

Agent-authored periodic refresh; human-owned repository PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OpenTelemetry Collector Builder guidance, examples, and references to align with v0.157.0 (and related module/provider versions).
  * Refreshed workflow instructions, Docker build tags, and example configuration snippets to the new builder and provider versions.
  * Updated troubleshooting notes and version-alignment tables, including the authoritative reference link.
  * Bumped documented provider and gomod versions in the manifest reference for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->