### PR TITLE
docs(otel-semantic-conventions): correct lookup modes

### DIFF
--- a/skills/otel-semantic-conventions/references/otel-semantic-conventions.md
+++ b/skills/otel-semantic-conventions/references/otel-semantic-conventions.md
@@ -8,14 +8,16 @@ Do not load the full semantic convention spec into context. Query only the neede
 Use:
 - list groups: `./scripts/query-otel-semantic-conventions.sh --groups`
 - group lookup: `./scripts/query-otel-semantic-conventions.sh http`
-- exact attribute: `./scripts/query-otel-semantic-conventions.sh http http.request.method`
+- kind lookup: `./scripts/query-otel-semantic-conventions.sh http spans`
+- exact entry: `./scripts/query-otel-semantic-conventions.sh http http.request.method`
 - local checkout mode: `OTEL_SEMCONV_REPO=/path/to/semantic-conventions ./scripts/query-otel-semantic-conventions.sh http`
 
 Rules:
 - use `--groups` first if you do not already know the right group
 - start with one group
 - use the one-argument form first to discover the current released attribute ids and available kinds
-- use the two-argument form only when you need the exact upstream definition block for one attribute
+- pass a listed kind as the second argument to list the released entries of that kind
+- pass an exact entry id as the second argument to return its upstream definition block
 - the script resolves the latest released semantic conventions version and reads released YAML model files under `model/<group>/` from that tag
 - deprecated model files and directories are excluded from lookup results
 - the core semantic-conventions repository added `model/manifest.yaml` in v1.43.0; use it as release metadata, not as a convention group

--- a/skills/otel-semantic-conventions/references/semconv-selection.md
+++ b/skills/otel-semantic-conventions/references/semconv-selection.md
@@ -31,9 +31,9 @@ Use the bundled script instead of loading large spec files:
 
 1. `./scripts/query-otel-semantic-conventions.sh --groups`
 2. `./scripts/query-otel-semantic-conventions.sh <group>`
-3. `./scripts/query-otel-semantic-conventions.sh <group> <attribute-id>`
+3. `./scripts/query-otel-semantic-conventions.sh <group> <kind-or-entry-id>`
 
-Use the one-argument form first. Use the two-argument form only when you need the exact released upstream definition for a single attribute.
+Use the one-argument form first. Pass a listed kind to enumerate its entries, or pass an exact entry id to return its released upstream definition.
 To verify against a local upstream checkout, set `OTEL_SEMCONV_REPO=/path/to/semantic-conventions`.
 
 ## Typical Group Pairings


### PR DESCRIPTION
## Summary

- Correct the semantic-conventions lookup documentation to distinguish kind listings from exact entry-ID lookups.
- Keep the dynamic released-data workflow intact without adding hardcoded catalog content.

## Verification

- 81/81 released group queries and 175/175 group/kind queries passed against `v1.43.0`.
- Representative metric, span, event, entity, and attribute entry lookups passed.
- Released-tag compatibility passed for `v1.41.1`, `v1.42.0`, and `v1.43.0`.
- `skills-ref validate skills/otel-semantic-conventions`
- `bash -n skills/otel-semantic-conventions/scripts/query-otel-semantic-conventions.sh`
- `git diff --check -- skills/otel-semantic-conventions`

## Deliberately excluded

- Unreleased `v1.44.0` model changes.
- The separate GenAI semantic-conventions repository.

Agent-authored periodic refresh; human-owned repository PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to use the OpenTelemetry semantic convention lookup helper.
  * Added examples for listing available kinds and retrieving exact released attribute definitions.
  * Documented when to use one-argument versus two-argument lookup commands and updated local checkout guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->