### PR TITLE
docs(otel-span-events-to-logs-migration): refresh released status

### DIFF
--- a/skills/otel-span-events-to-logs-migration/SKILL.md
+++ b/skills/otel-span-events-to-logs-migration/SKILL.md
@@ -11,7 +11,7 @@ Use this skill to migrate instrumentation from the Span Event API (`AddEvent`, `
 
 The OpenTelemetry project accepted a plan to deprecate `Span.AddEvent` and `Span.RecordException` in favor of emitting events and exceptions through the Logs API. Span Events as a concept remain valid -- they can be emitted via logs that correlate to the active span, and optionally bridged back into the span proto.
 
-Status as of 2026-07-20: OTEP 4430 is accepted, log-based event/exception emission is specified in the Logs API, and the SDK "event to span event bridge" is specified with Development status. The trace API methods `AddEvent`/`RecordException` are not yet formally marked Deprecated in the specification -- that step is still pending. Treat existing span-event calls as migration candidates, not automatically invalid code; some SDK-specific equivalents have already changed status (for example OpenTelemetry .NET's `Activity.RecordException` extension is `[Obsolete]` in favor of `Activity.AddException`, which is still a span-event API).
+Status as of 2026-07-29: OTEP 4430 is accepted, log-based event/exception emission is specified in the Logs API, and the SDK "event to span event bridge" is specified with Development status. The trace API methods `AddEvent`/`RecordException` are not yet formally marked Deprecated in the specification -- that step is still pending. Treat existing span-event calls as migration candidates, not automatically invalid code; some SDK-specific equivalents have already changed status (for example OpenTelemetry .NET's `Activity.RecordException` extension is `[Obsolete]` in favor of `Activity.AddException`, which is still a span-event API).
 
 See `references/deprecation-plan.md` for the full context.
 

--- a/skills/otel-span-events-to-logs-migration/references/deprecation-plan.md
+++ b/skills/otel-span-events-to-logs-migration/references/deprecation-plan.md
@@ -7,7 +7,7 @@ This reference summarizes the [OTEP 4430](https://github.com/open-telemetry/open
 - `Span.AddEvent` -- the API method for attaching events to spans
 - `Span.RecordException` -- the API method for recording exceptions on spans
 
-As of 2026-07-20, these methods are planned deprecation targets from the accepted OTEP. They are not yet marked Deprecated in `specification/trace/api.md`.
+As of 2026-07-29, these methods are planned deprecation targets from the accepted OTEP. They are not yet marked Deprecated in `specification/trace/api.md`.
 
 ## What Is NOT Being Deprecated
 
@@ -41,9 +41,9 @@ Stabilize log-based Events. (The `event_name` LogRecord field is part of the sta
 - Next major version: migrate to the Logs API; for span-detail-without-a-timestamp cases, record span attributes instead ([semantic-conventions#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010), [opentelemetry-specification#4446](https://github.com/open-telemetry/opentelemetry-specification/issues/4446))
 - Users opt into the SDK bridge if they need span events in the proto envelope
 
-## Current Status (2026-07-20)
+## Current Status (2026-07-29)
 
-- **Proto 1.10.0**: log-based Events are stable; `event_name` is a stable LogRecord field.
+- **Proto 1.11.0**: log-based Events are stable; `event_name` is a stable LogRecord field.
 - **Specification 1.59.0**: the Logs API is Stable, including the `event_name` field and the optional `Exception` parameter to Emit, so log-based exception/event emission is specified. The "event to span event bridge" `LogRecordProcessor` is specified in `specification/logs/sdk.md` (Status: Development), with a matching `event_to_span_event_bridge/development` declarative-config key.
 - **Not yet done in spec**: `Span.AddEvent` and `Span.RecordException` are **not** yet marked Deprecated in `specification/trace/api.md`. That step remains pending.
 - **Semantic conventions 1.43.0**: exception events normally use an operation-specific name with a `.exception` suffix; the generic `exception` name is for handlers not tied to an operation or domain. Existing instrumentations introducing log-based exceptions should use `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN` with `logs` or `logs/dup` for a phased rollout while keeping span events as the default in the current major version.
@@ -53,13 +53,13 @@ Stabilize log-based Events. (The `event_name` LogRecord field is part of the sta
 
 Use current released source for the target language before editing user code.
 The snapshot below was verified against synced upstream checkouts and exact
-released tags on 2026-07-20:
+released tags on 2026-07-29:
 
 | Language | Current migration-relevant status |
 |---|---|
 | Go trace 1.44.0 / logs 0.20.0 | `trace.Span.AddEvent` / `RecordError` are present and not marked deprecated. `log.Record.SetEventName` and `SetErr` are available; the log SDK derives `exception.type` and `exception.message` from the error. No event-to-span-event bridge implementation was found in these releases. |
 | Java 1.64.0 | `Span.addEvent` / `recordException` are present and not marked deprecated; `LogRecordBuilder.setEventName` is available since 1.50.0 and `setException(Throwable)` since 1.60.0. The bridge is available in `opentelemetry-sdk-extension-incubator`; the older Java contrib bridge is deprecated. |
-| JavaScript / TypeScript 2.9.0 / experimental 0.220.0 | `Span.addEvent` / `recordException` are present and not marked deprecated; `@opentelemetry/api-logs` / `@opentelemetry/sdk-logs` support `eventName`; the `exception` log-record field is marked experimental. No event-to-span-event bridge implementation was found in these releases. |
+| JavaScript / TypeScript 2.10.0 / experimental 0.221.0 | `Span.addEvent` / `recordException` are present and not marked deprecated; `@opentelemetry/api-logs` / `@opentelemetry/sdk-logs` support `eventName`; the `exception` log-record field is marked experimental. No event-to-span-event bridge implementation was found in these releases. |
 | Python 1.44.0 / 0.65b0 | `span.add_event` / `record_exception` are present and not marked deprecated; `opentelemetry._logs.Logger.emit` accepts `event_name` and `exception`, and the SDK derives exception attributes. The deprecated standalone Events API/SDK was removed in favor of `LogRecord` with `event_name`. No event-to-span-event bridge implementation was found in this release. |
 | .NET 1.17.0 | `ActivityExtensions.RecordException` is `[Obsolete]` and points to `Activity.AddException`; both record span events. `TelemetrySpan.AddEvent` / `RecordException` are not marked obsolete. `ILogger` supplies an event name through `EventId.Name`; the lower-level Logs API is pre-release. No event-to-span-event bridge implementation was found in this release. |
 


### PR DESCRIPTION
## Summary

- Refresh the released migration baseline to Proto `1.11.0` and JavaScript `2.10.0` / experimental `0.221.0`.
- Preserve the key current-status distinction: accepted migration plan, but no formal trace API deprecation yet.

## Verification

- Released specification `1.59.0`, Proto `1.11.0`, and all five SDK release tags inspected.
- Go log API and SDK tests passed.
- Python released API import/signature checks passed.
- `skills-ref validate skills/otel-span-events-to-logs-migration`
- Scanner execution and shell syntax checks passed.
- `git diff --check -- skills/otel-span-events-to-logs-migration`

## Deliberately excluded

- Unreleased specification, proto, and SDK changes.
- JavaScript compilation: dependencies are absent; exact released tag source was inspected.

Agent-authored periodic refresh; human-owned repository PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated OpenTelemetry migration guidance and deprecation plans with the latest July 29, 2026 status date.
  - Refreshed protocol and language-support information, including the latest JavaScript/TypeScript versions and Events stability details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->