### PR TITLE
docs(otel-ottl): tighten context and safety guidance

### DIFF
--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -46,10 +46,13 @@ For a single path or function, read only the relevant section instead of loading
 - Guard optional or polymorphic input before conversion: `where x != nil`, `IsString(x)`, or the
   appropriate type check.
 - For JSON-object-only work, guard both the type and shape before calling `ParseJSON`, for example
-  `IsString(log.body) and IsMatch(log.body.string, "^\\s*\\{.*\\}\\s*$")`. Checking `IsMap` after
+  `IsString(log.body) and IsMatch(log.body.string, "(?s)^\\s*\\{.*\\}\\s*$")`. The RE2 `(?s)`
+  flag admits pretty-printed objects containing newlines. Checking `IsMap` after
   parsing does not prevent arrays or scalar JSON from being parsed.
 - On a version-pinned request, confirm every chosen path and function against that release tag;
   do not assume a function listed for this skill's v0.157 anchor exists in an older release.
+  For v0.156 JSON-object parsing, `ParseJSON`, `IsString`, and `IsMatch` are available without the
+  v0.157 alpha lambda feature gate.
 - Request metadata is read-only and may contain credentials. Copy only explicitly allowlisted,
   non-sensitive keys. OTLP metadata routing requires `include_metadata: true` on the receiver.
   HTTP/client header spelling may retain its form (`otelcol.client.metadata["X-Tenant"][0]`);

--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -5,274 +5,76 @@ description: OpenTelemetry Transformation Language (OTTL) expert for writing and
 
 # OpenTelemetry Transformation Language (OTTL)
 
-OTTL is a domain-specific language for transforming telemetry inside the OpenTelemetry Collector. It is consumed by the `transform`, `filter`, and `tail_sampling` processors, the `routing` connector, and a few other components in [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl).
+OTTL transforms or selects telemetry inside Collector components. This skill is pinned to
+collector-contrib **v0.157.0**. Function, path, default, and feature-gate availability varies by
+release; when the user's version differs, verify against the matching upstream tag.
 
-This skill targets `pkg/ottl` as of collector-contrib **v0.157.0**. Function and path availability differs across Collector releases; check the upstream `pkg/ottl/ottlfuncs/README.md` and `pkg/ottl/contexts/*/README.md` for the exact set in older or newer releases.
+## Workflow
 
-## Statement syntax
-
-```ottl
-function(arguments) [where condition]
-```
-
-Every statement has exactly one **editor** (lowercase: `set`, `delete_key`, `append`, …) optionally guarded by a `where` clause whose body is a boolean expression. Conditions can call **converters** (uppercase: `Concat`, `IsMatch`, `ParseJSON`, …) which return values but do not mutate telemetry.
+1. **Choose the component.** `transform` rewrites, `filter` drops, `tail_sampling` decides whether
+   to retain traces, and `routing` sends telemetry to pipelines. A component controls its available
+   contexts and functions.
+2. **Choose the lowest usable context.** Lower contexts can read their parents (for example, a span
+   can read `resource.attributes`), but parents cannot read children. Use `datapoint` for point
+   attributes instead of traversing `metric.data_points`.
+3. **Write the statement.** An editor such as `set` or `delete_key` mutates data and may have a
+   `where` condition. Converters such as `ParseJSON` and `IsMatch` return values; they do not mutate.
+4. **Set error behavior deliberately.** `ignore` logs statement errors and continues; `silent`
+   continues without logging; `propagate` returns the error and can cause the component to drop the
+   payload. In v0.157, transform and filter default to `ignore`; routing also defaults to `ignore`
+   while its beta default-error feature gate is enabled. For routing, `ignore` sends an errored
+   payload to `default_pipelines`; configure that fallback or the payload is dropped.
+5. **Verify end to end.** Validate the exact Collector version, then send known telemetry and inspect
+   file-exporter output. Use the
+   [telemetrygen recipe](../otel-telemetrygen/SKILL.md#verifying-a-collector-config).
 
 ```ottl
 set(span.attributes["env"], "prod") where resource.attributes["env"] == nil
 ```
 
-## Workflow
+## Load only what the task needs
 
-1. **Pick the component.** `transform` rewrites; `filter` drops; the `routing` connector fans out by pipeline; `tail_sampling` keeps/drops traces. The component decides which contexts and function set are usable.
-2. **Pick the context.** `resource`, `scope`, `span`, `spanevent`, `metric`, `datapoint`, `exemplar`, `log`, `profile`, `profilesample`, or `otelcol` for Collector request/client metadata. Operate at the lowest level that gives you the data — using `datapoint` to set attributes is much cheaper than walking through `metric.data_points` from the metric context.
-3. **Write statements.** Reach for `references/quick-reference.md` for common recipes; `references/contexts.md` for paths/enums; `references/functions.md` for the editor and converter catalog.
-4. **Set `error_mode`.** `ignore` keeps the pipeline running and logs errors; `silent` does the same but quietly; `propagate` aborts on first failure. In v0.157, `transform` and `filter` permanently default to `ignore` through stable feature gates; `routing` also defaults to `ignore` through the enabled beta `connector.routing.defaultErrorModeIgnore` gate (disable it to restore `propagate`). Lower-level OTTL sequences default to `propagate`.
-5. **Verify.** OTTL gotchas are the kind that pass the eye test (see [Common gotchas](#common-gotchas)). Use the [telemetrygen verification recipe](../otel-telemetrygen/SKILL.md#verifying-a-collector-config) — `otelcol-contrib` + file exporter + telemetrygen — to confirm the snippet does what the prose claims before shipping.
+- [Contexts](references/contexts.md) — exact paths, hierarchy, enums, and request metadata.
+- [Functions](references/functions.md) — editor/converter signatures and release availability.
+- [Quick reference](references/quick-reference.md) — component YAML, recipes, escaping,
+  troubleshooting, and safe skeletons.
 
-## Contexts at a glance
+For a single path or function, read only the relevant section instead of loading the full catalogs.
 
-OTTL paths are scoped by signal. Higher levels are reachable from lower ones (e.g., `resource.attributes` from a span statement); the reverse is not true.
+## Safety and correctness gates
 
-| Context | Common paths |
-|---------|--------------|
-| Resource | `resource.attributes["service.name"]`, `resource.schema_url` |
-| Scope | `scope.name`, `scope.version`, `scope.attributes["…"]` |
-| Span | `span.name`, `span.kind`, `span.status.code`, `span.attributes["…"]`, `span.flags` |
-| Span Event | `spanevent.name`, `spanevent.attributes["…"]`, `spanevent.event_index` |
-| Metric | `metric.name`, `metric.unit`, `metric.type`, `metric.aggregation_temporality` |
-| DataPoint | `datapoint.value_double`, `datapoint.value_int`, `datapoint.attributes["…"]` |
-| Exemplar | `exemplar.double_value`, `exemplar.int_value`, `exemplar.filtered_attributes["…"]` (transform `metric_statements` only, v0.156+) |
-| Log | `log.body`, `log.body.string`, `log.severity_number`, `log.attributes["…"]` |
-| Profile | `profile.profile_id`, `profile.attributes["…"]` (Development) |
-| OTelCol | `otelcol.client.metadata["x-tenant"][0]`, `otelcol.grpc.metadata["x-tenant"][0]` (read-only, enabled by default feature gate) |
+- Guard optional or polymorphic input before conversion: `where x != nil`, `IsString(x)`, or the
+  appropriate type check.
+- For JSON-object-only work, guard both the type and shape before calling `ParseJSON`, for example
+  `IsString(log.body) and IsMatch(log.body.string, "^\\s*\\{.*\\}\\s*$")`. Checking `IsMap` after
+  parsing does not prevent arrays or scalar JSON from being parsed.
+- On a version-pinned request, confirm every chosen path and function against that release tag;
+  do not assume a function listed for this skill's v0.157 anchor exists in an older release.
+- Request metadata is read-only and may contain credentials. Copy only explicitly allowlisted,
+  non-sensitive keys. OTLP metadata routing requires `include_metadata: true` on the receiver.
+  HTTP/client header spelling may retain its form (`otelcol.client.metadata["X-Tenant"][0]`);
+  gRPC metadata keys are lowercase (`otelcol.grpc.metadata["x-tenant"][0]`).
+- The routing `request` context is deprecated as of v0.156; use `otelcol.client.metadata` or
+  `otelcol.grpc.metadata`.
+- Log-record-specific rewrites of shared resource or scope data require `flatten_data: true` and the
+  alpha `transform.flatten.logs` gate. This copies and regroups data; do not enable it accidentally.
+- Hashing an identifier does not necessarily anonymize it. Apply the organization's data-handling
+  policy before retaining deterministic hashes of personal data.
 
-Full path inventory plus enums in `references/contexts.md`.
+## Frequent syntax traps
 
-## Essential functions
+- In Collector YAML, write an OTTL replacement backreference `${1}` as `$${1}`. A replacement such
+  as `$1REDACTED` is literal and silently fails to substitute the capture.
+- Go RE2 rejects large counted repetitions such as `(.{1024}).*`; use `Substring` with a nil/type
+  guard and `Len`, or `truncate_all` for a map.
+- Current span-event paths use `spanevent.*`, not `span_event.*`. Cache paths are context-qualified,
+  such as `span.cache["parsed"]`.
+- Use `Decode(value, "base64")`; `Base64Decode` is deprecated.
+- Regex escapes inside OTTL strings are doubled (`\\d`, `\\s`, `\\.`).
 
-```ottl
-# Editors (mutate telemetry)
-set(target, value)
-delete_key(target, key)               # delete by exact key
-delete_matching_keys(target, regex)   # delete by regex
-delete_index(target, start, end?)     # remove one slice item or range (v0.145+)
-keep_keys(target, [k1, k2])           # keep only these keys
-merge_maps(target, source, "upsert")  # "insert" | "update" | "upsert"
-truncate_all(target, max_len, utf8_safe = true, truncation_marker = "") # marker added in v0.157
-replace_pattern(target, regex, replacement)
-stringify_all(target)                 # map values -> strings (v0.155+)
+## Upstream sources
 
-# Converters (return values)
-Concat([a, b], "-")
-Split(s, ",")
-ToLowerCase(s) / ToUpperCase(s)
-IsMatch(s, "pattern") / IsEmpty(v)    # bool
-String(v) / Int(v) / Double(v) / Bool(v)
-ParseJSON(s) / ParseKeyValue(s, "=", "&")
-URL(s)                                # parse URL components (v0.127+)
-ExtractPatterns(s, "(?P<name>…)")     # named captures → map
-ExtractGrokPatterns(s, "%{IP:client}") # Grok (v0.130+)
-IsInCIDR(ip, ["10.0.0.0/8"])          # CIDR membership (v0.146+)
-SHA256(s) / Murmur3Hash(s) / XXH3(s)  # hexadecimal string hashes
-UUID() / UUIDv7()
-```
-
-Converter results can be indexed by dynamic string or integer expressions in v0.155+:
-
-```ottl
-set(log.attributes["last"], Split(log.body.string, ",")[Len(Split(log.body.string, ",")) - 1])
-set(log.attributes["selected"], ParseJSON(log.body.string)[log.attributes["field_name"]])
-```
-
-Full catalog with signatures in `references/functions.md`.
-
-The `transform` processor also provides 18 signal-specific functions that are not
-part of the common `pkg/ottl/ottlfuncs` catalog. See the
-[transform-only function table](references/functions.md#transform-processor-only-functions)
-for their contexts, signatures, and released-source links.
-
-## Common patterns
-
-```ottl
-# Conditional set
-set(span.attributes["sampled"], true)
-    where (span.end_time_unix_nano - span.start_time_unix_nano) > 1000000000
-
-# Normalize a value
-set(span.attributes["http.method"],
-    ToUpperCase(String(span.attributes["http.method"])))
-
-# Parse a JSON log body into structured attributes
-set(log.attributes, ParseJSON(log.body.string))
-    where IsString(log.body) and IsMatch(log.body.string, "^\\s*\\{.*\\}\\s*$")
-
-# Mark errored HTTP spans
-set(span.status.code, STATUS_CODE_ERROR)
-    where IsInt(span.attributes["http.status_code"])
-      and Int(span.attributes["http.status_code"]) >= 400
-
-# Redact secrets by key pattern
-delete_matching_keys(span.attributes, "(?i).*(password|secret|token|apikey).*")
-
-# Hash PII rather than dropping it (preserves cardinality for analytics)
-set(span.attributes["user.email_hash"], SHA256(span.attributes["user.email"]))
-delete_key(span.attributes, "user.email")
-```
-
-More recipes (sampling, redaction, time math, parsing) in `references/quick-reference.md`.
-
-## Processor wiring
-
-```yaml
-processors:
-  transform:
-    error_mode: ignore        # ignore | silent | propagate
-    trace_statements:
-      - context: span
-        statements:
-          - set(span.attributes["processed"], true)
-    log_statements:
-      - context: log
-        statements:
-          - set(log.attributes["source"], "collector")
-    metric_statements:
-      - context: datapoint
-        statements:
-          - set(datapoint.attributes["env"], "prod")
-
-  filter:
-    error_mode: ignore
-    trace_conditions:
-      - 'IsMatch(span.name, "^/health.*")'
-    log_conditions:
-      - 'log.severity_number < SEVERITY_NUMBER_WARN'
-
-  tail_sampling:
-    policies:
-      - name: errors
-        type: ottl_condition
-        ottl_condition:
-          span:
-            - 'span.status.code == STATUS_CODE_ERROR'
-
-connectors:
-  routing:
-    error_mode: ignore
-    default_pipelines: [traces/default]
-    table:
-      - condition: 'resource.attributes["env"] == "prod"'
-        pipelines: [traces/prod]
-      - condition: 'span.status.code == STATUS_CODE_ERROR'
-        pipelines: [traces/errors]
-```
-
-## Common gotchas
-
-These mistakes pass YAML validation but break OTTL semantics. Most have cost real time in production rollouts.
-
-### `replace_pattern` backreferences need `$${1}` in YAML
-
-OTTL uses `${1}`, `${2}`, … for regex backreferences. The collector's YAML loader treats `$` as an env-var marker, so YAML `$$` becomes OTTL `$`. To produce `${1}` at the OTTL level, write `$${1}` in YAML. Writing `"$1REDACTED"` produces literal `$1REDACTED` with no replacement — silent failure.
-
-### Go RE2 has a repeat-count ceiling
-
-Patterns like `(.{1024}).*` fail to compile with "invalid repeat count". For length-based truncation, prefer `Substring` + `Len`:
-
-```ottl
-set(attributes["db.statement"], Substring(attributes["db.statement"], 0, 1024))
-    where attributes["db.statement"] != nil and Len(attributes["db.statement"]) > 1024
-```
-
-Or use `truncate_all` for whole maps (UTF-8 safe by default since v0.148):
-
-```ottl
-truncate_all(span.attributes, 1024)
-```
-
-### `attributes` processor ≠ `resource` processor
-
-The OTel `attributes` processor only operates on span/log/metric attributes. To touch a *resource* attribute use the `resource` processor or a `transform` processor with `context: resource`. A config like `attributes/strip_resource: actions: [...delete os.description...]` runs without error but doesn't change resource attributes — silent no-op.
-
-### Per-log resource/scope rewrites may need `flatten_data`
-
-Log records can share resource and scope data. When a log-context statement derives either from record-specific `log.*` data, set `flatten_data: true` and enable the alpha `transform.flatten.logs` feature gate; otherwise records in the same batch can affect one another unexpectedly. In v0.157 the gate is disabled and `flatten_data` is `false` by default. The option is logs-only and incurs copying, hashing, and regrouping overhead.
-
-### `logdedup` paths use dot-notation only
-
-The processor accepts `include_fields` / `exclude_fields` (not `fields`). Paths must start with `attributes.` or `body.` and use dot-notation. Bracket notation (`attributes["service.name"]`) is rejected, and `resource[...]` paths are not addressable. Default behavior dedups on the full record, which is usually what's wanted.
-
-### `k8sattributes` cannot extract `k8s.cluster.name`
-
-The processor's `metadata` list is restricted to pod-level identity. Cluster name has to come from `resourcedetection` or a static `resource` processor that reads it from an env var.
-
-### Path syntax changed in v0.120
-
-In older configs you may see `span_event.*` — current syntax is `spanevent.*`. Cache paths now require the context prefix: write `span.cache["x"]` not just `cache["x"]`. Plain `cache` is only valid in profile/profilesample contexts where it's the documented path. Paste-from-old-config is the most common source of regressions.
-
-### `Base64Decode` is deprecated
-
-Use `Decode(value, "base64")` instead. The same `Decode` converter handles `base64-raw`, `base64-url`, `base64-raw-url`, and IANA character set encodings. Keep `Base64Decode` only if pinned to a pre-v0.141 collector.
-
-### `routing` request context is deprecated
-
-In routing connector configs, use `otelcol.client.metadata["key"][0]` for HTTP/client metadata or `otelcol.grpc.metadata["key"][0]` for gRPC metadata. The old `context: request` plus `request["key"] == "value"` form is deprecated in v0.156.
-
-### `Bool` converter coercion is loose
-
-`Bool` preserves booleans, treats any non-zero integer or double as `true`, and uses Go boolean parsing for strings (`1`, `t`, `T`, `TRUE`, `true`, `True`, and their false equivalents). Invalid strings and unsupported types error; `nil` returns `nil`. Don't assume Python-like truthiness for arbitrary strings.
-
-### Verify before publishing
-
-YAML/OTTL gotchas like the above pass the eye test. Use the [telemetrygen verification recipe](../otel-telemetrygen/SKILL.md#verifying-a-collector-config) (otelcol-contrib + file exporter + telemetrygen) to confirm the snippet does what the surrounding prose claims, especially before shipping to a customer or production.
-
-## Best practices
-
-1. **Validate inputs** before conversion: `where IsString(x)`, `where x != nil`.
-2. **Order conditions by selectivity** (cheap and most-selective first). `span.kind == SPAN_KIND_SERVER and IsMatch(...)` lets the kind check short-circuit before the regex runs.
-3. **Cache expensive operations** in `<context>.cache`: `set(span.cache["url_parts"], Split(span.attributes["http.url"], "/"))`, then read from cache.
-4. **Use the most specific context.** `datapoint` for metric-attribute work beats walking `metric.data_points` from the metric context.
-5. **Escape regex correctly.** Use `\\d+`, `\\.`, `\\s+` in OTTL strings (single backslash in YAML becomes a literal).
-6. **Prefer `keep_keys` to a long list of `delete_key`** when shaping output — easier to read, fails closed.
-
-## Versioning notes
-
-Recently added (still useful to know which release introduced them when supporting users on older collectors):
-
-| Feature | Since |
-|---------|-------|
-| Lambda converters `All`, `Any`, `Filter`, `Find`, `MapEach`, `MapKeys`, `Reduce`, `When` (alpha; require `ottl.functions.enableLambda`) | v0.157 |
-| `IsEmpty` converter; transform-only `ParseCEF` log converter | v0.157 |
-| `truncate_all` optional `truncation_marker` parameter | v0.157 |
-| `transform` / `filter` default-error gates stable; routing default-error gate beta (default `ignore`) | v0.157 |
-| Exemplar context (transform `metric_statements` only) | v0.156 |
-| Routing connector context inference (`condition` with context-qualified paths) | v0.156 |
-| Routing connector `request` context deprecated; use `otelcol.*` metadata paths | v0.156 |
-| Log-only `flatten_data` via alpha `transform.flatten.logs` feature gate | v0.103 |
-| `connector.routing.defaultErrorModeIgnore` feature gate | v0.155 |
-| `otelcol.*` context via enabled-by-default `ottl.contexts.enableOTelColContext` feature gate | v0.147 |
-| Filter processor top-level `trace_conditions`, `metric_conditions`, `log_conditions` | v0.146 |
-| Profile / ProfileSample contexts | v0.124 / v0.132 (Development) |
-| Cache paths require context prefix; `spanevent` rename | v0.120 (breaking) |
-| `delete_index` editor | v0.145 |
-| `span.flags` path | v0.145 |
-| `truncate_all` UTF-8 safe default (`utf8_safe` parameter) | v0.148 (behavior change) |
-| `Substring` optional `utf8_safe` parameter (default `false`) | v0.156 |
-| `SpanID` / `TraceID` accept hex strings | v0.142 |
-| `flatten` `resolveConflicts` parameter | v0.139 |
-| `Base64Encode` | v0.147 |
-| `Decode`, deprecates `Base64Decode` | v0.141 |
-| `Bool` converter | v0.143 |
-| `ExtractGrokPatterns` | v0.130 |
-| `URL`, `UserAgent` | v0.127, v0.134 |
-| `IsInCIDR` | v0.146 |
-| `Murmur3Hash*`, `XXH3`, `XXH128` | v0.129, v0.135 |
-| `Sort`, `Index`, `SliceToMap` | v0.125, v0.126, v0.128 |
-| `UUIDv7`, `ParseSeverity`, `CommunityID` | v0.138, v0.133, v0.131 |
-| `stringify_all` editor; dynamic keys when indexing converter results | v0.155 |
-
-## References
-
-- `references/contexts.md` — context paths and enums
-- `references/functions.md` — editors and converters with signatures
-- `references/quick-reference.md` — recipes, regex patterns, troubleshooting
-- Upstream: <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl>
+- [OTTL package](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.157.0/pkg/ottl)
+- [Transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.157.0/processor/transformprocessor)
+- [Filter processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.157.0/processor/filterprocessor)
+- [Routing connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.157.0/connector/routingconnector)

--- a/skills/otel-ottl/evals/evals.json
+++ b/skills/otel-ottl/evals/evals.json
@@ -7,10 +7,11 @@
       "id": "routing-metadata-fallback",
       "prompt": "We run OpenTelemetry Collector contrib v0.157. Route OTLP logs by the X-Tenant header to logs/acme, but malformed or missing headers must not lose telemetry. Provide the relevant YAML and explain the failure behavior.",
       "expectations": [
-        "Uses the routing connector with an otelcol.client.metadata path indexed at [0].",
+        "Uses executable routing YAML with either otelcol.client.metadata[\"X-Tenant\"][0] for HTTP or otelcol.grpc.metadata[\"x-tenant\"][0] for gRPC.",
         "Enables include_metadata on the OTLP receiver and notes lowercase keys for gRPC metadata.",
         "Configures default_pipelines and explains that routing error_mode ignore sends evaluation errors there; without it the payload is dropped.",
-        "Does not use the deprecated routing request context."
+        "Does not use the deprecated routing request context.",
+        "Provides a routing condition matching tenant value acme and assigns the match to pipelines: [logs/acme]."
       ]
     },
     {
@@ -20,7 +21,8 @@
         "Uses a span-context transform statement with replace_pattern.",
         "Uses the Collector-YAML replacement $${1}REDACTED and does not present $1REDACTED as valid.",
         "Guards a potentially absent or non-string URL input.",
-        "Recommends an end-to-end known-input check such as telemetrygen plus file-exporter output."
+        "Recommends an end-to-end known-input check such as telemetrygen plus file-exporter output.",
+        "Uses ([?&]token=)[^&]+ or an equivalent capture that preserves the parameter delimiter and name while replacing only its value."
       ]
     },
     {
@@ -30,7 +32,8 @@
         "Uses log context with ParseJSON and a type-safe IsString guard.",
         "Restricts parsing to JSON-object-shaped input rather than arbitrary JSON arrays or strings.",
         "Does not require or use v0.157 alpha lambda converters.",
-        "Treats function availability as release-dependent and keeps the answer compatible with v0.156."
+        "Treats function availability as release-dependent and keeps the answer compatible with v0.156.",
+        "Writes or merges the parsed JSON object into log.attributes under the object-type guard rather than discarding the parse result."
       ]
     }
   ]

--- a/skills/otel-ottl/evals/evals.json
+++ b/skills/otel-ottl/evals/evals.json
@@ -1,0 +1,37 @@
+{
+  "skill": "otel-ottl",
+  "runtime": "Codex CLI",
+  "model": "gpt-5.6-terra",
+  "cases": [
+    {
+      "id": "routing-metadata-fallback",
+      "prompt": "We run OpenTelemetry Collector contrib v0.157. Route OTLP logs by the X-Tenant header to logs/acme, but malformed or missing headers must not lose telemetry. Provide the relevant YAML and explain the failure behavior.",
+      "expectations": [
+        "Uses the routing connector with an otelcol.client.metadata path indexed at [0].",
+        "Enables include_metadata on the OTLP receiver and notes lowercase keys for gRPC metadata.",
+        "Configures default_pipelines and explains that routing error_mode ignore sends evaluation errors there; without it the payload is dropped.",
+        "Does not use the deprecated routing request context."
+      ]
+    },
+    {
+      "id": "yaml-backreference-redaction",
+      "prompt": "For Collector contrib v0.157, write a transform processor that redacts token query-parameter values in span URL attributes while preserving the parameter name. Include how you would verify it.",
+      "expectations": [
+        "Uses a span-context transform statement with replace_pattern.",
+        "Uses the Collector-YAML replacement $${1}REDACTED and does not present $1REDACTED as valid.",
+        "Guards a potentially absent or non-string URL input.",
+        "Recommends an end-to-end known-input check such as telemetrygen plus file-exporter output."
+      ]
+    },
+    {
+      "id": "v0156-json-log-parse",
+      "prompt": "My Collector is pinned to contrib v0.156. Parse JSON-object log bodies and set parsed fields as log attributes only when the body is actually a JSON object. Do I need an alpha lambda feature gate? Give the transform fragment.",
+      "expectations": [
+        "Uses log context with ParseJSON and a type-safe IsString guard.",
+        "Restricts parsing to JSON-object-shaped input rather than arbitrary JSON arrays or strings.",
+        "Does not require or use v0.157 alpha lambda converters.",
+        "Treats function availability as release-dependent and keeps the answer compatible with v0.156."
+      ]
+    }
+  ]
+}

--- a/skills/otel-ottl/references/contexts.md
+++ b/skills/otel-ottl/references/contexts.md
@@ -2,6 +2,15 @@
 
 Context paths and enums for collector-contrib **v0.157.0**. Higher-level contexts are reachable from lower ones (a span statement can read `resource.attributes`); the reverse is not true. Always pick the most specific context for the work — using `datapoint` to set metric-point attributes is much cheaper than walking through `metric.data_points` from the metric context.
 
+## Contents
+
+- [Context hierarchy](#context-hierarchy)
+- [Resource](#resource-context), [scope](#scope-instrumentation-scope-context), [span](#span-context-beta), and [span event](#span-event-context-beta)
+- [Metric](#metric-context-beta), [data point](#datapoint-context), and [exemplar](#exemplar-context-v0156)
+- [Log](#log-context-beta), [profile](#profile-context-development-v0124), and [profile sample](#profile-sample-context-development-v0132)
+- [Collector request metadata](#otelcol-context-v0147-enabled-by-default-feature-gate)
+- [Enums](#enums)
+
 ## Context hierarchy
 
 ```
@@ -301,16 +310,16 @@ cache["key"]
 
 ## OTelCol context (v0.147+, enabled by default feature gate)
 
-The `otelcol` context exposes Collector-side client and request data that is not part of the telemetry payload. It is read-only. In v0.156, the routing connector deprecated its old `request` context in favor of these paths.
+The `otelcol` context exposes Collector-side client and request data that is not part of the telemetry payload. It is read-only. In v0.156, the routing connector deprecated its old `request` context in favor of these paths. OTLP receivers must set `include_metadata: true` for request metadata to reach downstream routing. HTTP/client key spelling may retain its form; gRPC keys are lowercase.
 
 ```ottl
 otelcol.client.addr
-otelcol.client.metadata["x-tenant-id"][0]   # first HTTP/client metadata value
+otelcol.client.metadata["X-Tenant-Id"][0]   # first HTTP/client metadata value
 otelcol.client.auth.attributes["subject"]   # auth extension attributes
 otelcol.grpc.metadata["x-tenant-id"][0]     # incoming gRPC metadata value
 ```
 
-Prefer `otelcol.*` paths for routing/filtering conditions. If copying values into telemetry, only copy allowlisted, non-sensitive keys; metadata often includes authorization headers, cookies, or API keys.
+Prefer `otelcol.*` paths for routing/filtering conditions. If copying values into telemetry, only copy allowlisted, non-sensitive keys; metadata often includes authorization headers, cookies, or API keys. With routing `error_mode: ignore`, an evaluation error goes to `default_pipelines`; without that fallback it is dropped.
 
 ## Enums
 

--- a/skills/otel-ottl/references/contexts.md
+++ b/skills/otel-ottl/references/contexts.md
@@ -254,7 +254,7 @@ log.event_name                       # for event-shaped logs
 ```ottl
 # Parse JSON body into structured attributes
 set(log.attributes, ParseJSON(log.body.string))
-    where IsString(log.body) and IsMatch(log.body.string, "^\\s*\\{.*\\}\\s*$")
+    where IsString(log.body) and IsMatch(log.body.string, "(?s)^\\s*\\{.*\\}\\s*$")
 
 # Normalize severity text
 set(log.severity_text, "ERROR")

--- a/skills/otel-ottl/references/functions.md
+++ b/skills/otel-ottl/references/functions.md
@@ -2,6 +2,15 @@
 
 Editor and converter reference for collector-contrib **v0.157.0**. Editors mutate telemetry; converters return values for use in expressions. See the upstream `pkg/ottl/ottlfuncs/README.md` for the authoritative source.
 
+## Contents
+
+- [Transform-only functions](#transform-processor-only-functions)
+- [Editors](#editors-data-manipulation)
+- [String](#string-converters), [type conversion](#type-conversion), and [type checking](#type-checking)
+- [Lambda converters](#lambda-converters-v0157-alpha), [patterns](#pattern-matching), and [parsing](#data-parsing)
+- [Collections](#collections), [date/time](#datetime), [encoding](#hashing--encoding), and [OpenTelemetry-specific](#opentelemetry-specific)
+- [Safe function patterns](#function-patterns)
+
 ## Transform-processor-only functions
 
 The `transform` processor adds the following functions to the common OTTL
@@ -400,7 +409,7 @@ UUID()
 UUIDv7()                                      # v0.138+; time-ordered
 ```
 
-`UUIDv7` is preferable to `UUID()` when the resulting value is used as a primary key or sort key, because v7 is monotonic-ish and storage-friendly.
+`UUIDv7` is time-ordered; choose the identifier form according to the consuming system's requirements.
 
 ---
 
@@ -411,14 +420,6 @@ Log(value)                                    # natural logarithm
 ```
 
 OTTL's basic arithmetic operators (`+`, `-`, `*`, `/`) cover most needs; `Log` is the rare named math converter.
-
----
-
-## Utility
-
-```ottl
-UUID() / UUIDv7()
-```
 
 ---
 

--- a/skills/otel-ottl/references/functions.md
+++ b/skills/otel-ottl/references/functions.md
@@ -310,10 +310,13 @@ URL(s)                                        # v0.127+; { url.scheme, url.domai
 UserAgent(s)                                  # v0.134+; { user_agent.name, .version, os.name, os.version, … }
 ```
 
+`ParseJSON`, `IsString`, and `IsMatch` are available in v0.156 and do not require the v0.157
+`ottl.functions.enableLambda` feature gate.
+
 ```ottl
 # Conditional JSON parsing
 set(log.attributes, ParseJSON(log.body.string))
-    where IsString(log.body) and IsMatch(log.body.string, "^\\s*\\{.*\\}\\s*$")
+    where IsString(log.body) and IsMatch(log.body.string, "(?s)^\\s*\\{.*\\}\\s*$")
 
 # URL parsing
 set(span.attributes["http.host"], URL(span.attributes["http.url"])["url.domain"])
@@ -441,7 +444,7 @@ set(span.attributes["normalized"],
 ### Conditional parsing into cache
 ```ottl
 set(log.cache["parsed"], ParseJSON(log.body.string))
-    where IsString(log.body) and IsMatch(log.body.string, "^\\s*\\{.*\\}\\s*$")
+    where IsString(log.body) and IsMatch(log.body.string, "(?s)^\\s*\\{.*\\}\\s*$")
 ```
 
 Then read from `log.cache["parsed"]` in subsequent statements without paying the parse cost again.

--- a/skills/otel-ottl/references/quick-reference.md
+++ b/skills/otel-ottl/references/quick-reference.md
@@ -52,7 +52,7 @@ set(log.body, Trim(log.body.string, " \t\n"))
 ```ottl
 # JSON body -> attributes
 set(log.attributes, ParseJSON(log.body.string))
-    where IsString(log.body) and IsMatch(log.body.string, "^\\s*\\{.*\\}\\s*$")
+    where IsString(log.body) and IsMatch(log.body.string, "(?s)^\\s*\\{.*\\}\\s*$")
 
 # Query string -> map
 set(span.attributes["params"],

--- a/skills/otel-ottl/references/quick-reference.md
+++ b/skills/otel-ottl/references/quick-reference.md
@@ -2,6 +2,15 @@
 
 Recipes, regex patterns, and a troubleshooting table. Pair with `contexts.md` for paths and `functions.md` for full signatures.
 
+## Contents
+
+- [Common patterns](#common-patterns)
+- [Processor configuration](#processor-configuration)
+- [Regular expressions](#regular-expressions)
+- [Debugging](#debugging)
+- [Performance](#performance)
+- [Troubleshooting and verification](#troubleshooting)
+
 ## Common patterns
 
 ### Attribute management
@@ -148,7 +157,7 @@ replace_all_patterns(log.attributes, "value",
                      "\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b",
                      "[REDACTED_IP]")
 
-# Hash, don't drop — preserves cardinality for analytics
+# Deterministic hash example; policy must permit retaining linkable identifiers
 set(span.attributes["user.email_hash"], SHA256(span.attributes["user.email"]))
 delete_key(span.attributes, "user.email")
 ```
@@ -201,6 +210,12 @@ connectors:
       - condition: 'span.status.code == STATUS_CODE_ERROR'
         pipelines: [traces/errors]
 ```
+
+With `error_mode: ignore`, an evaluation error is logged and the payload is sent to
+`default_pipelines`; without a configured fallback it is dropped. Metadata-based routing also
+requires `include_metadata: true` on the receiving OTLP protocol. Use
+`otelcol.client.metadata["X-Tenant"][0]` for HTTP/client metadata and lowercase
+`otelcol.grpc.metadata["x-tenant"][0]` for gRPC metadata.
 
 ### `tail_sampling`
 


### PR DESCRIPTION
## Summary

- cut the always-loaded `otel-ottl` body from 273 lines / about 2,300 tokens to 80 lines / about 810 tokens while preserving its discovery surface and core workflow
- correct routing error semantics: `ignore` needs `default_pipelines` to prevent evaluation-error payload loss
- document OTLP metadata propagation, HTTP/gRPC key casing, version-pinned lookup, JSON-object guards, and deterministic-hash privacy limits
- add navigation to the large references and a three-case public behavioral eval corpus

No skill name, path, registration, or published set changed, so repository registration metadata and downstream consumers do not require updates.

## Agent involvement

Codex implemented and evaluated this change under human direction. A human owns and will review the PR before merge.

## Harness results

Runtime: Codex CLI with `gpt-5.6-terra`, fresh ephemeral read-only sessions, ambient skills/apps/plugins disabled, 180-second timeout. Each of three public prompts in `skills/otel-ottl/evals/evals.json` ran three times in each arm. No Collector, container, network, credential, or production-data operation was allowed.

| Arm | Atomic expectations | Result |
| --- | ---: | ---: |
| Without skill | 27 / 45 | 60.0% |
| Existing skill from `origin/main` | 37 / 45 | 82.2% |
| Revised skill | 45 / 45 | 100% |

The prompts cover routing by request metadata without data loss, YAML regex backreference escaping, and v0.156-safe JSON-object log parsing. Initial blinded failures were retained and drove fixes for the JSON shape guard and explicit release compatibility. CodeRabbit then strengthened the corpus with exact route, capture, mutation, and transport-path expectations; nine revised reruns plus three focused compatibility reruns passed the final 45-point rubric. Navigation traces confirmed the revised runs read the body and task-relevant reference sections.

Measured harness usage stayed under the approved $10 ceiling; the conservative estimate is about $4.08 across retained primary and targeted runs before small judge usage. Raw transcripts stay in gitignored `local/` because command-event streams are not appropriate repository artifacts; the committed corpus and exact harness parameters above make the comparison reproducible.

## Validation

- `skills-ref validate skills/otel-ottl`
- `python3 .github/scripts/check-skill-registration.py`
- JSON parse, unique IDs, non-empty atomic expectations, and no `SKILL.md` link to `evals/`
- `git diff --check`

## Checklist

- [x] I read and agree to follow the Code of Conduct
- [x] `skills-ref validate skills/otel-ottl` passes
- [x] `python3 .github/scripts/check-skill-registration.py` passes
- [x] Existing registration remains unchanged
- [x] Content is vendor-neutral, non-opinionated, DRY, and token-efficient
- [x] Harness comparison results are included above
- [x] Commit message follows Conventional Commits
- [x] I have signed (or will sign via the CLA bot on this PR) the OllyGarden CLA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the OTTL guide for OpenTelemetry Collector v0.157.0 workflows.
  * Added guidance on component selection, error handling, version verification, safety checks, syntax pitfalls, and metadata-based routing.
  * Clarified routing fallbacks, metadata requirements, hash redaction policies, UUIDv7 usage, and feature availability.
  * Improved JSON parsing guidance for multiline log bodies and expanded OTelCol metadata behavior documentation.

* **Tests**
  * Added evaluation cases covering routing metadata fallback, URL redaction, and JSON log parsing compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->