### PR TITLE
docs: refresh browser and JavaScript guidance

### DIFF
--- a/skills/otel-browser/SKILL.md
+++ b/skills/otel-browser/SKILL.md
@@ -5,7 +5,7 @@ description: OpenTelemetry browser/RUM mechanics for SPAs and MPAs. Use for “b
 
 # OpenTelemetry in the Browser (RUM)
 
-> **Stability (captured 2026-08):** the JS API and web tracing primitives
+> **Stability (captured 2026-09):** the JS API and web tracing primitives
 > (`@opentelemetry/sdk-trace-web`, `@opentelemetry/context-zone`) are stable. The Browser SDK and
 > event instrumentations are experimental 0.x packages. Pin exact compatible versions and verify
 > current releases/source before relying on configuration or output shape.
@@ -64,7 +64,7 @@ known mismatches. If no convention exists, use bounded, low-cardinality custom n
 guessing a released-looking name.
 
 The reviewed package-map snapshot is the upstream
-[`opentelemetry-browser` Browser Packages table at `browser-instrumentation-v0.7.0`](https://github.com/open-telemetry/opentelemetry-browser/tree/browser-instrumentation-v0.7.0#browser-packages).
+[`opentelemetry-browser` Browser Packages table at `browser-instrumentation-v0.8.0`](https://github.com/open-telemetry/opentelemetry-browser/tree/browser-instrumentation-v0.8.0#browser-packages).
 For current versions, select the matching release tag as described below.
 Use [`references/instrumentation.md`](references/instrumentation.md) for task routing instead of
 copying volatile package inventories.

--- a/skills/otel-browser/references/instrumentation.md
+++ b/skills/otel-browser/references/instrumentation.md
@@ -1,12 +1,12 @@
 # Browser instrumentation catalog
 
-Captured against `@opentelemetry/browser-instrumentation` 0.7.0 (2026-08). Verify current exports,
+Captured against `@opentelemetry/browser-instrumentation` 0.8.0 (2026-09). Verify current exports,
 README options, and release notes before relying on experimental behavior.
 
 ## Contents
 
 - [Event-based instrumentations](#event-based-instrumentations-opentelemetrybrowser-instrumentation)
-- [Span-based instrumentations](#span-based-instrumentations-opentelemetry-js--js-contrib)
+- [Span-based instrumentations](#span-based-instrumentations)
 - [Choosing what to enable](#choosing-what-to-enable)
 
 Choosing and configuring browser/RUM instrumentations. Browser telemetry uses **two signal shapes**;
@@ -26,7 +26,7 @@ with a real begin/end and parent/child relationship.
 > against the upstream READMEs and `package.json` `exports` (see
 > [SKILL.md Sources of Truth](../SKILL.md#sources-of-truth)).
 
-### Network context correlation proposal (captured through 0.7.0)
+### Network context correlation (captured through 0.8.0)
 
 Release 0.6.0 added `ContextRegistry` and `NetworkContextRegistry` as a proposal for sharing
 OpenTelemetry context between instrumentations that observe the same network operation from
@@ -35,10 +35,12 @@ window, then lets a consumer match that context to a `PerformanceResourceTiming`
 `fetchStart` and `responseEnd` fall inside the window. This is intended to let resource-timing
 telemetry retain the network span's trace context.
 
-This is **not yet a user-facing activation mechanism** in 0.7.0: the package does not expose the
-registry through its npm `exports`, and no released instrumentation registers or consumes it.
-Track it as released experimental groundwork; do not import internal source paths or claim
-resource-timing events are correlated automatically.
+Release 0.8.0 added consolidated Fetch and XHR instrumentations. They register completed network
+span context internally, and Resource Timing consumes matching context automatically. Activate this
+correlation by using the 0.8.0 consolidated Fetch/XHR subpath exports together with Resource Timing;
+the registry itself remains an internal API and is not an npm subpath export. Do not import its
+internal source path, and do not claim this correlation for the separate opentelemetry-js Fetch/XHR
+packages.
 
 ## Event-based instrumentations (`@opentelemetry/browser-instrumentation`)
 
@@ -127,7 +129,7 @@ stability; verify via the
 `browser.web_vital.name`, `.value`, `.delta`, and `.id` log attributes. The `.rating` and
 `.navigation_type` attributes are recommended.
 
-`@opentelemetry/browser-instrumentation` 0.7.0 matches that released shape. Its record body is unset
+`@opentelemetry/browser-instrumentation` 0.8.0 matches that released shape. Its record body is unset
 unless `includeRawAttribution` is enabled, which adds JSON-stringified attribution details outside
 the semantic-convention fields. For hand-written reporting, put the web-vital fields in attributes,
 not the record body.
@@ -178,13 +180,13 @@ new UserActionInstrumentation({ autoCapturedActions: ['click'] }); // default
 
 > `data-otel-*` values are exported verbatim — do not put PII (emails, names) in them.
 
-In 0.7.0, user-action instrumentation also accepts `applyCustomLogRecordData`; review that hook as
+User-action instrumentation also accepts `applyCustomLogRecordData`; review that hook as
 untrusted-data handling and keep any added fields bounded and non-PII.
 
-## Span-based instrumentations (`opentelemetry-js` / `js-contrib`)
+## Span-based instrumentations
 
-These produce **spans** and live outside `opentelemetry-browser`. The easiest on-ramp is the auto
-bundle:
+These produce **spans**. The established opentelemetry-js and js-contrib packages are available
+through the auto bundle:
 
 ```typescript
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
@@ -198,6 +200,8 @@ registerInstrumentations({
 
 | Package | Repo | What it does |
 |---|---|---|
+| `@opentelemetry/browser-instrumentation/experimental/fetch` | browser | Experimental consolidated Fetch spans; correlates matching Resource Timing events. |
+| `@opentelemetry/browser-instrumentation/experimental/xhr` | browser | Experimental consolidated XHR spans; correlates matching Resource Timing events. |
 | `instrumentation-fetch` | js | Spans for `fetch()`; injects `traceparent` (configure `propagateTraceHeaderCorsUrls`). |
 | `instrumentation-xml-http-request` | js | Spans for `XMLHttpRequest`; same propagation knobs. |
 | `instrumentation-document-load` | js-contrib | Spans for document load + navigation/resource timing (span flavor). |
@@ -207,7 +211,8 @@ registerInstrumentations({
 | `instrumentation-web-exception` | js-contrib | Event-based unhandled exception capture. |
 | `plugin-react-load` | js-contrib | React component mount/load performance; **unmaintained** upstream. |
 
-The released fetch/XHR instrumentations `0.221.0` and document-load `0.66.0` emit only the stable
+The released opentelemetry-js fetch/XHR instrumentations `0.222.0` and js-contrib document-load
+`0.67.0` emit only the stable
 HTTP semantic conventions. Their `semconvStabilityOptIn` migration option and legacy attributes
 (`http.method`, `http.url`, `http.status_code`, …) are gone; query the stable names such as
 `http.request.method`, `url.full`, and `http.response.status_code`.

--- a/skills/otel-browser/references/setup-sdk.md
+++ b/skills/otel-browser/references/setup-sdk.md
@@ -13,9 +13,8 @@ experimental Browser SDK and are outside this RUM setup.
 - [Connecting frontend to backend traces](#connecting-frontend-to-backend-traces)
 - [Validation levels](#validation-levels)
 
-> **Stability (captured 2026-08):** npm publishes `@opentelemetry/browser-sdk` 0.1.0; the upstream
-> GitHub `browser-sdk-v0.2.0` release tag is not an npm release. Check the current package version
-> and tagged source before answering. The settled path wires providers
+> **Stability (captured 2026-09):** the latest released Browser SDK is 0.3.0. Check the current
+> package version and matching tagged source before answering. The settled path wires providers
 > directly: the **stable** web tracing SDK (`@opentelemetry/sdk-trace-web`, `@opentelemetry/context-zone`)
 > for spans, plus the **experimental** Logs SDK (`@opentelemetry/api-logs`, `@opentelemetry/sdk-logs`,
 > still on the 0.x line) for events. Both approaches are shown below.
@@ -195,11 +194,12 @@ Keep authentication at the Collector or edge; do not put backend credentials in 
 
 `startBrowserSdk` exposes full control (`resourceAttributes`, `exportConfig`,
 `batchProcessorConfig`, per-signal `logs` / `traces` blocks with
-`spanLimits`/`logRecordLimits`, `contextManager`, and `propagators`), and `await sdk.shutdown()`
-flushes and stops. Published npm 0.1.0 accepts `traces.sampler` in its type but does not pass it to
-the provider. Source at the GitHub `browser-sdk-v0.2.0` release tag does pass the sampler; use that
-behavior only for a local build pinned to that tag until it is published. Keep exact compatible pins
-and re-check package metadata, release notes, and source after upgrades.
+`spanLimits`/`logRecordLimits`, `contextManager`, `propagators`, and `sampler`), and
+`await sdk.shutdown()` flushes and stops. Since 0.3.0, traces install the SDK's synchronous default
+context manager plus W3C Trace Context and Baggage propagators when none are supplied. This default
+manager preserves context only within `context.with`; supply a context manager appropriate to the
+application when context must cross asynchronous boundaries. Keep exact compatible pins and
+re-check package metadata, release notes, and source after upgrades.
 
 ### Per-signal SDKs (tree-shaking)
 

--- a/skills/otel-js/SKILL.md
+++ b/skills/otel-js/SKILL.md
@@ -24,10 +24,10 @@ For Node.js-specific facts:
 | Latest `@opentelemetry/configuration` | `npm view @opentelemetry/configuration version` |
 | Latest `@opentelemetry/sdk-node` | `npm view @opentelemetry/sdk-node version` |
 | Latest `@opentelemetry/auto-instrumentations-node` | `npm view @opentelemetry/auto-instrumentations-node version` |
-| Released package status / breaking changes (`2.10.0` / `0.221.0`) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/configuration/README.md` and `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/opentelemetry-sdk-node/README.md` |
-| Experimental CHANGELOG through `0.221.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/CHANGELOG.md` |
-| ESM / CJS preload mechanics at `2.10.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/doc/esm-support.md` |
-| Auto-instrumentations register entry point at `0.79.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js-contrib/auto-instrumentations-node-v0.79.0/packages/auto-instrumentations-node/README.md` |
+| Released package status / breaking changes (`2.11.0` / `0.222.0`) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.11.0/experimental/packages/configuration/README.md` and `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.11.0/experimental/packages/opentelemetry-sdk-node/README.md` |
+| Experimental CHANGELOG through `0.222.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.11.0/experimental/CHANGELOG.md` |
+| ESM / CJS preload mechanics at `2.11.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.11.0/doc/esm-support.md` |
+| Auto-instrumentations register entry point at `0.80.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js-contrib/auto-instrumentations-node-v0.80.0/packages/auto-instrumentations-node/README.md` |
 | Node.js getting-started docs | `WebFetch https://opentelemetry.io/docs/languages/js/getting-started/nodejs/` |
 
 ## Cross-References

--- a/skills/otel-js/references/declarative-setup.md
+++ b/skills/otel-js/references/declarative-setup.md
@@ -19,13 +19,13 @@ skill. For JS-specific facts:
 | Latest `@opentelemetry/configuration` | `npm view @opentelemetry/configuration version` |
 | Latest `@opentelemetry/sdk-node` | `npm view @opentelemetry/sdk-node version` |
 | Latest `@opentelemetry/auto-instrumentations-node` | `npm view @opentelemetry/auto-instrumentations-node version` |
-| Released package status / breaking changes (`2.10.0` / `0.221.0`) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/configuration/README.md` and `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/opentelemetry-sdk-node/README.md` |
-| SDK declarative startup helper at `0.221.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/opentelemetry-sdk-node/src/start.ts` |
-| Released file config parser (`file_format` acceptance) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/configuration/src/FileConfigFactory.ts` |
-| Released file config fixtures | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/packages/configuration/test/fixtures/sdk-config.yaml` |
-| Experimental CHANGELOG through `0.221.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/experimental/CHANGELOG.md` |
-| ESM / CJS preload mechanics at `2.10.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.10.0/doc/esm-support.md` |
-| Auto-instrumentations register entry point at `0.79.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js-contrib/auto-instrumentations-node-v0.79.0/packages/auto-instrumentations-node/README.md` |
+| Released package status / breaking changes (`2.11.0` / `0.222.0`) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.11.0/experimental/packages/configuration/README.md` and `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.11.0/experimental/packages/opentelemetry-sdk-node/README.md` |
+| SDK declarative startup helper at `0.222.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.11.0/experimental/packages/opentelemetry-sdk-node/src/start.ts` |
+| Released file config parser (`file_format` acceptance) | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.11.0/experimental/packages/configuration/src/FileConfigFactory.ts` |
+| Released file config fixtures | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.11.0/experimental/packages/configuration/test/fixtures/sdk-config.yaml` |
+| Experimental CHANGELOG through `0.222.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.11.0/experimental/CHANGELOG.md` |
+| ESM / CJS preload mechanics at `2.11.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/v2.11.0/doc/esm-support.md` |
+| Auto-instrumentations register entry point at `0.80.0` | `WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-js-contrib/auto-instrumentations-node-v0.80.0/packages/auto-instrumentations-node/README.md` |
 | Node.js getting-started docs | `WebFetch https://opentelemetry.io/docs/languages/js/getting-started/nodejs/` |
 
 ## Activation
@@ -119,7 +119,8 @@ declarative YAML via `OTEL_CONFIG_FILE`.
 ## Key API Facts
 
 - **Import order matters**: Telemetry setup must be imported and started before any other application imports. Auto-instrumentation patches modules at require/import time.
-- **`@opentelemetry/sdk-node` is experimental** but is the recommended way to set up OTel in Node.js. It handles context manager, propagator, and provider registration automatically.
+- **`@opentelemetry/sdk-node` is experimental**. `new NodeSDK()` is its currently recommended startup mechanism; the declarative `startNodeSDK()` helper is also experimental. Both handle context manager, propagator, and provider registration automatically.
 - **v2.0 migration**: `Resource` class is no longer exported. Use `resourceFromAttributes()`, `defaultResource()`, `emptyResource()` instead.
 - **2.9.0 / 0.220.0 migration note**: `@opentelemetry/sdk-node` now uses `@opentelemetry/sdk-trace`; the `node` and `tracing` namespace re-exports are deprecated. Import trace SDK types/classes directly from their packages.
 - **2.10.0 / 0.221.0 propagator note**: Selecting `jaeger` through `OTEL_PROPAGATORS` or declarative config emits a deprecation warning. Use `tracecontext`; the Jaeger propagator still works in this release but is planned for removal.
+- **2.11.0 / 0.222.0 declarative migration note**: `startNodeSDK()` now fails fast while creating invalid resource, tracer-provider, meter-provider, or propagator configuration and returns a no-op SDK. This can also affect environment-derived configuration—for example, `OTEL_NODE_RESOURCE_DETECTORS=all` currently includes the unsupported declarative `container` detector. This does not affect `new NodeSDK()`.


### PR DESCRIPTION
## Summary

- refresh browser instrumentation to 0.8.0 and Browser SDK guidance to 0.3.0
- document consolidated Fetch/XHR Resource Timing correlation and its package boundary
- refresh JavaScript to stable 2.11.0, experimental 0.222.0, and auto-instrumentations-node 0.80.0

## Agent involvement

Amp audited released browser and JavaScript sources, implemented and reviewed the changes, ran the gates and three-arm harness, and prepared this PR. The human owner initiated the refresh and will review before merge.

## Harness results

**Model + harness:** Claude Code CLI 2.1.258 driving Sonnet; safe mode, no tools or MCP servers, controlled injection of selected public skill files.

**Prompt used:** “Use `$otel-browser` and `$otel-js` if installed. Give a released-state review of browser instrumentation 0.8.0, Browser SDK 0.3.0, JS stable 2.11.0 / experimental 0.222.0, and auto-instrumentations-node 0.80.0. Explain Fetch/XHR Resource Timing correlation and package boundaries, Browser SDK default context/propagators and async limitation, and `startNodeSDK` invalid declarative configuration behavior including the all-detectors trap. Do not run commands or browse.”

| Arm | Target-skill revision / state | Cases × reps | Pass | Fail | Unknown |
| --- | --- | ---: | ---: | ---: | ---: |
| Target skills withheld | `Withheld` | 1 × 3 | 0 | 3 | 0 |
| Current `origin/main` skills | `42084b5bfdd9cf8615897ebcc6bf42df77994af4` | 1 × 3 | 0 | 3 | 0 |
| Proposed PR skills | `5f49ea404a01f74c1a0fa30334f2199b52b83a38` | 1 × 3 | 3 | 0 | 0 |

**What differed:** Proposed answers consistently distinguished consolidated browser Fetch/XHR correlation from the separate JS packages, explained Browser SDK defaults and async limits, and covered Node declarative fail-fast behavior. Baselines lacked those released boundaries.

**Failing or unknown runs kept, and why:** All baseline failures are retained. Strict regex rejected proposed answers that used the documented same-package shorthand `./experimental/fetch` / `./experimental/xhr` after naming `@opentelemetry/browser-instrumentation`; the package boundary and full paths were unambiguous. Human adjudication accepted all three without retry.

**Per-case results by arm:** browser-js-refresh — withheld 0/3, current 0/3, proposed 3/3.

**Limitations:** Static released-source review; no browser bundle or live endpoint test. Raw transcripts contain local absolute paths, so this sanitized summary replaces transcript links.

## Verification

- released-tag package/export/source-path audit
- `./bin/validate-skill.sh`
- `./bin/check-skill-inventory.py`
- `git diff --check`
- `lychee 0.24.2 --no-progress --root-dir "$PWD" --config .github/lychee.toml .` — 752 links, 0 errors

## Checklist

- [x] I read and agree to follow the Code of Conduct
- [x] `./bin/validate-skill.sh` passes
- [x] `./bin/check-skill-inventory.py` passes
- [x] No skill was added or renamed
- [x] Content is vendor-neutral, non-opinionated, DRY, and token-efficient
- [x] All three harness arms are reported
- [x] Commit messages follow Conventional Commits
- [x] CLA is already covered or will be handled by the CLA bot
