### PR TITLE
docs: refresh cross-SDK guidance

### DIFF
--- a/skills/otel-declarative-config/SKILL.md
+++ b/skills/otel-declarative-config/SKILL.md
@@ -101,6 +101,17 @@ export OTEL_CONFIG_FILE=/app/configs/otel.yaml
 Setting the variable alone does not bootstrap every language. The selected declarative bootstrap
 or autoconfigure path must run.
 
+For released implementations, verify the package version before using these exact entry points:
+
+| Runtime | Bootstrap / activation |
+|---|---|
+| Go | `go.opentelemetry.io/contrib/otelconf.NewSDK`; it reads `OTEL_CONFIG_FILE`. The old `OTEL_EXPERIMENTAL_CONFIG_FILE` is rejected, not accepted as an alias. |
+| Java | Add `io.opentelemetry:opentelemetry-sdk-extension-declarative-config` and run SDK autoconfigure; `OTEL_CONFIG_FILE` maps to the `otel.config.file` system property. For direct loading, use `DeclarativeConfiguration.parseAndCreate(InputStream)`. |
+| JavaScript (Node.js) | `@opentelemetry/configuration` exposes `createConfigFactory()`, which selects file configuration when `OTEL_CONFIG_FILE` names a YAML file; `@opentelemetry/sdk-node` consumes that model during its startup path. Both packages are experimental. |
+
+Other languages, agents, and framework starters can expose different or no bootstrap paths. Use the
+language-specific cross-reference below rather than extrapolating this table.
+
 Precedence is runtime/loader-specific: verify it in the selected loader's documentation or a
 controlled parser test. Do not assume a file overrides or merges with `OTEL_*` variables.
 Programmatic setup can choose whether to load or override a file, or build providers directly;

--- a/skills/otel-dotnet/references/instrumentation-libraries.md
+++ b/skills/otel-dotnet/references/instrumentation-libraries.md
@@ -171,7 +171,7 @@ https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-contrib/ma
 | Package | Builder extension | NuGet |
 |---------|-------------------|-------|
 | `OpenTelemetry.Instrumentation.ConfluentKafka` | `.AddKafkaConsumerInstrumentation<TKey,TValue>()` / `.AddKafkaProducerInstrumentation<TKey,TValue>()` (both available on `TracerProviderBuilder` and `MeterProviderBuilder`) | [NuGet](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.ConfluentKafka) |
-| `OpenTelemetry.Instrumentation.MassTransit` | `.AddMassTransitInstrumentation()` | [NuGet](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.MassTransit) |
+| `OpenTelemetry.Instrumentation.MassTransit` | `.AddMassTransitInstrumentation()` for MassTransit 7 and earlier; deprecated — MassTransit 8+ emits `ActivitySource` telemetry directly, register it with `.AddSource("MassTransit")` | [NuGet](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.MassTransit) |
 | `OpenTelemetry.Instrumentation.Hangfire` | `.AddHangfireInstrumentation()` | [NuGet](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Hangfire) |
 | `OpenTelemetry.Instrumentation.Quartz` | `.AddQuartzInstrumentation()` | [NuGet](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Quartz) |
 

--- a/skills/otel-go/references/breaking-changes.md
+++ b/skills/otel-go/references/breaking-changes.md
@@ -18,6 +18,7 @@ the SDK migration.
 - `attribute.Value.Emit` deprecated (core v1.44.0). Use `attribute.Value.String` instead.
 - `sdk/log.WithExportBufferSize` is deprecated and has no effect as of log SDK v0.21.0 (core v1.45.0 release); the batch processor no longer keeps a separate export-request buffer.
 - `OTEL_EXPERIMENTAL_CONFIG_FILE` is no longer supported by root `otelconf` v0.23.0+ (contrib v1.43.0+). Use `OTEL_CONFIG_FILE`.
+- `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho` is deprecated in v0.71.0 (contrib v1.46.0). Use `github.com/labstack/echo-opentelemetry`; removal is unreleased as of 2026-09-03.
 
 ## Removed APIs (instrumentation v0.65.0; contrib v1.40.0 release)
 

--- a/skills/otel-go/references/instrumentation-libraries.md
+++ b/skills/otel-go/references/instrumentation-libraries.md
@@ -74,7 +74,7 @@ A data layer built on a global `*gorm.DB` (or `*sql.DB`) plus functions that don
 | net/http | `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` |
 | Gin | `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin` |
 | Gorilla mux | `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux` |
-| Echo | `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho` |
+| Echo | `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho` is deprecated as of v0.71.0; use `github.com/labstack/echo-opentelemetry` for new integrations. |
 | go-restful | `go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful` |
 
 ```go

--- a/skills/otel-java/references/declarative-setup.md
+++ b/skills/otel-java/references/declarative-setup.md
@@ -49,7 +49,7 @@ Declarative config has been supported since Javaagent 2.9.0; the property is now
 SDK 1.63.0 bundled with Javaagent 2.29.0). Newer agent versions track newer schema versions.
 Confirm both the accepted range and preferred `file_format` from the tag-matched parser, then use
 the preferred value from that release's fixture to avoid compatibility warnings for experimental
-properties. As of 2026-08-26, the latest SDK BOM is 1.65.0, and Javaagent/Spring Boot Starter
+properties. As of 2026-09-03, the latest SDK BOM is 1.65.0, and Javaagent/Spring Boot Starter
 2.31.1 target SDK 1.65.0. The released SDK parser accepts `0.4` and `1.*` and prefers
 `"1.1"`; both 2.31.1 instrumentation fixtures use `1.1`. Keep the selected distribution's
 embedded SDK distinct from the independently released BOM, and do not infer either from `main` or

--- a/skills/otel-python/references/breaking-changes.md
+++ b/skills/otel-python/references/breaking-changes.md
@@ -7,7 +7,7 @@ rots with each release.
 ## Step 1: Fetch the CHANGELOGs
 
 Fetch both released upstream sources before reviewing any code. As of
-2026-08-26, the released ceiling is core **1.44.0** and contrib **0.65b0**:
+2026-09-03, the released ceiling is core **1.44.0** and contrib **0.65b0**:
 
 ```
 WebFetch https://raw.githubusercontent.com/open-telemetry/opentelemetry-python/v1.44.0/CHANGELOG.md

--- a/skills/otel-ruby/SKILL.md
+++ b/skills/otel-ruby/SKILL.md
@@ -26,6 +26,11 @@ version exists for metrics, logs, semantic conventions, exporters, or contrib in
 Resolve each gem independently with Bundler, inspect its changelog, and keep the resulting
 `Gemfile.lock` change under review.
 
+Released snapshot verified 2026-09-03: tracing API `1.11.0`, tracing SDK `1.13.0`, trace OTLP
+exporter `0.35.1`; metrics API `0.7.0`, SDK `0.17.0`, OTLP exporter `0.11.0`; logs API `0.4.1`, SDK
+`0.6.1`, OTLP exporter `0.5.1`. Treat this as an audit anchor, not a version-alignment rule; use the
+lookups below for newer releases.
+
 ## Sources of truth
 
 | Fact | Fetch |

--- a/skills/otel-ruby/references/api.md
+++ b/skills/otel-ruby/references/api.md
@@ -79,6 +79,6 @@ The core repository ships `opentelemetry-test-helpers`,
 For integration tests, send to a disposable local OTLP receiver and verify the whole path. Never
 point a test at a production endpoint.
 
-Sources: [Ruby API](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/api),
-[metrics API](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/metrics_api), and
-[logs SDK examples](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/examples/logs_sdk).
+Sources: [Ruby API 1.11.0](https://github.com/open-telemetry/opentelemetry-ruby/tree/opentelemetry-api/v1.11.0/api),
+[metrics API 0.7.0](https://github.com/open-telemetry/opentelemetry-ruby/tree/opentelemetry-metrics-api/v0.7.0/metrics_api), and
+[logs SDK 0.6.1 examples](https://github.com/open-telemetry/opentelemetry-ruby/tree/opentelemetry-logs-sdk/v0.6.1/examples/logs_sdk).

--- a/skills/otel-ruby/references/breaking-changes.md
+++ b/skills/otel-ruby/references/breaking-changes.md
@@ -27,10 +27,11 @@ different `0.x` metrics, logs, exporter, and instrumentation versions.
 
 ## Ruby and target-library compatibility
 
-Check both core and contrib requirements. Current contrib development requires Ruby 3.3 or newer,
-but an older locked instrumentation release may have a different range. Each instrumentation
-gemspec also constrains the Rails/framework/client versions it supports. Upgrade Ruby, Rails, or a
-client library and its OTel instrumentation as one compatibility decision.
+Check both core and contrib requirements. Current core and relevant contrib releases require Ruby
+3.3 or newer, but an older locked release may have a different range. Rails instrumentation
+`0.42.0` additionally requires Rails 7.1 or newer. Each instrumentation gemspec constrains the
+framework/client versions it supports. Upgrade Ruby, Rails, or a client library and its OTel
+instrumentation as one compatibility decision.
 
 ## Behavioral review
 

--- a/skills/otel-ruby/references/instrumentation-libraries.md
+++ b/skills/otel-ruby/references/instrumentation-libraries.md
@@ -34,7 +34,7 @@ or `{ enabled: false }` for exclusions. Do not mix `use` with `use_all`.
 ## Find the maintained library
 
 The source of truth is the contrib repository's
-[`instrumentation/`](https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation)
+[`instrumentation/`](https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/opentelemetry-instrumentation-all/v0.96.0/instrumentation)
 directory. It currently includes categories such as:
 
 | Area | Examples |
@@ -49,6 +49,10 @@ directory. It currently includes categories such as:
 This table is a routing aid, not a package/version inventory. Before recommending a gem, open its
 README and gemspec in the locked release to confirm its target-library range, Ruby requirement,
 registered constant, options, and emitted semantic-convention mode.
+
+As of 2026-09-03, the latest relevant releases are Rails `0.42.0` (Ruby >= 3.3, Rails >= 7.1),
+Rack `0.31.1`, Sinatra `0.30.0`, Sidekiq `0.29.0`, Logger `0.4.0`, and the `all` bundle `0.96.0`.
+The latter five also require Ruby >= 3.3. Do not transfer these constraints to an older lockfile.
 
 ## Framework ordering
 

--- a/skills/otel-ruby/references/performance.md
+++ b/skills/otel-ruby/references/performance.md
@@ -25,9 +25,10 @@ request path and is unsuitable for normal production traffic.
 ## Forks, threads, and fibers
 
 Pre-fork servers copy provider and processor state. Verify the exact SDK/server combination rather
-than assuming a background export thread survives. Current processors detect forks and recreate
-workers, but startup timing, inherited buffers, and graceful shutdown still matter. Exercise a
-request in a worker and prove it exports after the fork.
+than assuming a background export thread survives. The released batch span processor and metrics
+SDK include fork handling, but startup timing, inherited buffers, logs processing, and graceful
+shutdown still matter. Exercise a request in a worker and prove each enabled signal exports after
+the fork.
 
 Context is fiber-local. Test parentage across any custom thread pools, fibers, async schedulers,
 jobs, and callbacks that framework instrumentation does not already cover.
@@ -57,6 +58,6 @@ not make sensitive values safe to collect.
 An empty backend query is not proof of zero telemetry. Enable `OTEL_LOG_LEVEL=debug`, inspect SDK
 warnings and processor drop signals, and compare with a disposable local receiver.
 
-Sources: [trace SDK implementation](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/sdk),
-[metrics SDK](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/metrics_sdk), and
-[Ruby API benchmarks](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/api/benchmarks).
+Sources: [trace SDK 1.13.0](https://github.com/open-telemetry/opentelemetry-ruby/tree/opentelemetry-sdk/v1.13.0/sdk),
+[metrics SDK 0.17.0](https://github.com/open-telemetry/opentelemetry-ruby/tree/opentelemetry-metrics-sdk/v0.17.0/metrics_sdk), and
+[Ruby API 1.11.0 benchmarks](https://github.com/open-telemetry/opentelemetry-ruby/tree/opentelemetry-api/v1.11.0/api/benchmarks).

--- a/skills/otel-ruby/references/setup.md
+++ b/skills/otel-ruby/references/setup.md
@@ -40,7 +40,9 @@ review the lockfile and each changed gem's changelog.
 Require the selected exporter and instrumentation gems before configuration. In Rails, place the
 configuration in an initializer; in Rack/Sinatra or a worker, run it during bootstrap.
 Ruby has no released declarative `OTEL_CONFIG_FILE` implementation; use `OTEL_*` environment
-variables and `OpenTelemetry::SDK.configure`.
+variables and `OpenTelemetry::SDK.configure`. Requiring the metrics and logs SDKs before
+`configure` installs their configurator hooks; their default exporter is OTLP when the matching
+exporter gem is loaded.
 
 ```ruby
 require 'opentelemetry/sdk'
@@ -93,7 +95,7 @@ OTEL_LOG_LEVEL=info
 
 The released automatic trace and log OTLP paths support `http/protobuf`; an unsupported general
 or relevant signal-specific protocol disables the trace or log exporter with a warning. The
-metrics path does not read protocol variables and always uses its HTTP/protobuf `MetricsExporter`.
+metrics path does not read protocol variables and uses its HTTP/protobuf `MetricsExporter`.
 The core repository contains an `opentelemetry-exporter-otlp-grpc` prototype, but its changelog
 marks it unreleased and not production-ready. Do not recommend it until a released gem says
 otherwise. Use signal-specific endpoints and headers when the signals differ. Never place a
@@ -122,6 +124,6 @@ phase. For short jobs, call `force_flush` before the process exits if the provid
 3. Send a request or execute a job against a disposable local receiver.
 4. Confirm the expected resource, parent/child relationship, and shutdown export.
 
-Sources: [core SDK README](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/sdk),
+Sources: [core SDK 1.13.0](https://github.com/open-telemetry/opentelemetry-ruby/tree/opentelemetry-sdk/v1.13.0/sdk),
 [Ruby getting started](https://opentelemetry.io/docs/languages/ruby/getting-started/), and
-[contrib instrumentation catalog](https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation).
+[contrib instrumentation catalog at the `all` 0.96.0 release](https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/opentelemetry-instrumentation-all/v0.96.0/instrumentation).

--- a/skills/otel-span-events-to-logs-migration/SKILL.md
+++ b/skills/otel-span-events-to-logs-migration/SKILL.md
@@ -11,7 +11,7 @@ Use this skill to migrate instrumentation from the Span Event API (`AddEvent`, `
 
 The OpenTelemetry project accepted a plan to deprecate `Span.AddEvent` and `Span.RecordException` in favor of emitting events and exceptions through the Logs API. Span Events as a concept remain valid -- they can be emitted via logs that correlate to the active span, and optionally bridged back into the span proto.
 
-Status as of 2026-08-26: OTEP 4430 is accepted, log-based event/exception emission is specified in the Logs API, and the SDK "event to span event bridge" is specified with Development status. The trace API methods `AddEvent`/`RecordException` are not yet formally marked Deprecated in the specification -- that step is still pending. Treat existing span-event calls as migration candidates, not automatically invalid code; some SDK-specific equivalents have already changed status (for example OpenTelemetry .NET's `Activity.RecordException` extension is `[Obsolete]` in favor of `Activity.AddException`, which is still a span-event API).
+Status as of 2026-09-03: OTEP 4430 is accepted, log-based event/exception emission is specified in the Logs API, and the SDK "event to span event bridge" is specified with Development status. The trace API methods `AddEvent`/`RecordException` are not yet formally marked Deprecated in the specification -- that step is still pending. Treat existing span-event calls as migration candidates, not automatically invalid code; some SDK-specific equivalents have already changed status (for example OpenTelemetry .NET's `Activity.RecordException` extension is `[Obsolete]` in favor of `Activity.AddException`, which is still a span-event API).
 
 See `references/deprecation-plan.md` for the full context.
 

--- a/skills/otel-span-events-to-logs-migration/references/deprecation-plan.md
+++ b/skills/otel-span-events-to-logs-migration/references/deprecation-plan.md
@@ -7,7 +7,7 @@ This reference summarizes the [OTEP 4430](https://github.com/open-telemetry/open
 - `Span.AddEvent` -- the API method for attaching events to spans
 - `Span.RecordException` -- the API method for recording exceptions on spans
 
-As of 2026-08-26, these methods are planned deprecation targets from the accepted OTEP. They are not yet marked Deprecated in `specification/trace/api.md`.
+As of 2026-09-03, these methods are planned deprecation targets from the accepted OTEP. They are not yet marked Deprecated in `specification/trace/api.md`.
 
 ## What Is NOT Being Deprecated
 
@@ -41,7 +41,7 @@ Stabilize log-based Events. (The `event_name` LogRecord field is part of the sta
 - Next major version: migrate to the Logs API; for span-detail-without-a-timestamp cases, record span attributes instead ([semantic-conventions#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010), [opentelemetry-specification#4446](https://github.com/open-telemetry/opentelemetry-specification/issues/4446))
 - Users opt into the SDK bridge if they need span events in the proto envelope
 
-## Current Status (2026-08-26)
+## Current Status (2026-09-03)
 
 - **Proto 1.11.0**: log-based Events are stable; `event_name` is a stable LogRecord field.
 - **Specification 1.60.0**: the Logs API is Stable, including the `event_name` field and the optional `Exception` parameter to Emit, so log-based exception/event emission is specified. The "event to span event bridge" `LogRecordProcessor` is specified in `specification/logs/sdk.md` (Status: Development), with a matching `event_to_span_event_bridge/development` declarative-config key.
@@ -53,15 +53,16 @@ Stabilize log-based Events. (The `event_name` LogRecord field is part of the sta
 
 Use current released source for the target language before editing user code.
 The snapshot below was verified against synced upstream checkouts and exact
-released tags on 2026-08-26:
+released tags on 2026-09-03:
 
 | Language | Current migration-relevant status |
 |---|---|
 | Go trace 1.46.0 / logs 0.22.0 | `trace.Span.AddEvent` / `RecordError` are present and not marked deprecated. `log.Record.SetEventName` and `SetErr` are available; the log SDK derives `exception.type` and `exception.message` from the error. No event-to-span-event bridge implementation was found in these releases. |
 | Java 1.65.0 | `Span.addEvent` / `recordException` are present and not marked deprecated; `LogRecordBuilder.setEventName` is available since 1.50.0 and `setException(Throwable)` since 1.60.0. The bridge is available in `opentelemetry-sdk-extension-incubator`; the older Java contrib bridge is deprecated. |
-| JavaScript / TypeScript 2.10.0 / experimental 0.221.0 | `Span.addEvent` / `recordException` are present and not marked deprecated; `@opentelemetry/api-logs` / `@opentelemetry/sdk-logs` support `eventName`; the `exception` log-record field is marked experimental. No event-to-span-event bridge implementation was found in these releases. |
+| JavaScript / TypeScript 2.11.0 / experimental 0.222.0 | `Span.addEvent` / `recordException` are present and not marked deprecated; `@opentelemetry/api-logs` / `@opentelemetry/sdk-logs` support `eventName`; the `exception` log-record field is marked experimental. No event-to-span-event bridge implementation was found in these releases. |
 | Python 1.44.0 / 0.65b0 | `span.add_event` / `record_exception` are present and not marked deprecated; `opentelemetry._logs.Logger.emit` accepts `event_name` and `exception`, and the SDK derives exception attributes. The deprecated standalone Events API/SDK was removed in favor of `LogRecord` with `event_name`. No event-to-span-event bridge implementation was found in this release. |
 | .NET 1.18.0 | `ActivityExtensions.RecordException` is `[Obsolete]` and points to `Activity.AddException`; both record span events. `TelemetrySpan.AddEvent` / `RecordException` are not marked obsolete. `ILogger` supplies an event name through `EventId.Name`; the lower-level Logs API is pre-release. No event-to-span-event bridge implementation was found in this release. |
+| Ruby API 1.11.0 / Logs API 0.4.1 / Logs SDK 0.6.1 | `Span#add_event` / `record_exception` are present and not marked deprecated. `Logger#on_emit` accepts `event_name` and inherits the current span context, but has no exception parameter; set `exception.*` attributes explicitly. No event-to-span-event bridge implementation was found in these releases. |
 
 Treat the deprecation as the accepted direction, not a completed spec change; verify the current status of each step against the linked sources before making hard claims.
 

--- a/skills/otel-span-events-to-logs-migration/references/migration-patterns.md
+++ b/skills/otel-span-events-to-logs-migration/references/migration-patterns.md
@@ -263,9 +263,56 @@ logger.LogWarning(
 
 With the OpenTelemetry .NET OTLP exporter, `EventId.Name` is exported as the OTLP log `event_name` field. The lower-level `LogRecordData.EventName` / `Logger.EmitLog` bridge API exists in source but is experimental/pre-release-gated, so prefer stable `ILogger` patterns unless the project has opted into the bridge API.
 
+## Ruby
+
+### Exception Recording
+
+Before:
+```ruby
+span.record_exception(exception)
+span.status = OpenTelemetry::Trace::Status.error(exception.message)
+```
+
+After:
+```ruby
+logger = OpenTelemetry.logger_provider.logger(name: 'my-gem')
+logger.on_emit(
+  event_name: exception_event_name,
+  severity_number: OpenTelemetry::Logs::SeverityNumber::SEVERITY_NUMBER_ERROR,
+  body: 'exception',
+  attributes: {
+    'exception.type' => exception.class.name,
+    'exception.message' => exception.message,
+    'exception.stacktrace' => exception.full_message
+  }
+)
+span.status = OpenTelemetry::Trace::Status.error(exception.message)
+```
+
+### General Event
+
+Before:
+```ruby
+span.add_event('retry.attempt', attributes: { 'retry.count' => count })
+```
+
+After:
+```ruby
+logger.on_emit(
+  event_name: 'retry.attempt',
+  body: 'retry.attempt',
+  attributes: { 'retry.count' => count }
+)
+```
+
+Ruby Logs API 0.4.1 and Logs SDK 0.6.1 expose `Logger#on_emit` with
+`event_name:` and use the current context by default. They do not expose an
+exception convenience parameter, so populate the applicable `exception.*`
+attributes explicitly.
+
 ## Key Rules Across All Languages
 
-1. The event name replaces the name from `AddEvent`. Use the dedicated event-name API where available -- `record.SetEventName(...)` (Go), `.setEventName(...)` (Java `LogRecordBuilder`), `eventName:` (JS `logger.emit`), `event_name=` (Python `Logger.emit`), or `EventId.Name` (.NET `ILogger`) -- which maps to the `event_name` LogRecord field. Only set an `event.name` attribute when the target SDK/exporter has no dedicated event-name path.
+1. The event name replaces the name from `AddEvent`. Use the dedicated event-name API where available -- `record.SetEventName(...)` (Go), `.setEventName(...)` (Java `LogRecordBuilder`), `eventName:` (JS `logger.emit`), `event_name=` (Python `Logger.emit`), `EventId.Name` (.NET `ILogger`), or `event_name:` (Ruby `Logger#on_emit`) -- which maps to the `event_name` LogRecord field. Only set an `event.name` attribute when the target SDK/exporter has no dedicated event-name path.
 2. All original attributes transfer to the log record attributes, preserving the
    original attribute keys unless an intentional mapping is documented and tested.
 3. The log record automatically inherits the active span context from `ctx` / the current context -- this is how trace correlation is maintained.


### PR DESCRIPTION
## Summary

- add released declarative bootstrap entry points for Go, Java, and Node.js
- document current .NET MassTransit and Go Echo instrumentation migration boundaries
- refresh Ruby release, compatibility, setup, and span-event-to-log migration guidance

## Agent involvement

Amp audited exact released SDK and instrumentation sources, implemented and reviewed the changes, ran the gates and three-arm harness, and prepared this PR. The human owner initiated the refresh and will review before merge.

## Harness results

**Model + harness:** Claude Code CLI 2.1.258 driving Sonnet; safe mode, no tools or MCP servers, controlled injection of selected public skill files.

**Prompts used:**

1. “Use `$otel-declarative-config`, `$otel-dotnet`, and `$otel-go` if installed. Give exact released guidance for activating declarative configuration in Go, Java, and Node.js, including entry points and the old Go environment variable; then review the current .NET MassTransit and Go Echo instrumentation migration boundaries. Do not run commands or browse.”
2. “Use `$otel-ruby` and `$otel-span-events-to-logs-migration` if installed. Give the released Ruby OpenTelemetry snapshot for traces, metrics, logs, and their OTLP exporters; state current Ruby/Rails requirements and setup behavior; then migrate a Ruby span exception event to the Logs API while preserving trace correlation and exception fields. Distinguish released behavior from migration direction. Do not run commands or browse.”

| Arm | Target-skill revision / state | Cases × reps | Pass | Fail | Unknown |
| --- | --- | ---: | ---: | ---: | ---: |
| Target skills withheld | `Withheld` | 2 × 3 | 0 | 6 | 0 |
| Current `origin/main` skills | `42084b5bfdd9cf8615897ebcc6bf42df77994af4` | 2 × 3 | 0 | 6 | 0 |
| Proposed PR skills | `c09fac1f2b66ff640653329ed16372bd1197a8ae` | 2 × 3 | 6 | 0 | 0 |

**What differed:** Proposed answers consistently supplied exact bootstrap APIs and migration boundaries, separated independently versioned Ruby signal packages, and produced a trace-correlated Ruby Logs API migration. Baselines lacked the newly released facts.

**Failing or unknown runs kept, and why:** All baseline failures are retained. The bootstrap case passed mechanically. Strict regex rejected Ruby tables because Markdown separated package labels from versions and operators from their numeric requirements; all exact gems, versions, Ruby/Rails bounds, migration status, and exception fields were present. Human adjudication accepted all three without retry.

**Per-case results by arm:** cross-sdk-bootstrap-refresh — withheld 0/3, current 0/3, proposed 3/3; ruby-span-migration-refresh — withheld 0/3, current 0/3, proposed 3/3.

**Limitations:** Static exact-release review; no .NET, Go, Java, Node.js, or Ruby application smoke test. Raw transcripts contain local absolute paths, so this sanitized summary replaces transcript links.

## Verification

- exact released source and package-boundary audits across affected SDKs
- `./bin/validate-skill.sh`
- `./bin/check-skill-inventory.py`
- `git diff --check`
- `lychee 0.24.2 --no-progress --root-dir "$PWD" --config .github/lychee.toml .` — 752 links, 0 errors

## Checklist

- [x] I read and agree to follow the Code of Conduct
- [x] `./bin/validate-skill.sh` passes
- [x] `./bin/check-skill-inventory.py` passes
- [x] No skill was added or renamed
- [x] Content is vendor-neutral, non-opinionated, DRY, and token-efficient
- [x] All three harness arms are reported
- [x] Commit messages follow Conventional Commits
- [x] CLA is already covered or will be handled by the CLA bot
