### PR TITLE
fix: refresh semantic convention tooling

### DIFF
--- a/skills/otel-semantic-conventions/references/otel-semantic-conventions.md
+++ b/skills/otel-semantic-conventions/references/otel-semantic-conventions.md
@@ -19,7 +19,7 @@ Rules:
 - pass a listed kind as the second argument to list the released entries of that kind
 - pass an exact entry id as the second argument to return its upstream definition block
 - the script resolves the latest released semantic conventions version and reads released YAML model files under `model/<group>/` from that tag
-- definition/2 provider refinement files introduced in v1.44 are included under their signal kind even when their filenames do not contain `spans`, `metrics`, or `events`
+- definition/2 registry attributes, signal definitions, and refinements introduced in v1.44 are parsed by their schema entry keys; messaging provider files are included under their signal kind even when their filenames do not contain `spans`, `metrics`, or `events`
 - deprecated model files and directories are excluded from lookup results
 - the core semantic-conventions repository added `model/manifest.yaml` in v1.43.0; use it as release metadata, not as a convention group
 - `gen_ai.*`, OpenAI, and MCP conventions moved to the dedicated OpenTelemetry GenAI semantic conventions repository in v1.42.0; do not treat deprecated stubs under the core repository as current guidance

--- a/skills/otel-semantic-conventions/scripts/query-otel-semantic-conventions.sh
+++ b/skills/otel-semantic-conventions/scripts/query-otel-semantic-conventions.sh
@@ -156,7 +156,7 @@ model_records() {
       kind = kind_for_file(file)
       if (kind != "") {
         printf "%s\t%s\t%s\t%s\n", parts[2], kind, path, parts[count]
-      } else if (path ~ /^model\/messaging\/[^/]+\.ya?ml$/) {
+      } else if (count == 3 && parts[1] == "model" && parts[2] == "messaging") {
         # v1.44 definition/2 provider files can contain both span definitions
         # and cross-signal attribute groups, despite neutral filenames.
         printf "%s\tspans\t%s\t%s\n", parts[2], path, parts[count]
@@ -212,6 +212,12 @@ find_kind_files() {
 find_registry_path() {
   local records="$1"
   awk -F '\t' '$2 == "registry" { print $3; exit }' <<<"$records"
+}
+
+is_definition_v2() {
+  local content="$1"
+  [[ "$content" == file_format:\ definition/2* ||
+     "$content" == *$'\nfile_format: definition/2'* ]]
 }
 
 print_available_groups() {
@@ -346,6 +352,7 @@ extract_v2_entries() {
       return trim(value)
     }
     function section_kind(value) {
+      if (value == "attributes") return "registry"
       if (value == "spans" || value == "span_refinements") return "spans"
       if (value == "events" || value == "event_refinements") return "events"
       if (value == "metrics" || value == "metric_refinements") return "metrics"
@@ -368,10 +375,10 @@ extract_v2_entries() {
       active = section_kind(section) == requested_kind
       next
     }
-    active && /^  - (id|type): / {
+    active && /^  - (id|key|name|type): / {
       emit()
       id = $0
-      sub(/^  - (id|type): /, "", id)
+      sub(/^  - (id|key|name|type): /, "", id)
       next
     }
     active && id != "" && /^    stability: / {
@@ -407,10 +414,10 @@ extract_exact_v2_entry() {
   local path="$4"
 
   awk -v entry_id="$entry_id" -v tag="$tag" -v path="$path" '
-    /^  - (id|type): / {
+    /^  - (id|key|name|type): / {
       if (found) exit
       candidate = $0
-      sub(/^  - (id|type): /, "", candidate)
+      sub(/^  - (id|key|name|type): /, "", candidate)
       if (candidate == entry_id) {
         found = 1
         start_line = NR
@@ -555,7 +562,11 @@ main() {
   if [[ -z "$second_arg" ]]; then
     if [[ -n "$registry_path" ]]; then
       registry_content="$(fetch_group_file "$tag" "$registry_path")"
-      registry_entries="$(extract_entries "$registry_content" "      - id: " "        " 32)"
+      if is_definition_v2 "$registry_content"; then
+        registry_entries="$(extract_v2_entries "$registry_content" registry 32)"
+      else
+        registry_entries="$(extract_entries "$registry_content" "      - id: " "        " 32)"
+      fi
     else
       registry_entries=""
     fi
@@ -577,7 +588,11 @@ main() {
         return 1
       }
       registry_content="$(fetch_group_file "$tag" "$registry_path")"
-      registry_entries="$(extract_entries "$registry_content" "      - id: " "        " 32)"
+      if is_definition_v2 "$registry_content"; then
+        registry_entries="$(extract_v2_entries "$registry_content" registry 32)"
+      else
+        registry_entries="$(extract_entries "$registry_content" "      - id: " "        " 32)"
+      fi
       print_kind_listing "$resolved_group" "$version" "$kinds" "$source_url" "$requested_kind" "$registry_entries"
       return 0
     fi
@@ -586,7 +601,7 @@ main() {
     while IFS=$'\t' read -r file_path _; do
       [[ -n "$file_path" ]] || continue
       file_content="$(fetch_group_file "$tag" "$file_path")"
-      if [[ "$file_content" == file_format:\ definition/2* ]]; then
+      if is_definition_v2 "$file_content"; then
         kind_entries+="$(extract_v2_entries "$file_content" "$requested_kind" 36)"$'\n'
       else
         kind_entries+="$(extract_entries "$file_content" "  - id: " "    " 36)"$'\n'
@@ -599,6 +614,11 @@ main() {
 
   if [[ -n "$registry_path" ]]; then
     registry_content="$(fetch_group_file "$tag" "$registry_path")"
+    if is_definition_v2 "$registry_content" &&
+        matched_entry="$(extract_exact_v2_entry "$registry_content" "$second_arg" "$tag" "$registry_path")"; then
+      printf '%s\n' "$matched_entry"
+      return 0
+    fi
     if matched_entry="$(extract_exact_entry "$registry_content" "      - id: " "$second_arg" "$tag" "$registry_path")"; then
       printf '%s\n' "$matched_entry"
       return 0
@@ -612,7 +632,7 @@ main() {
     while IFS=$'\t' read -r file_path _; do
       [[ -n "$file_path" ]] || continue
       file_content="$(fetch_group_file "$tag" "$file_path")"
-      if [[ "$file_content" == file_format:\ definition/2* ]] &&
+      if is_definition_v2 "$file_content" &&
           matched_entry="$(extract_exact_v2_entry "$file_content" "$second_arg" "$tag" "$file_path")"; then
         printf '%s\n' "$matched_entry"
         return 0

--- a/skills/otel-semantic-conventions/scripts/test-query-otel-semantic-conventions.sh
+++ b/skills/otel-semantic-conventions/scripts/test-query-otel-semantic-conventions.sh
@@ -22,6 +22,18 @@ grep -q '^messaging[.]rabbitmq[.]attributes[.]destination' <<<"$messaging_common
 exact_entry=$("${query[@]}" messaging span.messaging.aws.sqs.send.producer)
 grep -q '^source: .*semantic-conventions/blob/v1[.]44[.]0/model/messaging/aws[.]yaml#L' <<<"$exact_entry"
 
+client_registry=$("${query[@]}" client registry)
+grep -q '^client[.]address' <<<"$client_registry"
+
+client_exact=$("${query[@]}" client client.address)
+grep -q '^source: .*semantic-conventions/blob/v1[.]44[.]0/model/client/registry[.]yaml#L' <<<"$client_exact"
+
+hardware_metrics=$("${query[@]}" hardware metrics)
+grep -q '^hw[.]battery[.]charge ' <<<"$hardware_metrics"
+
+hardware_exact=$("${query[@]}" hardware hw.battery.charge)
+grep -q '^source: .*semantic-conventions/blob/v1[.]44[.]0/model/hardware/battery-metrics[.]yaml#L' <<<"$hardware_exact"
+
 legacy_http=$(env OTEL_SEMCONV_REPO="$repo" OTEL_SEMCONV_TAG=v1.43.0 "$script_dir/query-otel-semantic-conventions.sh" http spans)
 grep -q '^span[.]http[.]client' <<<"$legacy_http"
 

--- a/skills/otel-weaver/references/template-authoring.md
+++ b/skills/otel-weaver/references/template-authoring.md
@@ -91,10 +91,10 @@ Notes:
 - `application_mode: single` renders the template once with the filter result bound to `ctx`.
 - Bundled jq filters live in [`defaults/jq/semconv.jq`](https://github.com/open-telemetry/weaver/blob/main/defaults/jq/semconv.jq) in the Weaver repo. In v0.25.1, released grouped helpers are `semconv_grouped_attributes`, `semconv_grouped_metrics`, `semconv_grouped_spans`, `semconv_grouped_events`, and `semconv_grouped_entities`.
 - The no-argument helpers default to the legacy schema. For a `definition/2` registry, call them with `{"v2": true}` (as shown above). Use a folded YAML scalar (`filter: >`) so the object's colon doesn't collide with YAML mapping syntax. A custom multi-clause jq expression that takes no arguments should be single-quoted instead — for the same reason.
-- `acronyms` shapes how `pascal_case_const` and similar filters split words.
+- `acronyms` configures the explicit `acronym` filter; case filters such as `pascal_case_const` do not consult that list automatically.
 - `comment_formats` lets `comment(format="go")` know what comment prefix to emit.
 - A template entry may add `when: <jq-expression>` to gate the entire template before its `filter` runs. It must return exactly one boolean; empty streams and non-booleans are errors. Template parameters are exposed as `$params`.
-- v0.25.1 also lets a project-wide `.weaver.toml` `[template]` section override `acronyms` and `text_maps` across template packages; other `weaver.yaml` settings are not project-level overrides.
+- v0.25.1 also lets a project-wide `.weaver.toml` `[template]` section layer `acronyms` and `text_maps` over every template package; case-insensitive acronym collisions and text-map name collisions favor the TOML values. Other `weaver.yaml` settings are not project-level overrides.
 
 ## Jinja2 template patterns
 
@@ -160,14 +160,14 @@ const (
 ## Filter reference
 
 - `comment(format="go")`: emits a comment with the configured prefix. Already includes `// `; do not double-prefix.
-- `pascal_case_const`: converts `ecommerce.order.id` → `EcommerceOrderId`. Honors the `acronyms` list.
+- `pascal_case_const`: converts `ecommerce.order.id` → `EcommerceOrderId`.
 
 Weaver ships more MiniJinja filters/tests/functions than any one template needs — reach for these instead of hand-rolling string manipulation in a template:
 
-- **Case filters**: `snake_case`, `camel_case`, `pascal_case`, `screaming_snake_case`, `kebab_case`, `acronym`, `pascal_case_const` (all honor the `acronyms` list from `weaver.yaml`).
+- **Case filters**: `snake_case`, `camel_case`, `pascal_case`, `screaming_snake_case`, `kebab_case`, `pascal_case_const`; use `acronym` explicitly where configured acronym replacement is needed.
 - **Other filters**: `map_text` (looks up a value in a `text_maps` table from `weaver.yaml`, e.g. `attr.type | map_text("go_types")`), `attribute_sort`, `required`, `not_required`, `instantiated_type`, `enum_type`, `body_fields`, `prometheus_metric_name`, `prometheus_unit_name`, plus ANSI color filters (rarely needed outside CLI output templates).
 - **Tests**: `stable`, `experimental`, `deprecated`, `enum`, `simple_type`, `template_type`, `enum_type`, `array` — e.g. `{% if attr is deprecated %}`.
-- **Functions**: `concat_if(...)`, `now()`.
+- **Functions**: `concat_if(...)`.
 - **Loop controls**: `break`/`continue` are supported inside `{% for %}` loops (a MiniJinja extension beyond stock Jinja2).
 
 ## Generation


### PR DESCRIPTION
## Summary

- refresh the generated semantic-conventions lookup for released v1.44.0 and accept all four `definition/2` entry keys
- correct the released Weaver v0.25.1 function, acronym-filter, and project TOML layering guidance
- regenerate and verify the focused lookup behavior against released sources

Tracks OTEL-332.

## Agent involvement

Codex audited upstream releases, implemented the change, ran the gates and harness, and prepared this PR. The human owner initiated the refresh, approved the evaluation model/budget, and will review before merge.

## Harness results

**Model + harness:** Claude Code CLI 2.1.246 driving `claude-sonnet-5`; safe mode, no tools or MCP servers, controlled injection of only the selected public skill files.

**Prompt used:** “Use `$otel-semantic-conventions` and `$otel-weaver` if installed. Against released semantic-conventions v1.44.0 and Weaver v0.25.1, answer two questions without running commands or browsing: (1) Which `definition/2` entry keys must a targeted semantic-convention lookup accept, and give one released v2 registry attribute plus one released metric that exact lookup should resolve. (2) Does released Weaver expose `now()`, do `pascal_case_const`-style case filters automatically apply the acronyms list, and how do project `.weaver.toml` acronym/text-map collisions layer with package `weaver.yaml`? Give exact identifiers and concise reasoning.”

| Arm | Target-skill revision / state | Cases × reps | Pass | Fail | Unknown |
| --- | --- | ---: | ---: | ---: | ---: |
| Target skills withheld | `Withheld` | 1 × 3 | 0 | 3 | 0 |
| Current `origin/main` skills | `547b102c4f3c5c52429820e35a642a6918e3d89f` | 1 × 3 | 0 | 3 | 0 |
| Proposed PR skills | `28c14657b48cee6c3da3b74cdfc1d7d259c1110c` | 1 × 3 | 3 | 0 | 0 |

**What differed:** Current answers accepted only `id`/`type`, claimed `now()` exists, and claimed case filters automatically apply acronyms. Proposed answers consistently gave `id`, `key`, `name`, `type`, rejected `now()`, required the explicit `acronym` filter, and explained that TOML values win only for acronym/text-map collisions.

**Failing or unknown runs kept, and why:** All six baseline failures are retained. The strict regex initially scored the proposed arm 0/3 because it required two particular examples not specified by the prompt; all answers supplied different valid released attributes/metrics. Human adjudication corrected only that rubric mismatch—no answer was retried.

**Per-case results by arm:** schema-tooling-v144 — withheld 0/3, current 0/3, proposed 3/3.

**Limitations:** Static, source-grounded lookup/template questions only; no production endpoints or private data. Raw transcripts contain local absolute paths, so this sanitized result summary replaces public transcript links.

## Verification

- semantic-convention query-script tests against released v1.44.0
- Weaver v0.25.1 binary checks for registry check/generate/diff and template behavior
- `./bin/validate-skill.sh`
- `./bin/check-skill-inventory.py`
- `git diff --check`
- repository link check: 0 errors

## Checklist

- [x] I read and agree to follow the Code of Conduct
- [x] `./bin/validate-skill.sh` passes
- [x] `./bin/check-skill-inventory.py` passes
- [x] No skill was added or renamed
- [x] Content is vendor-neutral, non-opinionated, DRY, and token-efficient
- [x] All three harness arms are reported
- [x] Commit messages follow Conventional Commits
- [x] CLA is already covered or will be handled by the CLA bot
