### PR TITLE
docs(otel-dotnet): update messaging semconv

### DIFF
--- a/skills/otel-dotnet/references/instrumentation-libraries.md
+++ b/skills/otel-dotnet/references/instrumentation-libraries.md
@@ -274,7 +274,8 @@ activity?.SetTag("batch.failed", items.Count - processed);
 ```
 
 Semconv reference: `otel-semantic-conventions` → messaging/general spans (use `messaging.system`,
-`messaging.operation`, etc. for queue-backed jobs; omit if purely internal).
+`messaging.operation.name`, `messaging.operation.type`, etc. for queue-backed jobs; omit if
+purely internal).
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace deprecated `messaging.operation` guidance with the released `messaging.operation.name` and `messaging.operation.type` attributes.

## Verification

- Verified against released `Instrumentation.ConfluentKafka-0.2.0-alpha.2` source and changelog.
- Rechecked the 32-package contrib catalog and documented builder extensions at their latest released tags.
- `skills-ref validate skills/otel-dotnet`
- `git diff --check -- skills/otel-dotnet`

## Deliberately excluded

- Unreleased core/contrib changes.
- Compilation: no .NET SDK is installed; released source and package metadata were inspected instead.
- Auto-instrumentation activation prose was not re-stamped because its source checkout is unavailable.

Agent-authored periodic refresh; human-owned repository PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for instrumenting queue-backed background jobs.
  * Clarified use of the more specific messaging operation name and type attributes.
  * Retained guidance to omit these attributes for purely internal jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->