### PR TITLE
fix(ci): narrow the link-check workflow exclusion from a path to a URL

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -10,11 +10,19 @@ include_verbatim = false
 
 exclude_path = [
   "(^|/)\\.git/",
+  # Conditional, not dead: nothing matches this in a default run, but a local
+  # `lychee --cache` creates the directory. Keep the distinction in mind when
+  # pruning — an exclusion that *cannot* match is rot, one that does not match
+  # *today* is not.
   "(^|/)\\.lycheecache/",
-  # These two files hold link *patterns* rather than links: this config's own
-  # exclude regexes, and the workflow line that interpolates ${LYCHEE_VERSION}.
+  # This config's own content is entirely link *patterns*, not links: lychee
+  # reads `https://github/` and `https://api/` straight out of the regexes
+  # below (5 errors when this line is removed). Excluding those by URL would
+  # take one exclusion per pattern, each itself a pattern — so the file is
+  # excluded wholesale. Every other file is scanned; prefer a narrow URL
+  # exclusion to a path exclusion, which also hides whether a pattern still
+  # works.
   "(^|/)\\.github/lychee\\.toml$",
-  "(^|/)\\.github/workflows/link-check\\.yml$",
   # Eval fixtures are synthetic inputs, written to look hostile or malformed on
   # purpose; their URLs are payloads under test, not references to check.
   "(^|/)skills/[^/]+/evals/files/"
@@ -40,6 +48,13 @@ exclude = [
   "^https://github\\.com/open-telemetry/semantic-conventions/(blob|tree)/",
   "^https://raw\\.githubusercontent\\.com/open-telemetry/semantic-conventions/\\$%7Btag%7D/",
   "^https://api\\.github\\.com/repos/open-telemetry/semantic-conventions/git/trees/\\$%7Btag%7D",
+  # The lychee release URL in .github/workflows/link-check.yml, built from
+  # ${LYCHEE_VERSION} at run time. Excluded by URL rather than by excluding the
+  # whole workflow file, so the rest of that file still gets checked. Note the
+  # encoding: lychee leaves `$` literal and percent-encodes the braces, so this
+  # must be `\$%7B...%7D` — an unencoded `\$\{...\}` here would never match, and
+  # a path exclusion would hide that it had stopped working.
+  "^https://github\\.com/lycheeverse/lychee/releases/download/\\$%7BLYCHEE_VERSION%7D",
   # Example in-cluster endpoint in skill prose and eval prompts; by design it
   # resolves only inside a user's own cluster, never from CI.
   "^http://otel-gateway:4318([/?#]|$)"


### PR DESCRIPTION
## Summary

`.github/workflows/link-check.yml` was excluded from link checking **as a whole file**, in order to hide **one** URL: the lychee release download built from `${LYCHEE_VERSION}` at run time.

That is too blunt in two ways. It hides every other link in the file, and — the part that matters more — it hides whether the pattern meant to match that URL still works.

Replaced with a URL exclusion. The workflow file is now scanned:

```console
$ lychee --no-progress --root-dir "$PWD" --config .github/lychee.toml .   # lychee 0.24.2
🔍 720 Total  🔗 462 Unique  ✅ 699 OK  🚫 0 Errors  👻 21 Excluded      # was 719 / 20
```

Verified load-bearing rather than assumed — removing the new exclusion produces exactly the one 404 it exists for:

```console
[404] https://github.com/lycheeverse/lychee/releases/download/$%7BLYCHEE_VERSION%7D (at 41:21)
🔍 720 Total  🚫 1 Error
```

## The encoding is the point, and it is now written next to the pattern

lychee leaves `$` literal and percent-encodes the braces, so the exclusion must read `\$%7BLYCHEE_VERSION%7D`. An unencoded `\$\{LYCHEE_VERSION\}` can never match.

[`ollygarden/humus`](https://github.com/ollygarden/humus) carries the **unencoded** form *and* the path exclusion — so its URL pattern cannot match, and nothing will ever reveal that, because the path exclusion suppresses the error the dead pattern would otherwise produce. That is precisely the failure this change avoids here, and I'll file it upstream against humus separately.

## Full audit of the remaining exclusions

Since a dead exclusion is invisible by construction, I tested **every** exclusion by removing it and re-running, rather than reasoning about them:

| Exclusion | Verdict |
|---|---|
| All 8 URL exclusions | **Load-bearing** — each produces errors when removed |
| `.github/lychee.toml` (path) | **Load-bearing** (5 errors without it) — **kept**, see below |
| `skills/*/evals/files/` (path) | **Load-bearing** — synthetic fixtures, 1 error + 4 links |
| `.git/` (path) | Excludes 1 link, no errors — kept as hygiene |
| `.lycheecache/` (path) | Matches nothing today — **kept**, see below |

**`lychee.toml` keeps its path exclusion** because its content is entirely link *patterns*: lychee reads `https://github/` and `https://api/` straight out of the regexes. Narrowing it would take one exclusion per pattern, each itself a pattern. The reason is now recorded at the line so the next person doesn't have to re-derive it.

**`.lycheecache/` is conditional, not dead.** It matches nothing in a default run, but a local `lychee --cache` creates the directory. Worth the distinction: an exclusion that *cannot* match is rot and should go; one that does not match *today* should not be pruned on that basis alone. Noted inline.

## Test plan

CI config only; no skill content, scripts, or workflows changed in behavior.

```console
$ ./bin/validate-skill.sh
OK: 15 skill(s) validated

$ ./bin/check-skill-inventory.py
Validated registration for 15 skills.

$ lychee --no-progress --root-dir "$PWD" --config .github/lychee.toml .
🔍 720 Total  🚫 0 Errors  👻 21 Excluded
```

The `Link Check` workflow itself exercises this config on this PR, so the check on this PR is the test.

## Harness results

Not applicable — no skill content changed. This PR touches only `.github/lychee.toml`.

## Agent involvement

Implemented by Claude Code (Opus 5), reviewed by me before submitting. The finding came from an agent-run cross-repo review against the same port in `ollygarden/skills`, where the equivalent blunt exclusion was flagged first; the audit method (remove, re-run, keep only what changes the result) came from that exchange too.

## Checklist

- [x] I read and agree to follow the [Code of Conduct](https://github.com/ollygarden/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] `./bin/validate-skill.sh` passes
- [x] `./bin/check-skill-inventory.py` passes
- [x] Skill registered in all three places — n/a, no skill added or renamed
- [x] Content is vendor-neutral, non-opinionated, DRY, and token-efficient
- [x] All three harness arms reported above — n/a, no skill content changed
- [x] Commit messages follow Conventional Commits
- [x] I have signed the [OllyGarden CLA](https://github.com/ollygarden/.github/blob/main/CLA.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Pn5R8uwaaPcAcV7L7kpg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link checking coverage for the link-check workflow while excluding only expected generated and fixture content.
  * Added an exception for the workflow’s dynamically generated release URL to reduce false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->