### PR TITLE
docs(otel-go): refresh for v1.45

### DIFF
--- a/skills/otel-go/SKILL.md
+++ b/skills/otel-go/SKILL.md
@@ -27,12 +27,12 @@ and version churn:
 
 | Module group | Example modules | Version line |
 |---|---|---|
-| Stable signals (traces, metrics) | `go.opentelemetry.io/otel`, `otel/sdk`, `otel/trace`, `otel/metric`, OTLP trace/metric exporters | **v1.x** (e.g. v1.44.0) |
+| Stable signals (traces, metrics) | `go.opentelemetry.io/otel`, `otel/sdk`, `otel/trace`, `otel/metric`, OTLP trace/metric exporters | **v1.x** (e.g. v1.45.0) |
 | Logs | `otel/log`, `otel/sdk/log`, `otel/exporters/otlp/otlplog/otlploghttp` | **v0.x** (separate, lower line) |
-| Contrib instrumentation | `contrib/instrumentation/net/http/otelhttp`, `.../otelgrpc` | **v0.x** (separate line, e.g. v0.69.0) |
+| Contrib instrumentation | `contrib/instrumentation/net/http/otelhttp`, `.../otelgrpc` | **v0.x** (separate line, e.g. v0.70.0) |
 | Contrib log bridges | `contrib/bridges/otelslog`, `otelzap`, `otellogrus`, `otellogr` | **v0.x** |
 
-**The trap:** pinning every module to the core version (e.g. `go get go.opentelemetry.io/otel/log@v1.44.0`)
+**The trap:** pinning every module to the core version (e.g. `go get go.opentelemetry.io/otel/log@v1.45.0`)
 fails — log and bridge modules have no v1.x tag. Hand-picking and re-guessing each `@vX`
 is the churn to avoid.
 

--- a/skills/otel-go/SKILL.md
+++ b/skills/otel-go/SKILL.md
@@ -19,6 +19,10 @@ task; each reference is self-contained.
 | [`references/breaking-changes.md`](references/breaking-changes.md) | Auditing existing code for deprecated calls, renamed semantic conventions, and removed APIs across recent SDK / contrib releases. |
 | [`references/compile-time-instrumentation.md`](references/compile-time-instrumentation.md) | Zero-code, compile-time instrumentation with `otelc`: usage modes (`otelc go build`, tool dependency, toolexec drop-in), subcommands, supported libraries, rule sources/precedence, and pinning via `otel.instrumentation.go`. |
 
+For upgrade reviews, always finish with a safe local verification path (`go mod tidy -diff`,
+`go build ./...`, and `go test ./...`). Test exporter URL or retry changes against a disposable
+local receiver, never a deployment endpoint.
+
 ## Module versioning — read before adding dependencies
 
 opentelemetry-go is split into **independently versioned module groups**. They do NOT

--- a/skills/otel-go/evals/evals.json
+++ b/skills/otel-go/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "otel-go",
+  "runtime": "Claude Code",
+  "model": "opus",
+  "cases": [
+    {
+      "id": "go-v145-upgrade-review",
+      "prompt": "Review skills/otel-go/evals/files/go-v145-upgrade.md and give the exact code/configuration changes needed for the OpenTelemetry Go v1.45.0 upgrade. Explain each behavior change and distinguish it from v1.44.0. Do not modify files or contact an endpoint.",
+      "files": [
+        "skills/otel-go/evals/files/go-v145-upgrade.md"
+      ],
+      "expectations": [
+        "Replaces log.StringValue and log.String with attribute.StringValue and attribute.String, and identifies the log API/SDK v0.21.0 migration from log.Value/log.KeyValue to attribute.Value/attribute.KeyValue.",
+        "States that pathless otlptracehttp.WithEndpointURL uses the root path / in v1.45.0 and explicitly includes /v1/traces in the configured URL (or uses WithURLPath) to preserve the intended OTLP trace route.",
+        "States that v1.45.0 HTTP exporters interpret integer Retry-After values as seconds and support HTTP-date values, while v1.44.0 mistakenly treated integers as nanoseconds and ignored HTTP dates.",
+        "Does not claim that the code was compiled, an exporter contacted, or live behavior validated; proposes a safe local compile or test path instead."
+      ]
+    }
+  ]
+}

--- a/skills/otel-go/evals/evals.json
+++ b/skills/otel-go/evals/evals.json
@@ -1,7 +1,7 @@
 {
   "skill": "otel-go",
-  "runtime": "Claude Code",
-  "model": "opus",
+  "runtime": "Codex CLI 0.147.0",
+  "model": "gpt-5.6-sol",
   "cases": [
     {
       "id": "go-v145-upgrade-review",

--- a/skills/otel-go/evals/files/go-v145-upgrade.md
+++ b/skills/otel-go/evals/files/go-v145-upgrade.md
@@ -1,0 +1,24 @@
+# OpenTelemetry Go upgrade review
+
+The service is upgrading from core OpenTelemetry Go v1.44.0 and log API/SDK v0.20.0 to
+core v1.45.0 and log API/SDK v0.21.0. It currently emits a log record like this:
+
+```go
+var rec log.Record
+rec.SetBody(log.StringValue("checkout failed"))
+rec.AddAttributes(log.String("component", "checkout"))
+logger.Emit(ctx, rec)
+```
+
+Its trace exporter is configured as follows, and the Collector expects traces at
+`http://otel-gateway:4318/v1/traces`:
+
+```go
+exporter, err := otlptracehttp.New(ctx,
+    otlptracehttp.WithEndpointURL("http://otel-gateway:4318"),
+)
+```
+
+The Collector may return either `Retry-After: 5` or an HTTP-date value while throttling.
+The team needs to know whether the v1.45.0 exporter honors both forms and how that differs
+from v1.44.0. This is a static review only: do not contact the example endpoint.

--- a/skills/otel-go/evals/results.md
+++ b/skills/otel-go/evals/results.md
@@ -1,0 +1,53 @@
+# `go-v145-upgrade-review` harness results
+
+Run on 2026-08-14 with Codex CLI 0.147.0 driving `gpt-5.6-sol` through ChatGPT
+authentication. Every retained repetition used a fresh isolated `HOME` and `CODEX_HOME`,
+read-only sandbox, identical prompt and tool access, and a five-minute orchestration ceiling.
+Codex reported no marginal API billing.
+
+The deterministic grader marked a repetition passing only when all four expectations in
+`evals.json` were present in its final answer. The selected repetitions are the earliest valid
+fresh repetitions for each arm and were not chosen by outcome.
+
+| Arm | Selected attempts | Pass | Fail | Unknown |
+|---|---|---:|---:|---:|
+| Target skill withheld | `withheld-4`, `withheld-5`, `withheld-6` | 0 | 3 | 0 |
+| Current `origin/main` skill | `current-1`, `current-2`, `current-5` | 1 | 2 | 0 |
+| Proposed skill | `proposed-9`, `proposed-10`, `proposed-12` | 3 | 0 | 0 |
+
+## Per-attempt grading
+
+`A` is the log `attribute.Value` migration, `B` is the explicit OTLP HTTP trace path,
+`C` is corrected `Retry-After` behavior, and `D` is safe local verification.
+
+| Attempt | A | B | C | D | Result |
+|---|---|---|---|---|---|
+| `withheld-4` | pass | pass | pass | fail | fail |
+| `withheld-5` | pass | pass | pass | fail | fail |
+| `withheld-6` | pass | pass | pass | fail | fail |
+| `current-1` | pass | pass | pass | pass | pass |
+| `current-2` | pass | pass | pass | fail | fail |
+| `current-5` | pass | pass | pass | fail | fail |
+| `proposed-9` | pass | pass | pass | pass | pass |
+| `proposed-10` | pass | pass | pass | pass | pass |
+| `proposed-12` | pass | pass | pass | pass | pass |
+
+The three factual upgrade expectations were saturated in every arm. The measurable lift was
+safe verification: the proposed skill consistently concluded with `go mod tidy -diff`,
+`go build ./...`, `go test ./...`, and a disposable local receiver for exporter behavior.
+
+## Preserved invalid and superseded attempts
+
+- `withheld-1`: unknown; the JSONL transcript ended before a final answer.
+- `withheld-2`: invalid; harness initialization failed before a model turn due temporary quota.
+- `current-3`: invalid; no final answer was retained.
+- `current-4`: invalid; harness initialization failed before a model turn due temporary quota.
+- `proposed-2` and `proposed-11`: invalid; temporary quota interrupted output before a final answer.
+- `proposed-1`, `proposed-3`, `proposed-4`, `proposed-6`, `proposed-7`, and `proposed-8`:
+  valid results against superseded proposed revisions, retained during iteration but excluded
+  because they do not describe the final head.
+- `proposed-5`: invalidated because the revised skill copy was not loaded.
+
+Raw harness transcripts contained local absolute paths and runtime internals, so this sanitized
+public summary replaces them. The final answers were reviewed to confirm that they contained no
+credentials, customer data, or private repository content.

--- a/skills/otel-go/evals/results.md
+++ b/skills/otel-go/evals/results.md
@@ -13,7 +13,7 @@ fresh repetitions for each arm and were not chosen by outcome.
 |---|---|---:|---:|---:|
 | Target skill withheld | `withheld-4`, `withheld-5`, `withheld-6` | 0 | 3 | 0 |
 | Current `origin/main` skill | `current-1`, `current-2`, `current-5` | 1 | 2 | 0 |
-| Proposed skill | `proposed-9`, `proposed-10`, `proposed-12` | 3 | 0 | 0 |
+| Proposed skill | `proposed-14`, `proposed-15`, `proposed-16` | 3 | 0 | 0 |
 
 ## Per-attempt grading
 
@@ -28,9 +28,9 @@ fresh repetitions for each arm and were not chosen by outcome.
 | `current-1` | pass | pass | pass | pass | pass |
 | `current-2` | pass | pass | pass | fail | fail |
 | `current-5` | pass | pass | pass | fail | fail |
-| `proposed-9` | pass | pass | pass | pass | pass |
-| `proposed-10` | pass | pass | pass | pass | pass |
-| `proposed-12` | pass | pass | pass | pass | pass |
+| `proposed-14` | pass | pass | pass | pass | pass |
+| `proposed-15` | pass | pass | pass | pass | pass |
+| `proposed-16` | pass | pass | pass | pass | pass |
 
 The three factual upgrade expectations were saturated in every arm. The measurable lift was
 safe verification: the proposed skill consistently concluded with `go mod tidy -diff`,
@@ -42,8 +42,9 @@ safe verification: the proposed skill consistently concluded with `go mod tidy -
 - `withheld-2`: invalid; harness initialization failed before a model turn due temporary quota.
 - `current-3`: invalid; no final answer was retained.
 - `current-4`: invalid; harness initialization failed before a model turn due temporary quota.
-- `proposed-2` and `proposed-11`: invalid; temporary quota interrupted output before a final answer.
-- `proposed-1`, `proposed-3`, `proposed-4`, `proposed-6`, `proposed-7`, and `proposed-8`:
+- `proposed-2`, `proposed-11`, and `proposed-13`: invalid; temporary quota interrupted output before a final answer.
+- `proposed-1`, `proposed-3`, `proposed-4`, `proposed-6`, `proposed-7`, `proposed-8`,
+  `proposed-9`, `proposed-10`, and `proposed-12`:
   valid results against superseded proposed revisions, retained during iteration but excluded
   because they do not describe the final head.
 - `proposed-5`: invalidated because the revised skill copy was not loaded.

--- a/skills/otel-go/references/api.md
+++ b/skills/otel-go/references/api.md
@@ -187,6 +187,7 @@ attribute.Int64Slice("ids", []int64{1, 2, 3})
 attribute.Float64Slice("values", []float64{1.1, 2.2})
 attribute.BoolSlice("flags", []bool{true, false})
 attribute.Slice("nested", attribute.StringValue("a"), attribute.Int64Value(1)) // v1.44.0+
+attribute.Map("labels", attribute.String("region", "eu")) // v1.45.0+
 ```
 
 ### Attribute Sets
@@ -226,7 +227,7 @@ propagator.Inject(ctx, propagation.HeaderCarrier(w.Header()))
 ## Logs API
 
 The Logs API and SDK are versioned on a **separate v0.x line** (currently `otel/log` and
-`otel/sdk/log` v0.20.0, released alongside core v1.44.0) and are **Beta** — interfaces may
+`otel/sdk/log` v0.21.0, released alongside core v1.45.0) and are **Beta** — interfaces may
 still change without a major bump. They primarily provide a bridge for existing logging
 libraries. Track their version independently from the stable v1.x traces/metrics
 signals (see the module-versioning table in SKILL.md).
@@ -236,7 +237,7 @@ signals (see the module-versioning table in SKILL.md).
 log.LoggerProvider     // Creates Loggers
 log.Logger             // Emits log records
 log.Record             // Log record with attributes
-log.Value              // Typed attribute value
+attribute.Value        // Log body value (v0.21.0+)
 log.Severity           // Log severity level
 ```
 
@@ -251,10 +252,10 @@ if logger.Enabled(ctx, params) {
     var rec log.Record
     rec.SetTimestamp(time.Now())
     rec.SetSeverity(log.SeverityInfo)
-    rec.SetBody(log.StringValue("User logged in"))
+    rec.SetBody(attribute.StringValue("User logged in"))
     rec.AddAttributes(
-        log.String("user.id", userID),
-        log.String("session.id", sessionID),
+        attribute.String("user.id", userID),
+        attribute.String("session.id", sessionID),
     )
     logger.Emit(ctx, rec)
 }
@@ -263,7 +264,7 @@ if logger.Enabled(ctx, params) {
 // The SDK automatically sets exception attributes (exception.type, exception.message)
 var rec log.Record
 rec.SetSeverity(log.SeverityError)
-rec.SetBody(log.StringValue("operation failed"))
+rec.SetBody(attribute.StringValue("operation failed"))
 rec.SetErr(err) // Attaches error; SDK sets exception attributes automatically
 logger.Emit(ctx, rec)
 
@@ -285,14 +286,14 @@ log.SeverityFatal1 through log.SeverityFatal4
 
 ### Log Values
 ```go
-log.StringValue("text")
-log.IntValue(42)
-log.Int64Value(int64(42))
-log.Float64Value(3.14)
-log.BoolValue(true)
-log.BytesValue([]byte("data"))
-log.SliceValue(log.StringValue("a"), log.StringValue("b"))
-log.MapValue(log.String("key", "value"))
+attribute.StringValue("text")
+attribute.IntValue(42)
+attribute.Int64Value(int64(42))
+attribute.Float64Value(3.14)
+attribute.BoolValue(true)
+attribute.ByteSliceValue([]byte("data"))
+attribute.SliceValue(attribute.StringValue("a"), attribute.StringValue("b"))
+attribute.MapValue(attribute.String("key", "value"))
 ```
 
 ## Logging Bridges

--- a/skills/otel-go/references/breaking-changes.md
+++ b/skills/otel-go/references/breaking-changes.md
@@ -4,6 +4,11 @@ Audit reference for upgrading existing Go OpenTelemetry code. For current SDK/co
 version selection, fetch from the Sources of Truth table in the `otel-go` skill (or
 `go.opentelemetry.io/otel` and `go.opentelemetry.io/contrib` release tags directly).
 
+After applying an upgrade, verify it locally with `go mod tidy -diff`, `go build ./...`,
+and `go test ./...`. For exporter URL or retry behavior, use an `httptest.Server` or
+another disposable local receiver; never probe a deployment endpoint merely to confirm
+the SDK migration.
+
 ## API Deprecations
 
 - `go.opentelemetry.io/contrib/config` was removed in contrib v1.35.0. Use `go.opentelemetry.io/contrib/otelconf` instead.

--- a/skills/otel-go/references/breaking-changes.md
+++ b/skills/otel-go/references/breaking-changes.md
@@ -11,6 +11,7 @@ version selection, fetch from the Sources of Truth table in the `otel-go` skill 
 - otelgrpc's deprecated client/server interceptors were removed in v0.60.0. Use stats handlers (`NewServerHandler` / `NewClientHandler`).
 - `attribute.INVALID` deprecated (core v1.43.0) — an empty value is now valid; use `attribute.EMPTY` instead.
 - `attribute.Value.Emit` deprecated (core v1.44.0). Use `attribute.Value.String` instead.
+- `sdk/log.WithExportBufferSize` is deprecated and has no effect as of log SDK v0.21.0 (core v1.45.0 release); the batch processor no longer keeps a separate export-request buffer.
 - `OTEL_EXPERIMENTAL_CONFIG_FILE` is no longer supported by root `otelconf` v0.23.0+ (contrib v1.43.0+). Use `OTEL_CONFIG_FILE`.
 
 ## Removed APIs (instrumentation v0.65.0; contrib v1.40.0 release)
@@ -43,16 +44,28 @@ RPC attribute changes:
 
 - The 8192-byte baggage size limit is now enforced during extraction/parsing (`otel/baggage`, `otel/propagation`): baggage strings over the limit are rejected outright, while malformed members are skipped — valid members are retained and an error is reported.
 
+## Log value API replacement (log API/SDK v0.21.0; core v1.45.0 release)
+
+- Log bodies and record attributes now use `go.opentelemetry.io/otel/attribute.Value` and `attribute.KeyValue`. The former `log.Kind`, `log.Value`, `log.KeyValue`, their constructors, and conversion helpers were removed. Replace `log.StringValue(...)` / `log.String(...)` with `attribute.StringValue(...)` / `attribute.String(...)` (and the corresponding typed constructors).
+- `sdk/log/logtest.RecordFactory` no longer has `AttributeValueLengthLimit` or `AttributeCountLimit`; test records now keep attribute limits disabled.
+
+## OTLP HTTP endpoint URLs (core v1.45.0)
+
+- `otlptracehttp.WithEndpointURL` and `otlpmetrichttp.WithEndpointURL` no longer append `/v1/traces` or `/v1/metrics` when the URL has no path. They now use `/`, matching signal-specific endpoint environment variables and the log exporter. Join the signal path explicitly to preserve the old behavior.
+
 ## HTTP instrumentation behaviour (instrumentation v0.69.0; contrib v1.44.0 release)
 
 - Unknown or empty HTTP methods now report `_OTHER` instead of `GET` across all HTTP instrumentations (otelhttp, otelmux).
 - The default server span name is now `{method} {route}` (e.g. `GET /foo/{id}`) when a route is available, or `{method}` otherwise — conforming to HTTP semconv.
+
+In otelhttp v0.70.0 (contrib v1.45.0), client spans and request metrics derive `network.protocol.name` / `network.protocol.version` from the negotiated response protocol rather than the request's initial `Proto` value.
 
 ## Removed / renamed contrib APIs (v1.43.0–v1.44.0 release lines)
 
 - otelgrpc removed the deprecated `WithSpanOptions` option in v0.69.0.
 - `otelconf`: experimental config types moved from `otelconf` to the `otelconf/x` subpackage in v0.23.0. The `host` resource detector no longer sets `host.id` in v0.23.0.
 - otelgrpc added `OTEL_SEMCONV_STABILITY_OPT_IN` (values `rpc` default, `rpc/dup`, `rpc/old`) in v0.68.0 to stage RPC semconv migration.
+- Contrib v1.45.0 updates instrumentation and detectors to semconv v1.43.0; use the exact versioned semconv package and its generated migration file rather than mixing helpers from older versions.
 
 ## Log bridges attach errors via SetErr (bridge v0.18.0–v0.19.0)
 

--- a/skills/otel-go/references/declarative-setup.md
+++ b/skills/otel-go/references/declarative-setup.md
@@ -39,6 +39,7 @@ latest module tag supports.
 - `go.opentelemetry.io/contrib/config` was removed in contrib v1.35.0. Use `go.opentelemetry.io/contrib/otelconf`.
 - In the root package, use `OTEL_CONFIG_FILE`; `OTEL_EXPERIMENTAL_CONFIG_FILE` is rejected by
   current released `otelconf`.
+- Root `otelconf` v0.25.0 (contrib v1.45.0) includes the SDK's default resource attributes in the resolved resource; account for those when comparing telemetry across an upgrade.
 - If migrating from the schema-pinned `otelconf/v0.3.0` import, the YAML must also migrate to
   the new schema (fetch `examples/otel-sdk-migration-config.yaml` from the schema repo for
   before/after pairs).
@@ -50,7 +51,7 @@ import (
     "go.opentelemetry.io/otel"
     "go.opentelemetry.io/otel/log/global"
     "go.opentelemetry.io/otel/propagation"
-    semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
+    semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
     otelconf "go.opentelemetry.io/contrib/otelconf"
 )
 ```

--- a/skills/otel-go/references/instrumentation-libraries.md
+++ b/skills/otel-go/references/instrumentation-libraries.md
@@ -280,7 +280,7 @@ func (c *CustomClient) CallExternalAPI(ctx context.Context, endpoint string) err
 
 ```go
 func (r *Repository) CreateUser(ctx context.Context, userData *UserData) (*User, error) {
-    // semconv helpers below track go.opentelemetry.io/otel/semconv/v1.41.0
+    // semconv helpers below track go.opentelemetry.io/otel/semconv/v1.43.0
     ctx, span := r.tracer.Start(ctx, "INSERT users",
         trace.WithAttributes(
             semconv.DBSystemNamePostgreSQL,        // db.system.name (was DBSystem/db.system)
@@ -394,10 +394,10 @@ func (w *Worker) ProcessBatch(ctx context.Context, batchID string) error {
             var rec log.Record
             rec.SetTimestamp(time.Now())
             rec.SetSeverity(log.SeverityWarn)
-            rec.SetBody(log.StringValue("item processing failed"))
+            rec.SetBody(attribute.StringValue("item processing failed"))
             rec.AddAttributes(
-                log.String("item.id", item.ID),
-                log.String("error", err.Error()),
+                attribute.String("item.id", item.ID),
+                attribute.String("error", err.Error()),
             )
             w.logger.Emit(ctx, rec)
             continue

--- a/skills/otel-go/references/instrumentation-libraries.md
+++ b/skills/otel-go/references/instrumentation-libraries.md
@@ -397,8 +397,8 @@ func (w *Worker) ProcessBatch(ctx context.Context, batchID string) error {
             rec.SetBody(attribute.StringValue("item processing failed"))
             rec.AddAttributes(
                 attribute.String("item.id", item.ID),
-                attribute.String("error", err.Error()),
             )
+            rec.SetErr(err)
             w.logger.Emit(ctx, rec)
             continue
         }

--- a/skills/otel-go/references/performance.md
+++ b/skills/otel-go/references/performance.md
@@ -337,9 +337,9 @@ The OTLP exporters use exponential backoff with jitter:
 | Max interval | 30s |
 | Max elapsed time | 1min |
 
-gRPC retries honor server pushback. In the current v1.44.0 HTTP exporters, integer
-`Retry-After` values are mistakenly treated as nanoseconds rather than seconds, and HTTP-date
-values are ignored; do not rely on server-directed HTTP backoff in this release.
+gRPC retries honor server pushback. Since v1.45.0 the HTTP exporters correctly interpret
+integer `Retry-After` values as seconds and also support HTTP-date values. On v1.44.0, integer
+values were mistakenly treated as nanoseconds and HTTP-date values were ignored.
 
 ### Request Size Cap (v1.44.0+)
 
@@ -375,7 +375,7 @@ logger := otellog.GetLoggerProvider().Logger("my-service")
 
 if logger.Enabled(ctx, log.EnabledParameters{Severity: log.SeverityInfo}) {
     var rec log.Record
-    rec.SetBody(log.StringValue(expensiveStringBuild()))
+    rec.SetBody(attribute.StringValue(expensiveStringBuild()))
     rec.SetSeverity(log.SeverityInfo)
     logger.Emit(ctx, rec)
 }
@@ -387,9 +387,9 @@ if logger.Enabled(ctx, log.EnabledParameters{Severity: log.SeverityInfo}) {
 
 ```go
 var rec log.Record
-rec.SetBody(log.StringValue("operation completed"))
+rec.SetBody(attribute.StringValue("operation completed"))
 rec.SetSeverity(log.SeverityInfo)
-rec.AddAttributes(log.String("component", "handler"))
+rec.AddAttributes(attribute.String("component", "handler"))
 logger.Emit(ctx, rec)
 ```
 


### PR DESCRIPTION
## Summary

- refresh `otel-go` for core v1.45.0, log API/SDK v0.21.0, and contrib v1.45.0
- migrate log examples from removed `log.Value` / `log.KeyValue` helpers to `attribute` values
- document pathless `WithEndpointURL` and corrected HTTP `Retry-After` behavior
- update semconv, otelconf, instrumentation, and performance guidance
- add a public upgrade-review eval and safe local verification guidance

Tracks [OTEL-318](https://linear.app/ollygarden/issue/OTEL-318/refresh-opentelemetry-agent-skills-against-current-upstream).

## Agent involvement

Codex implemented and evaluated this change. A human owns the PR and requested publication; human review is still required before merge.

## Harness results

**Model + harness:** Codex CLI 0.147.0 driving `gpt-5.6-sol` through ChatGPT auth; fresh isolated homes, read-only sandbox, identical prompt/tools, five-minute orchestration ceiling, no reported marginal API billing.

**Prompt used:** “Review `skills/otel-go/evals/files/go-v145-upgrade.md` and give the exact code/configuration changes needed for the OpenTelemetry Go v1.45.0 upgrade. Explain each behavior change and distinguish it from v1.44.0. Do not modify files or contact an endpoint.”

| Arm | Target-skill revision / state | Cases × reps | Pass | Fail | Unknown |
| --- | --- | ---: | ---: | ---: | ---: |
| Target skill withheld | `Withheld` | 1 × 3 | 0 | 3 | 0 |
| Current `origin/main` skill | `cedd0080db38593f01600137fb2d3a8a43a75b5c` | 1 × 3 | 1 | 2 | 0 |
| Proposed PR skill | `e1b4e9935a2dcbc3b2f628f4ce60c82c2dcf91e6` | 1 × 3 | 3 | 0 | 0 |

**What differed:** All arms correctly identified the three v1.45.0 facts. The withheld arm never supplied the required safe local verification path; current main did so once; the proposed skill did so in every repetition, including local build/test commands and a disposable receiver for endpoint/retry behavior.

**Failing or unknown runs kept, and why:** Selected failures are genuine grader failures. Initialization, quota, incomplete-output, wrong-revision, and superseded-head attempts are listed transparently in the sanitized report and excluded from the selected earliest-valid repetitions.

**Per-case results by arm:** [sanitized detailed report](https://github.com/ollygarden/opentelemetry-agent-skills/blob/jpkroehling/otel-318-refresh-go/skills/otel-go/evals/results.md)

**Limitations:** One focused case covers the three changed v1.45.0 behaviors and verification discipline. It does not benchmark token efficiency, compile a real consumer fixture, or empirically exercise exporter retries.

**Transcripts or summaries:** Raw JSONL includes local absolute paths and runtime internals, so the [sanitized public summary](https://github.com/ollygarden/opentelemetry-agent-skills/blob/jpkroehling/otel-318-refresh-go/skills/otel-go/evals/results.md) replaces raw transcripts, as permitted by `CONTRIBUTING.md`.

## Verification

- `./bin/validate-skill.sh skills/otel-go`
- `./bin/check-skill-inventory.py`
- `git diff --check origin/main...HEAD`
- deterministic eval JSON, unique-ID, expectation, fixture-containment, and no-SKILL-to-evals-link checks

`lychee` was unavailable locally; CI Link Check is authoritative.

## Deliberately excluded

- no scope expansion to uncovered Go contrib modules
- no unreleased upstream changes
- no release, rollout, or merge

## Checklist

- [x] I read and agree to follow the [Code of Conduct](https://github.com/ollygarden/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] `./bin/validate-skill.sh` passes
- [x] `./bin/check-skill-inventory.py` passes
- [x] No registration change is needed; this refresh does not add, rename, or remove a skill
- [x] Content is vendor-neutral, non-opinionated, DRY, and token-efficient
- [x] All three harness arms are reported above
- [x] Commit messages follow Conventional Commits
- [x] The contributor has signed or will satisfy the OllyGarden CLA bot
