### PR TITLE
docs(otel-java): refresh released configuration

### DIFF
--- a/skills/otel-java/references/declarative-setup.md
+++ b/skills/otel-java/references/declarative-setup.md
@@ -48,10 +48,9 @@ Declarative config has been supported since Javaagent 2.9.0; the property is now
 SDK 1.63.0 bundled with Javaagent 2.29.0). Newer agent versions track newer schema versions.
 Confirm both the accepted range and preferred `file_format` from the tag-matched parser, then use
 the preferred value from that release's fixture to avoid compatibility warnings for experimental
-properties. As of 2026-07-20, SDK BOM 1.64.0 accepts `0.4` and `1.*` and prefers `"1.1"`.
-Javaagent/Spring Boot Starter 2.29.0 targets SDK 1.63.0, whose parser accepts `0.4` and the
-`1.0` release/RC forms and prefers `"1.0"`; both released fixtures use the value `1.0`. Do not
-infer this from `main` or the generic language support matrix alone.
+properties. As of 2026-07-29, SDK BOM 1.64.0 and Javaagent/Spring Boot Starter 2.30.0 use SDK
+1.64.0: the parser accepts `0.4` and `1.*`, prefers `"1.1"`, and both released instrumentation
+fixtures use `1.1`. Do not infer this from `main` or the generic language support matrix alone.
 
 When `otel.config.file` / `OTEL_CONFIG_FILE` is set, all other SDK autoconfigure properties are
 ignored except agent-only properties (see Key API Facts).
@@ -107,19 +106,19 @@ AutoConfiguredOpenTelemetrySdk sdk =
 - **Spring Boot Starter activation**: unlike the Javaagent/autoconfigure, the starter does
   not load an external file. Embed the declarative config inline under the `otel:` key in
   `application.yaml` (or as `otel.*` properties in `application.properties`) and opt in by
-  setting `otel.file_format` (for example, `file_format: "1.0"` for starter 2.29.0; verify the
+  setting `otel.file_format` (for example, `file_format: "1.1"` for starter 2.30.0; verify the
   selected release fixture). The presence of `otel.file_format` is what switches the starter into
   declarative-config mode.
 - **Shutdown hook**: The Javaagent and autoconfigure both register a JVM shutdown hook automatically — no manual `sdk.close()` needed.
 - **Agent-only properties**: `otel.javaagent.extensions`, `otel.javaagent.enabled`, and
   `otel.javaagent.debug` cannot be set via declarative config. Set them as system properties or
   their corresponding environment variables instead.
-- **Released 2.29.0 selectors**: Javaagent and Starter declarative config can select semantic
+- **Released 2.30.0 selectors**: Javaagent and Starter declarative config can select semantic
   conventions per `db`, `code`, `rpc`, or `messaging` domain under
   `instrumentation/development.general.<domain>.semconv` with `version`, `experimental`, and
   `dual_emit`. `service.peer` is still flag-only in this release. Check the schema for supported
   value combinations; unsupported combinations fall back rather than forcing the requested mode.
-- **Starter thread details**: Starter 2.29.0 can add experimental `thread.id` and `thread.name`
+- **Starter thread details**: Starter 2.30.0 can add experimental `thread.id` and `thread.name`
   to spans with `distribution.spring_starter.thread_details_enabled: true`. This path is
   Starter-only; the Javaagent uses the separate
   `distribution.javaagent.thread_details_enabled` path.

--- a/skills/otel-java/references/sensitive-data-capture.md
+++ b/skills/otel-java/references/sensitive-data-capture.md
@@ -32,18 +32,18 @@ otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters=\
 
 - Type: list of case-sensitive parameter names. Setting it **replaces** the default list
   (full override, not additive) — re-list the credential defaults when extending it.
-- Declarative config limitation in Javaagent and Spring Boot Starter **v2.29.0**: custom
-  query-parameter redaction is not usable from the YAML file. The apparent
-  `sensitive_query_parameters/development` spelling is rejected during startup as an
-  unrecognized field. The unsuffixed `sensitive_query_parameters` spelling parses but is
-  silently ignored, leaving only the default credential list active. Marker requests confirm
-  that a custom parameter remains raw while `AWSAccessKeyId` is still redacted.
+- Declarative config limitation in Javaagent and Spring Boot Starter **v2.30.0**: custom
+  query-parameter redaction is not usable from the YAML file. The SDK 1.64.0 model accepts
+  unsuffixed `sensitive_query_parameters`, while the instrumentation reads
+  `sensitive_query_parameters/development`. The suffixed spelling is therefore rejected during
+  startup as an unrecognized field, and the unsuffixed spelling parses but is ignored, leaving
+  only the default credential list active.
 
-  If custom query redaction is required on v2.29.0, use the flat
+  If custom query redaction is required on v2.30.0, use the flat
   `otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters` property
-  without activating declarative file-config mode, or redact `url.query` / `url.full` in a
-  `SpanProcessor` or Collector processor. Do not infer that redaction works merely because a
-  YAML file parses and the application starts.
+  without activating declarative file-config mode, customize the HTTP instrumentation's attribute
+  extraction, or redact `url.query` / `url.full` in a Collector processor. Do not infer that
+  redaction works merely because a YAML file parses and the application starts.
 - History: replaces `otel.instrumentation.http.client.experimental.redact-query-parameters`
   (client-only; deprecated, then removed in 2026 releases —
   [#18229](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18229)).
@@ -100,7 +100,7 @@ config, or
 variable. Per-instrumentation toggles can take precedence. Older property spellings
 (`otel.instrumentation.common.db-statement-sanitizer.enabled` and per-instrumentation
 `*-statement-sanitizer.enabled` variants) are deprecated and, when
-`instrumentation/development.java.common.v3_preview: true` in Javaagent/Starter 2.29.0, ignored.
+`instrumentation/development.java.common.v3_preview: true` in Javaagent/Starter 2.30.0, ignored.
 Use the `db.query_sanitization.enabled` forms above. Do not turn sanitization off on request paths.
 
 JDBC's parameter-capture switch shown above is a separate opt-in. It emits raw values as
@@ -111,6 +111,6 @@ JDBC's parameter-capture switch shown above is a separate opt-in. It emits raw v
 | Fact | Fetch |
 |---|---|
 | HTTP capture properties (headers, servlet params, known-methods) | `WebFetch https://opentelemetry.io/docs/zero-code/java/agent/instrumentation/http/` |
-| Current property names/defaults incl. `sensitive-query-parameters` | any instrumentation `metadata.yaml` at the selected Javaagent tag, e.g. `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/instrumentation/jodd-http-4.2/metadata.yaml` |
+| Current property names/defaults incl. `sensitive-query-parameters` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/instrumentation-docs/src/main/resources/shared-config-definitions.yaml`; per-instrumentation `metadata.yaml` files reference these shared definitions |
 | Renames/removals of capture & sanitization properties | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/<selected-agent-tag>/CHANGELOG.md` |
 | Semconv redaction rules for `url.query`/`url.full` | `WebFetch https://opentelemetry.io/docs/specs/semconv/http/http-spans/` |


### PR DESCRIPTION
## Summary

- Refresh declarative Java guidance for SDK/BOM `1.64.0` and agent/starter `2.30.0`.
- Record the released `file_format: "1.1"` preference and current selector/thread-details ceilings.
- Clarify the still-unresolved query-redaction YAML mismatch and point to centralized shared configuration definitions.

## Verification

- Released tag/release metadata and exact source-path checks for SDK `1.64.0` and instrumentation `2.30.0`.
- `skills-ref validate skills/otel-java`
- `git diff --check -- skills/otel-java`

## Deliberately excluded

- Unreleased source changes.
- Gradle/runtime execution: no host JRE is installed and Docker socket access is unavailable; released source and tests were inspected instead.

Agent-authored periodic refresh; human-owned repository PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Javaagent and Spring Boot Starter declarative configuration guidance for version 2.30.0 and configuration format 1.1.
  * Clarified query-parameter redaction behavior and limitations in declarative configuration.
  * Documented SQL sanitization behavior for the latest release.
  * Updated configuration references to use the shared definitions as the source of truth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->