### PR TITLE
docs: refresh Collector tooling skills

### DIFF
--- a/skills/otel-collector-builder/SKILL.md
+++ b/skills/otel-collector-builder/SKILL.md
@@ -26,7 +26,7 @@ Pick the OCB version equal to the Collector core version you're targeting.
 ```bash
 # Release binary (named ocb): https://github.com/open-telemetry/opentelemetry-collector-releases/releases?q=cmd/builder
 # Go install (binary is named `builder`, not `ocb`):
-go install go.opentelemetry.io/collector/cmd/builder@v0.157.0
+go install go.opentelemetry.io/collector/cmd/builder@v0.158.0
 ```
 
 The commands below use `ocb`, the release-archive binary name. If you install with
@@ -45,18 +45,18 @@ dist:
   version: 1.0.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.157.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.158.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.157.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.158.0
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.157.0
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.157.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.158.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.158.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.63.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.63.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.64.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.64.0
 ```
 
 **`providers:` semantics.** Omitting the key entirely keeps OCB's built-in default set (env, file, http, https, yaml at the paired stable version). But setting `providers:` at all **replaces** that set. The generated Collector defaults `conf_resolver.default_uri_scheme` to `env`, so an explicit list without `envprovider` fails configuration validation unless you set another included provider as the default. Either omit the key, or include `envprovider` plus every scheme the collector's config will use.
@@ -65,7 +65,7 @@ Contrib components use the same list syntax:
 
 ```yaml
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.157.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.158.0
 ```
 
 ## Version alignment
@@ -74,14 +74,14 @@ Two version streams exist and must be paired:
 
 | Stream | Modules | Example |
 |--------|---------|---------|
-| `v0.x.0` | OCB itself, all core components (`go.opentelemetry.io/collector/...`), all contrib components | `v0.157.0` |
-| `v1.y.0` (stable) | confmap providers (`confmap/provider/...`), other 1.x modules (pdata, etc.) | `v1.63.0` |
+| `v0.x.0` | OCB itself, all core components (`go.opentelemetry.io/collector/...`), all contrib components | `v0.158.0` |
+| `v1.y.0` (stable) | confmap providers (`confmap/provider/...`), other 1.x modules (pdata, etc.) | `v1.64.0` |
 
 Rules:
 
 - Use the **same `v0.x.0`** for every core and contrib component, matched to the OCB version.
-- The paired provider version for a given release is authoritative in that release's embedded default manifest: `https://github.com/open-telemetry/opentelemetry-collector/blob/cmd/builder/v0.157.0/cmd/builder/internal/config/default.yaml` — check it rather than guessing (for `v0.157.0` it is `v1.63.0`).
-- Versions require the `v` prefix (`v0.157.0`, not `0.157.0`).
+- The paired provider version for a given release is authoritative in that release's embedded default manifest: `https://github.com/open-telemetry/opentelemetry-collector/blob/cmd/builder/v0.158.0/cmd/builder/internal/config/default.yaml` — check it rather than guessing (for `v0.158.0` it is `v1.64.0`).
+- Versions require the `v` prefix (`v0.158.0`, not `0.158.0`).
 - `--skip-strict-versioning` defaults to `true`, so mismatches surface as Go module resolution errors, not friendly OCB errors. Align versions up front instead of debugging `go mod tidy` output.
 
 ## Build commands and flags

--- a/skills/otel-collector-builder/references/manifest.md
+++ b/skills/otel-collector-builder/references/manifest.md
@@ -70,11 +70,11 @@ Providers implement config URI schemes. The built binary can only load config th
 
 ```yaml
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.63.0   # file: and bare paths
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.63.0    # env: (${env:VAR})
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.63.0   # http://
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.63.0  # https://
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.63.0   # yaml: (inline YAML)
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.64.0   # file: and bare paths
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.64.0    # env: (${env:VAR})
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.64.0   # http://
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.64.0  # https://
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.64.0   # yaml: (inline YAML)
 ```
 
 Providers version on the stable `v1.y.0` stream (see the version-alignment section in SKILL.md for the pairing rule).
@@ -98,7 +98,7 @@ Advanced, single module (not a list). Overrides the collector's internal-telemet
 
 ```yaml
 telemetry:
-  gomod: go.opentelemetry.io/collector/service v0.157.0
+  gomod: go.opentelemetry.io/collector/service v0.158.0
   import: go.opentelemetry.io/collector/service/telemetry/otelconftelemetry
 ```
 
@@ -141,29 +141,29 @@ dist:
   version: 2.1.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.157.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.157.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.158.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.158.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.157.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.157.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.157.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.158.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.158.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.158.0
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.157.0
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.157.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.158.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.158.0
 
 extensions:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension v0.157.0
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.157.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension v0.158.0
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.158.0
 
 connectors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.157.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.158.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.63.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.63.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.63.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.64.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.64.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.64.0
 
 replaces:
   - github.com/acme/private-exporter => ../private-exporter

--- a/skills/otel-collector-builder/references/troubleshooting.md
+++ b/skills/otel-collector-builder/references/troubleshooting.md
@@ -19,7 +19,7 @@ Symptoms: `go mod tidy` errors during the "get modules" step, `there is a mismat
 Fix: align every core and contrib component on the same `v0.x.0` matching the OCB version, and providers on the paired `v1.y.0` (pairing rule in SKILL.md). Common mistakes:
 
 - One component pinned at an older `v0.x.0` than the rest — Go resolves the highest requested version and the manifest no longer matches reality.
-- Version written without the `v` prefix (`0.157.0`) — module query fails outright.
+- Version written without the `v` prefix (`0.158.0`) — module query fails outright.
 - OCB binary older than the component versions in the manifest — upgrade OCB first; the generated templates encode assumptions about the core APIs of the matching release.
 
 Strict checking is off by default; run with `--skip-strict-versioning=false` to make OCB verify resolved versions against the manifest instead of failing later in `go build`.
@@ -49,7 +49,7 @@ The manifest set `providers:` explicitly and omitted `envprovider`. The key **re
 - `cgo: C compiler "gcc" not found`: a component needs CGO. Either install a C toolchain and set `dist.cgo_enabled: true`, or drop the component. Default is CGO off.
 - `build constraints exclude all Go files`: `dist.build_tags` or `GOOS`/`GOARCH` excludes everything — clear the tags or fix the target platform.
 - OOM on small CI runners: the collector dependency graph is large. `GOMAXPROCS=2 ocb --config=builder.yaml`, or split into generate + `go build` stages.
-- `exec: "go": executable file not found`: install a compatible Go toolchain or set `dist.go` to its path. OCB v0.157.0 declares Go 1.25 and runs `go mod tidy -compat=1.25`; selected modules may require newer Go.
+- `exec: "go": executable file not found`: install a compatible Go toolchain or set `dist.go` to its path. OCB v0.158.0 declares Go 1.25 and runs `go mod tidy -compat=1.25`; selected modules may require newer Go.
 
 ## Runtime failures
 

--- a/skills/otel-collector-builder/references/workflows.md
+++ b/skills/otel-collector-builder/references/workflows.md
@@ -24,7 +24,7 @@ receivers:
 Requirements:
 
 - The local directory must contain a `go.mod` whose module path matches the `gomod` path.
-- Run OCB with a Go toolchain new enough for both OCB and the selected modules. OCB v0.157.0 declares Go 1.25, generates a `go 1.25` module, and runs `go mod tidy -compat=1.25`; a local component that requires newer Go needs that newer toolchain.
+- Run OCB with a Go toolchain new enough for both OCB and the selected modules. OCB v0.158.0 declares Go 1.25, generates a `go 1.25` module, and runs `go mod tidy -compat=1.25`; a local component that requires newer Go needs that newer toolchain.
 - Since v0.151.0 the generated `replace` uses a path relative to `dist.output_path`, so the generated tree can be committed or moved. Set `dist.use_absolute_replace_paths: true` if external tooling expects absolute paths.
 
 This is also the fastest verification loop when authoring a new component: manifest with the local component + `otlpreceiver` + `debugexporter`, build, run, send data with `telemetrygen`.
@@ -56,7 +56,7 @@ Run OCB in a container (no local Go needed):
 
 ```bash
 docker run --rm -v "$(pwd):/work" -w /work \
-  otel/opentelemetry-collector-builder:0.157.0 \
+  otel/opentelemetry-collector-builder:0.158.0 \
   --config=/work/builder.yaml
 ```
 
@@ -68,7 +68,7 @@ Typical multi-stage Dockerfile for shipping the result:
 FROM golang:1.25 AS build
 WORKDIR /build
 COPY builder.yaml .
-RUN go install go.opentelemetry.io/collector/cmd/builder@v0.157.0 \
+RUN go install go.opentelemetry.io/collector/cmd/builder@v0.158.0 \
  && builder --config=builder.yaml
 
 FROM gcr.io/distroless/static-debian12:nonroot

--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -6,7 +6,7 @@ description: OpenTelemetry Transformation Language (OTTL) expert for writing and
 # OpenTelemetry Transformation Language (OTTL)
 
 OTTL transforms or selects telemetry inside Collector components. This skill is pinned to
-collector-contrib **v0.157.0**. Function, path, default, and feature-gate availability varies by
+collector-contrib **v0.158.0**. Function, path, default, and feature-gate availability varies by
 release; when the user's version differs, verify against the matching upstream tag.
 
 ## Workflow
@@ -17,16 +17,19 @@ release; when the user's version differs, verify against the matching upstream t
 2. **Choose the lowest usable context.** Lower contexts can read their parents (for example, a span
    can read `resource.attributes`), but parents cannot read children. Use `datapoint` for point
    attributes instead of traversing `metric.data_points`.
-3. **Write the statement.** An editor such as `set` or `delete_key` mutates data and may have a
-   `where` condition. Converters such as `ParseJSON` and `IsMatch` return values; they do not mutate.
+3. **Verify every emitted function, then write the statement.** Confirm each function's exact
+   identifier and signature in [references/functions.md](references/functions.md). If an identifier
+   is absent, treat it as unsupported instead of deriving or substituting a plausible name. An
+   editor such as `set` or `delete_key` mutates data and may have a `where` condition. Converters
+   such as `ParseJSON` and `IsMatch` return values; they do not mutate.
 4. **Set error behavior deliberately.** `ignore` logs statement errors and continues; `silent`
    continues without logging; `propagate` returns the error and can cause the component to drop the
-   payload. In v0.157, transform and filter default to `ignore`; routing also defaults to `ignore`
+   payload. In v0.158, transform and filter default to `ignore`; routing also defaults to `ignore`
    while its beta default-error feature gate is enabled. For routing, `ignore` sends an errored
    payload to `default_pipelines`; configure that fallback or the payload is dropped.
 5. **Verify end to end.** Validate the exact Collector version, then send known telemetry and inspect
    file-exporter output. Use the
-   [telemetrygen recipe](../otel-telemetrygen/SKILL.md#verifying-a-collector-config).
+   [telemetrygen recipe](../otel-telemetrygen/SKILL.md#verify-collector-behavior).
 
 ```ottl
 set(span.attributes["env"], "prod") where resource.attributes["env"] == nil
@@ -50,7 +53,7 @@ For a single path or function, read only the relevant section instead of loading
   flag admits pretty-printed objects containing newlines. Checking `IsMap` after
   parsing does not prevent arrays or scalar JSON from being parsed.
 - On a version-pinned request, confirm every chosen path and function against that release tag;
-  do not assume a function listed for this skill's v0.157 anchor exists in an older release.
+  do not assume a function listed for this skill's v0.158 anchor exists in an older release.
   For v0.156 JSON-object parsing, `ParseJSON`, `IsString`, and `IsMatch` are available without the
   v0.157 alpha lambda feature gate.
 - Request metadata is read-only and may contain credentials. Copy only explicitly allowlisted,
@@ -77,7 +80,7 @@ For a single path or function, read only the relevant section instead of loading
 
 ## Upstream sources
 
-- [OTTL package](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.157.0/pkg/ottl)
-- [Transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.157.0/processor/transformprocessor)
-- [Filter processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.157.0/processor/filterprocessor)
-- [Routing connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.157.0/connector/routingconnector)
+- [OTTL package](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.158.0/pkg/ottl)
+- [Transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.158.0/processor/transformprocessor)
+- [Filter processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.158.0/processor/filterprocessor)
+- [Routing connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.158.0/connector/routingconnector)

--- a/skills/otel-ottl/evals/evals.json
+++ b/skills/otel-ottl/evals/evals.json
@@ -5,7 +5,7 @@
   "cases": [
     {
       "id": "routing-metadata-fallback",
-      "prompt": "We run OpenTelemetry Collector contrib v0.157. Route OTLP logs by the X-Tenant header to logs/acme, but malformed or missing headers must not lose telemetry. Provide the relevant YAML and explain the failure behavior.",
+      "prompt": "We run OpenTelemetry Collector contrib v0.158. Route OTLP logs by the X-Tenant header to logs/acme, but malformed or missing headers must not lose telemetry. Provide the relevant YAML and explain the failure behavior.",
       "expectations": [
         "Uses executable routing YAML with either otelcol.client.metadata[\"X-Tenant\"][0] for HTTP or otelcol.grpc.metadata[\"x-tenant\"][0] for gRPC.",
         "Enables include_metadata on the OTLP receiver and notes lowercase keys for gRPC metadata.",
@@ -16,7 +16,7 @@
     },
     {
       "id": "yaml-backreference-redaction",
-      "prompt": "For Collector contrib v0.157, write a transform processor that redacts token query-parameter values in span URL attributes while preserving the parameter name. Include how you would verify it.",
+      "prompt": "For Collector contrib v0.158, write a transform processor that redacts token query-parameter values in span URL attributes while preserving the parameter name. Include how you would verify it.",
       "expectations": [
         "Uses a span-context transform statement with replace_pattern.",
         "Uses the Collector-YAML replacement $${1}REDACTED and does not present $1REDACTED as valid.",

--- a/skills/otel-ottl/references/contexts.md
+++ b/skills/otel-ottl/references/contexts.md
@@ -1,6 +1,6 @@
 # OTTL Contexts Reference
 
-Context paths and enums for collector-contrib **v0.157.0**. Higher-level contexts are reachable from lower ones (a span statement can read `resource.attributes`); the reverse is not true. Always pick the most specific context for the work — using `datapoint` to set metric-point attributes is much cheaper than walking through `metric.data_points` from the metric context.
+Context paths and enums for collector-contrib **v0.158.0**. Higher-level contexts are reachable from lower ones (a span statement can read `resource.attributes`); the reverse is not true. Always pick the most specific context for the work — using `datapoint` to set metric-point attributes is much cheaper than walking through `metric.data_points` from the metric context.
 
 ## Contents
 

--- a/skills/otel-ottl/references/functions.md
+++ b/skills/otel-ottl/references/functions.md
@@ -1,6 +1,6 @@
 # OTTL Functions Catalog
 
-Editor and converter reference for collector-contrib **v0.157.0**. Editors mutate telemetry; converters return values for use in expressions. See the upstream `pkg/ottl/ottlfuncs/README.md` for the authoritative source.
+Editor and converter reference for collector-contrib **v0.158.0**. Editors mutate telemetry; converters return values for use in expressions. See the upstream `pkg/ottl/ottlfuncs/README.md` for the authoritative source.
 
 ## Contents
 
@@ -16,7 +16,7 @@ Editor and converter reference for collector-contrib **v0.157.0**. Editors mutat
 The `transform` processor adds the following functions to the common OTTL
 catalog. They are not generally available in other OTTL-consuming components.
 The contexts and signatures below are pinned to the released
-[v0.157.0 transform processor source](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/README.md#supported-functions).
+[v0.158.0 transform processor source](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.158.0/processor/transformprocessor/README.md#supported-functions).
 
 | Context | Signature | Behavior and limits |
 |---------|-----------|---------------------|
@@ -36,17 +36,18 @@ The contexts and signatures below are pinned to the released
 | `datapoint` | `merge_histogram_buckets(target_value, method?)` | Explicit Histograms only. Default `remove_explicit_bound` removes a matching bound; `limit_buckets` requires a positive integer target and reduces resolution. Other metric types are unchanged. |
 | `log` | `ParseCEF(target)` | Parses Common Event Format into a map, including an optional syslog prefix and string-valued extensions; malformed or empty input errors. |
 | `log` | `ParseCLF(target, format?)` | Parses CLF (`"clf"`, default) or NCSA combined (`"combined"`) text into a map; malformed or empty input errors. |
+| `log` | `ParseELF(target)` | Parses a complete W3C Extended Log Format block into directive metadata, fields, and entries; requires a `#Version` directive and `#Fields` before data. Added in v0.158. |
 | `log` | `ParseLEEF(target)` | Parses LEEF 1.0/2.0 into a map; malformed or empty input errors; attribute values remain strings. |
-| `span` | `set_semconv_span_name(semconv_version, original_span_name_attribute?)` | Derives low-cardinality HTTP, RPC, messaging, or database span names. v0.157 accepts semantic-convention versions 1.37.0 through 1.40.0; unrelated spans are unchanged. |
+| `span` | `set_semconv_span_name(semconv_version, original_span_name_attribute?)` | Derives low-cardinality HTTP, RPC, messaging, or database span names. v0.158 accepts semantic-convention versions 1.37.0 through 1.40.0; unrelated spans are unchanged. |
 
 For full behavior, examples, and edge cases, follow the tag-pinned
-[metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/README.md#convert_sum_to_gauge),
-[logs](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/README.md#parsecef), and
-[traces](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/README.md#set_semconv_span_name)
+[metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.158.0/processor/transformprocessor/README.md#convert_sum_to_gauge),
+[logs](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.158.0/processor/transformprocessor/README.md#parsecef), and
+[traces](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.158.0/processor/transformprocessor/README.md#set_semconv_span_name)
 function sections. The registrations that constrain the contexts are also tag-pinned:
-[metric/datapoint](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/internal/metrics/functions.go),
-[log](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/internal/logs/functions.go), and
-[span](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.157.0/processor/transformprocessor/internal/traces/functions.go).
+[metric/datapoint](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.158.0/processor/transformprocessor/internal/metrics/functions.go),
+[log](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.158.0/processor/transformprocessor/internal/logs/functions.go), and
+[span](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.158.0/processor/transformprocessor/internal/traces/functions.go).
 
 ## Editors (data manipulation)
 
@@ -58,6 +59,9 @@ set(target, value)
 set(span.attributes["env"], "production")
 set(log.body, Concat([log.severity_text, ": ", log.body.string], ""))
 ```
+
+Since v0.158, assigning `nil` to a map or slice path clears it, and assigning `nil` to a
+`pcommon.Value` makes it empty. Scalar and struct paths reject `nil`.
 
 ### `append`
 ```ottl

--- a/skills/otel-ottl/references/quick-reference.md
+++ b/skills/otel-ottl/references/quick-reference.md
@@ -359,7 +359,7 @@ where span.kind == SPAN_KIND_SERVER and IsMatch(span.name, "expensive.*")
 1. Syntax: parens balanced, strings closed, regex escapes doubled.
 2. Types: type-check before conversion (`IsString`, `IsInt`).
 3. Existence: nil-guard paths that may be absent.
-4. Logic: dry-run with the [telemetrygen verification recipe](../../otel-telemetrygen/SKILL.md#verifying-a-collector-config) — generate a known input, capture the file-exporter output, confirm the transformation. The eye test misses too many gotchas.
+4. Logic: dry-run with the [telemetrygen verification recipe](../../otel-telemetrygen/SKILL.md#verify-collector-behavior) — generate a known input, capture the file-exporter output, confirm the transformation. The eye test misses too many gotchas.
 5. Performance: most-selective `where` clause first.
 
 ### Safe transformation skeletons

--- a/skills/otel-telemetrygen/SKILL.md
+++ b/skills/otel-telemetrygen/SKILL.md
@@ -6,7 +6,7 @@ description: Build safe, version-pinned telemetrygen commands for synthetic OTLP
 # Telemetrygen
 
 Generate synthetic OpenTelemetry telemetry with `telemetrygen` from
-[opentelemetry-collector-contrib v0.157.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.157.0/cmd/telemetrygen).
+[opentelemetry-collector-contrib v0.158.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.158.0/cmd/telemetrygen).
 Upstream metadata marks its traces, metrics, and logs subcommands as alpha.
 
 ## Safety and input gate
@@ -116,8 +116,8 @@ Before finalizing a response, check that:
 Pin the release:
 
 ```bash
-go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@v0.157.0
-docker pull ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.157.0
+go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@v0.158.0
+docker pull ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.158.0
 ```
 
 The version belongs in the installation or image reference, not between the installed
@@ -127,7 +127,7 @@ Run the container with the same flags after the image name:
 
 ```bash
 docker run --rm --network "container:<collector-container-name>" \
-  ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.157.0 \
+  ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.158.0 \
   traces --otlp-insecure --otlp-endpoint 127.0.0.1:4317 \
   --traces 100 --workers 1 --rate 1
 ```

--- a/skills/otel-telemetrygen/evals/evals.json
+++ b/skills/otel-telemetrygen/evals/evals.json
@@ -3,7 +3,7 @@
   "cases": [
     {
       "id": "bounded-http-logs-env",
-      "prompt": "We use telemetrygen v0.157.0. Give me, but do not run, a reproducible command that sends logs over OTLP/HTTP with trusted TLS to collector.example.test:4318 for 30 seconds at exactly 120 logs/second total using four workers. Set service.name to checkout, the resource attribute deployment.environment.name to staging, and the log-record attribute test.scenario to refund. My shell may already define OTEL_EXPORTER_OTLP_* variables.",
+      "prompt": "We use telemetrygen v0.158.0. Give me, but do not run, a reproducible command that sends logs over OTLP/HTTP with trusted TLS to collector.example.test:4318 for 30 seconds at exactly 120 logs/second total using four workers. Set service.name to checkout, the resource attribute deployment.environment.name to staging, and the log-record attribute test.scenario to refund. My shell may already define OTEL_EXPORTER_OTLP_* variables.",
       "expectations": [
         "Uses the logs subcommand with --otlp-http and --otlp-endpoint collector.example.test:4318, and does not disable or skip verification of trusted TLS.",
         "Uses --duration 30s, --workers 4, and --rate 30 for an approximate configured target of 120 logs/second total, without also supplying --logs or an unbounded duration/rate; states that observed delivered throughput can be lower.",

--- a/skills/otel-telemetrygen/references/collector-verification.md
+++ b/skills/otel-telemetrygen/references/collector-verification.md
@@ -11,7 +11,7 @@ fixture execution, and live execution; report only the levels actually completed
   short-lived container and output directory.
 - Pick a unique container name and a newly created empty output directory. Never reuse `./out` or
   a prior `result.json`; stale output can create a false positive.
-- Pin Collector and telemetrygen to compatible reviewed versions. The examples use `0.157.0`.
+- Pin Collector and telemetrygen to compatible reviewed versions. The examples use `0.158.0`.
 
 ## Minimal local pipeline
 
@@ -119,7 +119,7 @@ started_container_id=$(docker run -d --name "$container_name" \
   --user "$(id -u):$(id -g)" \
   -v "$config_path:/etc/otelcol-contrib/config.yaml:ro" \
   -v "$output_dir:/output" \
-  otel/opentelemetry-collector-contrib:0.157.0 \
+  otel/opentelemetry-collector-contrib:0.158.0 \
   --config=/etc/otelcol-contrib/config.yaml)
 docker_run_status=$?
 [ "$docker_run_status" -eq 0 ] || exit "$docker_run_status"
@@ -151,7 +151,7 @@ fi
 
 set +e
 docker run --rm --network "container:$container_id" \
-  ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.157.0 \
+  ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.158.0 \
   logs --otlp-insecure --otlp-endpoint 127.0.0.1:4317 \
   --logs 1 --severity-text Info
 telemetrygen_status=$?

--- a/skills/otel-telemetrygen/references/flags.md
+++ b/skills/otel-telemetrygen/references/flags.md
@@ -1,6 +1,6 @@
 # Telemetrygen Flag Reference
 
-Complete flag reference for `telemetrygen` v0.157.0.
+Complete flag reference for `telemetrygen` v0.158.0.
 
 ## Table of Contents
 
@@ -39,7 +39,7 @@ These apply to all subcommands (`traces`, `metrics`, `logs`).
 | `--workers` | int | `1` | Concurrent worker goroutines |
 | `--rate` | float64 | `1` | Approximate configured record target per second per worker; delivered export throughput may be lower. For traces, parent and child spans count toward this target, so approximate traces/s = `workers * rate / (effective children + 1)`. `0` means no throttling and is prohibited by the safety gate |
 | `--duration` | duration | `0` | How long to generate. Use a finite Go duration (`5s`, `1m`); `inf` is recognized but prohibited by the safety gate. Overrides count flags |
-| `--interval` | duration | `1s` | Registered reporting interval; not consumed by generation code in v0.157.0 |
+| `--interval` | duration | `1s` | Registered reporting interval; not consumed by generation code in v0.158.0 |
 | `--timeout` | duration | `10s` | Maximum time to wait for the signals to reach destination |
 
 ### Batching
@@ -148,7 +148,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.157.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.158.0
         args:
         - traces
         - --otlp-endpoint=otel-collector.observability:4317

--- a/skills/otel-weaver/SKILL.md
+++ b/skills/otel-weaver/SKILL.md
@@ -60,8 +60,8 @@ These cost time and are not obvious from the upstream docs:
 8. CLI argument ordering for `generate`: target directory name is positional **after** `--registry` and `--templates`; the output directory follows. `--templates` points at the **parent** that contains target dirs, not at the language-specific subdir.
 9. Span name in registry vs. runtime: required schema fields are `type`, `kind` (`client`/`server`/`producer`/`consumer`/`internal`), `brief`, `stability`, and a structured `name: { note: "..." }`. For internal business spans, putting the dotted type identifier in `name.note` and rendering the resolved `span.name.note` string at runtime is clean.
 10. **What does NOT belong in your local registry.** DB, HTTP, messaging, RPC, network, GenAI, and similar boundary spans/attributes follow upstream OTel semconv. Until upstream is pulled in as a manifest dependency, instrumentation for those should reference the language SDK's semconv package directly. This is the most common modeling mistake.
-11. Counter and UpDownCounter names should not append `_total`; this is the current semconv v1.43.0 naming rule.
-12. Duration instruments should use seconds (`s`) under the current semconv v1.43.0 unit guidance.
+11. Counter and UpDownCounter names should not append `_total`; this is the current semconv v1.44.0 naming rule.
+12. Duration instruments should use seconds (`s`) under the current semconv v1.44.0 unit guidance.
 
 ## References To Load On Demand
 


### PR DESCRIPTION
## Summary

- refresh OCB, OTTL, and telemetrygen guidance to the released Collector/contrib v0.158.0 line and paired stable v1.64.0 modules
- add the released transform-processor `ParseELF` function and v0.158 nil-assignment semantics
- refresh Weaver metric guidance to semantic conventions v1.44.0
- require exact OTTL function-name/signature verification before emitting a call

Linear: [OTEL-318](https://linear.app/ollygarden/issue/OTEL-318/refresh-opentelemetry-agent-skills-against-current-upstream)

Deliberately excluded: unreleased upstream changes, new tooling/component scope, and generated artifacts outside these four skills.

## Agent involvement

Codex audited upstream release objects, implemented and validated the refresh, designed and ran the harness, and adversarially reviewed the diff. A human owns this PR; human review is still required before merge.

## Harness results (required for new or substantively changed skills)

**Model + harness:** Codex CLI 0.147.0 driving `gpt-5.6-sol` through ChatGPT authentication, fresh ephemeral read-only sessions, isolated per-arm homes, three repetitions per case.

**Prompt(s) used:** Four public, version-pinned prompts covering an OCB v0.158 manifest, W3C ELF parsing plus nil assignment in OTTL, a bounded telemetrygen v0.158 command, and Weaver metric naming/units under semconv v1.44.0. Each prompt used the same explicit `Use $<skill> if installed` wording in all arms.

| Arm | Target-skill revision / state | Cases × reps | Pass | Fail | Unknown |
| --- | --- | ---: | ---: | ---: | ---: |
| Target skill withheld | `Withheld` | 4 × 3 | 6 | 6 | 0 |
| Current `origin/main` skill | `cedd008cf94378c4454064f4a517781315f44aa8` | 4 × 3 | 9 | 3 | 0 |
| Proposed PR skill | `11226665aafeabf2423c48516a54e90fe51c7b97` | 4 × 3 | 12 | 0 | 0 |

**What differed:** Without the skill, all OCB runs emitted the nonexistent `dist.otelcol_version` key and all OTTL runs missed the released `ParseELF` API. Current `origin/main` fixed OCB but invented `ParseW3CLog` in every OTTL run because its v0.157 catalog does not contain `ParseELF`. The proposed skills produced valid version-aligned OCB manifests and exact `ParseELF`/nil behavior without regressing the telemetrygen or Weaver cases.

**Failing or unknown runs kept, and why:** All genuine failures are included in the counts. Network-blocked, quota-truncated, and missing-final attempts were preserved locally but excluded as invalid executions, never retried in place, and replaced only by the first valid response for that cell.

**Per-case results by arm:**

| Case | Withheld | `origin/main` | Proposed |
| --- | ---: | ---: | ---: |
| OCB manifest/version pairing | 0/3 | 3/3 | 3/3 |
| OTTL W3C ELF + nil assignment | 0/3 | 0/3 | 3/3 |
| bounded telemetrygen command | 3/3 | 3/3 | 3/3 |
| Weaver metric naming/units | 3/3 | 3/3 | 3/3 |

**Limitations:** The final-head OTTL proposed repetitions used controlled injection of the public proposed `SKILL.md` and `references/functions.md` to eliminate nondeterministic filesystem-read behavior observed in automatic activation runs. The user prompt, model, tools, sandbox, and grading remained unchanged. This comparison proves retrieval correctness for the changed facts, not runtime Collector execution or trigger-selection quality.

**Transcripts or summaries:** Public gist publication was blocked by the execution safety gate, so this sanitized result summary replaces transcript links. The retained responses contain only the public prompts, public skill content, and technical recommendations; no customer or private repository data was used.

## Verification

- `./bin/validate-skill.sh skills/otel-collector-builder`
- `./bin/validate-skill.sh skills/otel-ottl`
- `./bin/validate-skill.sh skills/otel-telemetrygen`
- `./bin/validate-skill.sh skills/otel-weaver`
- `./bin/check-skill-inventory.py`
- `git diff --check`
- tag-pinned source/path checks against local Collector `cmd/builder/v0.158.0`, collector-contrib `v0.158.0`, and semantic-conventions `v1.44.0` Git objects
- no registration change required

## Checklist

- [x] I read and agree to follow the [Code of Conduct](https://github.com/ollygarden/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] `./bin/validate-skill.sh` passes
- [x] `./bin/check-skill-inventory.py` passes
- [x] Skill registered in all three places — not applicable; no skill was added or renamed
- [x] Content is vendor-neutral, non-opinionated, DRY, and token-efficient
- [x] All three harness arms reported above
- [x] Commit messages follow Conventional Commits
- [x] I have signed (or will sign via the CLA bot on this PR) the OllyGarden CLA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenTelemetry Collector Builder, OTTL, and telemetrygen guidance to version 0.158.0.
  * Updated installation commands, container examples, manifests, workflows, troubleshooting steps, and verification links.
  * Added OTTL documentation for the `ParseELF` transform and clarified nil-assignment behavior for `set`.
  * Refreshed evaluation prompts and examples to match the latest documented versions.
  * Updated Weaver instrument-naming guidance to semantic conventions v1.44.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->