### PR TITLE
docs(otel-ottl): refresh released functions

### DIFF
--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -7,7 +7,7 @@ description: OpenTelemetry Transformation Language (OTTL) expert for writing and
 
 OTTL is a domain-specific language for transforming telemetry inside the OpenTelemetry Collector. It is consumed by the `transform`, `filter`, and `tail_sampling` processors, the `routing` connector, and a few other components in [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl).
 
-This skill targets `pkg/ottl` as of collector-contrib **v0.156.0**. Function and path availability differs across Collector releases; check the upstream `pkg/ottl/ottlfuncs/README.md` and `pkg/ottl/contexts/*/README.md` for the exact set in older or newer releases.
+This skill targets `pkg/ottl` as of collector-contrib **v0.157.0**. Function and path availability differs across Collector releases; check the upstream `pkg/ottl/ottlfuncs/README.md` and `pkg/ottl/contexts/*/README.md` for the exact set in older or newer releases.
 
 ## Statement syntax
 
@@ -26,7 +26,7 @@ set(span.attributes["env"], "prod") where resource.attributes["env"] == nil
 1. **Pick the component.** `transform` rewrites; `filter` drops; the `routing` connector fans out by pipeline; `tail_sampling` keeps/drops traces. The component decides which contexts and function set are usable.
 2. **Pick the context.** `resource`, `scope`, `span`, `spanevent`, `metric`, `datapoint`, `exemplar`, `log`, `profile`, `profilesample`, or `otelcol` for Collector request/client metadata. Operate at the lowest level that gives you the data — using `datapoint` to set attributes is much cheaper than walking through `metric.data_points` from the metric context.
 3. **Write statements.** Reach for `references/quick-reference.md` for common recipes; `references/contexts.md` for paths/enums; `references/functions.md` for the editor and converter catalog.
-4. **Set `error_mode`.** `ignore` keeps the pipeline running and logs errors; `silent` does the same but quietly; `propagate` aborts on first failure. In v0.156, `transform` and `filter` default to `ignore` through enabled beta feature gates; `routing` defaults to `propagate` unless `connector.routing.defaultErrorModeIgnore` is enabled; lower-level OTTL sequences default to `propagate`.
+4. **Set `error_mode`.** `ignore` keeps the pipeline running and logs errors; `silent` does the same but quietly; `propagate` aborts on first failure. In v0.157, `transform` and `filter` permanently default to `ignore` through stable feature gates; `routing` also defaults to `ignore` through the enabled beta `connector.routing.defaultErrorModeIgnore` gate (disable it to restore `propagate`). Lower-level OTTL sequences default to `propagate`.
 5. **Verify.** OTTL gotchas are the kind that pass the eye test (see [Common gotchas](#common-gotchas)). Use the [telemetrygen verification recipe](../otel-telemetrygen/SKILL.md#verifying-a-collector-config) — `otelcol-contrib` + file exporter + telemetrygen — to confirm the snippet does what the prose claims before shipping.
 
 ## Contexts at a glance
@@ -58,7 +58,7 @@ delete_matching_keys(target, regex)   # delete by regex
 delete_index(target, start, end?)     # remove one slice item or range (v0.145+)
 keep_keys(target, [k1, k2])           # keep only these keys
 merge_maps(target, source, "upsert")  # "insert" | "update" | "upsert"
-truncate_all(target, max_len)         # UTF-8 safe by default in v0.148+
+truncate_all(target, max_len, truncation_marker = "…") # marker optional in v0.157+
 replace_pattern(target, regex, replacement)
 stringify_all(target)                 # map values -> strings (v0.155+)
 
@@ -66,7 +66,7 @@ stringify_all(target)                 # map values -> strings (v0.155+)
 Concat([a, b], "-")
 Split(s, ",")
 ToLowerCase(s) / ToUpperCase(s)
-IsMatch(s, "pattern")                 # bool
+IsMatch(s, "pattern") / IsEmpty(v)    # bool
 String(v) / Int(v) / Double(v) / Bool(v)
 ParseJSON(s) / ParseKeyValue(s, "=", "&")
 URL(s)                                # parse URL components (v0.127+)
@@ -86,7 +86,7 @@ set(log.attributes["selected"], ParseJSON(log.body.string)[log.attributes["field
 
 Full catalog with signatures in `references/functions.md`.
 
-The `transform` processor also provides 17 signal-specific functions that are not
+The `transform` processor also provides 18 signal-specific functions that are not
 part of the common `pkg/ottl/ottlfuncs` catalog. See the
 [transform-only function table](references/functions.md#transform-processor-only-functions)
 for their contexts, signatures, and released-source links.
@@ -195,7 +195,7 @@ The OTel `attributes` processor only operates on span/log/metric attributes. To 
 
 ### Per-log resource/scope rewrites may need `flatten_data`
 
-Log records can share resource and scope data. When a log-context statement derives either from record-specific `log.*` data, set `flatten_data: true` and enable the alpha `transform.flatten.logs` feature gate; otherwise records in the same batch can affect one another unexpectedly. In v0.156 the gate is disabled and `flatten_data` is `false` by default. The option is logs-only and incurs copying, hashing, and regrouping overhead.
+Log records can share resource and scope data. When a log-context statement derives either from record-specific `log.*` data, set `flatten_data: true` and enable the alpha `transform.flatten.logs` feature gate; otherwise records in the same batch can affect one another unexpectedly. In v0.157 the gate is disabled and `flatten_data` is `false` by default. The option is logs-only and incurs copying, hashing, and regrouping overhead.
 
 ### `logdedup` paths use dot-notation only
 
@@ -240,6 +240,10 @@ Recently added (still useful to know which release introduced them when supporti
 
 | Feature | Since |
 |---------|-------|
+| Lambda converters `All`, `Any`, `Filter`, `Find`, `MapEach`, `MapKeys`, `Reduce`, `When` (alpha; require `ottl.functions.enableLambda`) | v0.157 |
+| `IsEmpty` converter; transform-only `ParseCEF` log converter | v0.157 |
+| `truncate_all` optional `truncation_marker` parameter | v0.157 |
+| `transform` / `filter` default-error gates stable; routing default-error gate beta (default `ignore`) | v0.157 |
 | Exemplar context (transform `metric_statements` only) | v0.156 |
 | Routing connector context inference (`condition` with context-qualified paths) | v0.156 |
 | Routing connector `request` context deprecated; use `otelcol.*` metadata paths | v0.156 |

--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -58,7 +58,7 @@ delete_matching_keys(target, regex)   # delete by regex
 delete_index(target, start, end?)     # remove one slice item or range (v0.145+)
 keep_keys(target, [k1, k2])           # keep only these keys
 merge_maps(target, source, "upsert")  # "insert" | "update" | "upsert"
-truncate_all(target, max_len, truncation_marker = "…") # marker optional in v0.157+
+truncate_all(target, max_len, utf8_safe = true, truncation_marker = "") # marker added in v0.157
 replace_pattern(target, regex, replacement)
 stringify_all(target)                 # map values -> strings (v0.155+)
 

--- a/skills/otel-ottl/references/contexts.md
+++ b/skills/otel-ottl/references/contexts.md
@@ -1,6 +1,6 @@
 # OTTL Contexts Reference
 
-Context paths and enums for collector-contrib **v0.156.0**. Higher-level contexts are reachable from lower ones (a span statement can read `resource.attributes`); the reverse is not true. Always pick the most specific context for the work — using `datapoint` to set metric-point attributes is much cheaper than walking through `metric.data_points` from the metric context.
+Context paths and enums for collector-contrib **v0.157.0**. Higher-level contexts are reachable from lower ones (a span statement can read `resource.attributes`); the reverse is not true. Always pick the most specific context for the work — using `datapoint` to set metric-point attributes is much cheaper than walking through `metric.data_points` from the metric context.
 
 ## Context hierarchy
 

--- a/skills/otel-ottl/references/functions.md
+++ b/skills/otel-ottl/references/functions.md
@@ -1,13 +1,13 @@
 # OTTL Functions Catalog
 
-Editor and converter reference for collector-contrib **v0.156.0**. Editors mutate telemetry; converters return values for use in expressions. See the upstream `pkg/ottl/ottlfuncs/README.md` for the authoritative source.
+Editor and converter reference for collector-contrib **v0.157.0**. Editors mutate telemetry; converters return values for use in expressions. See the upstream `pkg/ottl/ottlfuncs/README.md` for the authoritative source.
 
 ## Transform-processor-only functions
 
 The `transform` processor adds the following functions to the common OTTL
 catalog. They are not generally available in other OTTL-consuming components.
 The contexts and signatures below are pinned to the released
-[v0.156.0 transform processor source](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#supported-functions).
+[v0.157.0 transform processor source](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/README.md#supported-functions).
 
 | Context | Signature | Behavior and limits |
 |---------|-----------|---------------------|
@@ -25,18 +25,19 @@ The contexts and signatures below are pinned to the released
 | `metric` | `convert_exponential_histogram_to_histogram(distribution, explicit_bounds)` | Converts ExponentialHistogram to explicit Histogram using `upper`, `midpoint`, `uniform`, or `random`; bounds must be non-empty. This lossy conversion is not specified by OpenTelemetry. |
 | `metric` | `aggregate_on_attribute_value(function, attribute, values, new_value)` | Aggregates selected attribute values for Sum, Gauge, Histogram, or ExponentialHistogram datapoints; histogram types support only `sum`. |
 | `datapoint` | `merge_histogram_buckets(target_value, method?)` | Explicit Histograms only. Default `remove_explicit_bound` removes a matching bound; `limit_buckets` requires a positive integer target and reduces resolution. Other metric types are unchanged. |
+| `log` | `ParseCEF(target)` | Parses Common Event Format into a map, including an optional syslog prefix and string-valued extensions; malformed or empty input errors. |
 | `log` | `ParseCLF(target, format?)` | Parses CLF (`"clf"`, default) or NCSA combined (`"combined"`) text into a map; malformed or empty input errors. |
 | `log` | `ParseLEEF(target)` | Parses LEEF 1.0/2.0 into a map; malformed or empty input errors; attribute values remain strings. |
-| `span` | `set_semconv_span_name(semconv_version, original_span_name_attribute?)` | Derives low-cardinality HTTP, RPC, messaging, or database span names. v0.156 accepts semantic-convention versions 1.37.0 through 1.40.0; unrelated spans are unchanged. |
+| `span` | `set_semconv_span_name(semconv_version, original_span_name_attribute?)` | Derives low-cardinality HTTP, RPC, messaging, or database span names. v0.157 accepts semantic-convention versions 1.37.0 through 1.40.0; unrelated spans are unchanged. |
 
 For full behavior, examples, and edge cases, follow the tag-pinned
-[metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#convert_sum_to_gauge),
-[logs](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#parseclf), and
-[traces](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/README.md#set_semconv_span_name)
+[metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/README.md#convert_sum_to_gauge),
+[logs](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/README.md#parsecef), and
+[traces](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/README.md#set_semconv_span_name)
 function sections. The registrations that constrain the contexts are also tag-pinned:
-[metric/datapoint](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/internal/metrics/functions.go),
-[log](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/internal/logs/functions.go), and
-[span](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.156.0/processor/transformprocessor/internal/traces/functions.go).
+[metric/datapoint](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/internal/metrics/functions.go),
+[log](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/internal/logs/functions.go), and
+[span](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/internal/traces/functions.go).
 
 ## Editors (data manipulation)
 
@@ -101,10 +102,13 @@ merge_maps(span.attributes, ParseJSON(span.attributes["meta"]), "upsert")
 ```ottl
 truncate_all(target, max_length)
 truncate_all(target, max_length, utf8_safe = false)   # v0.148+
+truncate_all(target, max_length, truncation_marker = "(truncated)") # v0.157+
 truncate_all(span.attributes, 256)
 ```
 
 UTF-8 safe by default since v0.148 — truncates at character boundaries, so the result may be slightly shorter than `max_length`. Pass `utf8_safe = false` for the previous byte-level behavior.
+
+The optional `truncation_marker` is included inside `max_length`, so the complete result never exceeds the limit. A marker longer than the limit is an error.
 
 ### `stringify_all`
 ```ottl
@@ -225,10 +229,34 @@ Hex(bytes)               # bytes -> hex string
 ```ottl
 IsString(v) / IsInt(v) / IsDouble(v) / IsBool(v)
 IsList(v) / IsMap(v)
+IsEmpty(v)                                               # nil, zero value, or empty collection
 IsInCIDR(ip_string, ["10.0.0.0/8", "192.168.0.0/16"])   # v0.146+
 ```
 
 `IsInCIDR` returns `false` for invalid IP strings — useful in conditions: `where IsInCIDR(attributes["client.ip"], ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"])`.
+
+---
+
+## Lambda converters (v0.157+, alpha)
+
+These converters require the alpha `ottl.functions.enableLambda` feature gate.
+For slices, two-argument lambdas receive `(index, value)`; for maps they receive
+`(key, value)`. Use `_` for an ignored parameter.
+
+```ottl
+All(source, (k, v) => predicate)                 # every element; true for empty input
+Any(source, (k, v) => predicate)                 # at least one; false for empty input
+Filter(source, (k, v) => predicate)              # filtered slice or map
+Find(source, (k, v) => predicate, mapper?)        # first value, mapped value, or nil
+MapEach(source, (k, v) => mapped_value)           # transform values
+MapKeys(map, (k, v) => mapped_key)                # mapped_key must be a string
+Reduce(source, seed, (acc, k, v) => next_acc)     # fold; empty input returns seed
+When(() => condition, true_value, false_value)    # select one value
+```
+
+Map iteration order is not stable, so order-dependent `Reduce` expressions are
+not deterministic for maps. If `MapKeys` creates duplicate keys, which value is
+retained is unspecified.
 
 ---
 


### PR DESCRIPTION
## Summary

- Refresh OTTL guidance to released Collector Contrib `v0.157.0`.
- Add nine released common converters, transform-log-only `ParseCEF`, and `truncate_all` truncation-marker semantics.
- Correct released transform, filter, and routing error-mode gate/default behavior.

## Verification

- Official `0.157.0` binary config validation with and without `ottl.functions.enableLambda`.
- Runtime OTLP log exercise for the lambda converters, `IsEmpty`, `ParseCEF`, and truncation markers with no transform errors.
- Stable transform/filter gate and beta routing-gate expected-failure checks.
- Released function-catalog coverage and source-path/anchor checks.
- `skills-ref validate skills/otel-ottl`
- `python3 .github/scripts/check-skill-registration.py`
- `git diff --check -- skills/otel-ottl`

## Deliberately excluded

- Unreleased post-`v0.157.0` changes.
- Tail-sampling processor behavior outside the OTTL language/catalog scope.

Agent-authored periodic refresh; human-owned repository PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OTTL guidance and references to align with collector-contrib v0.157.0.
  * Added documentation for `ParseCEF(target)` and `IsEmpty(v)`, plus alpha lambda converters.
  * Extended `truncate_all` with an optional `truncation_marker` parameter and clarified its constraints.
  * Refreshed workflow guidance for default error modes in transform, filter, and routing.
  * Updated context references, function links, semantic convention wording, and versioning notes (including flattening behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->