### PR TITLE
chore(otel-agent-tools): upgrade Go to 1.26.6

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,3 +1,3 @@
-go 1.24.5
+go 1.26.6
 
 use ./tools/otel-agent-tools

--- a/tools/otel-agent-tools/go.mod
+++ b/tools/otel-agent-tools/go.mod
@@ -1,3 +1,3 @@
 module otel-agent-tools
 
-go 1.24.5
+go 1.26.6


### PR DESCRIPTION
## Summary
- upgrade the repository workspace Go directive to 1.26.6
- upgrade the maintained `tools/otel-agent-tools` module to 1.26.6

## Validation
- local Go commands intentionally not run under the laptop-safe sweep contract
- existing GitHub Actions CI validates the tool with golangci-lint, build, and tests using `go-version-file: tools/otel-agent-tools/go.mod`

## Scope
Source-free toolchain pin only; no dependency changes. Authored with Codex.